### PR TITLE
Add default watchers, hooks, and runbooks for A110 gate

### DIFF
--- a/docs/runbooks/data_contracts.md
+++ b/docs/runbooks/data_contracts.md
@@ -1,0 +1,62 @@
+# Runbook DATA — Contratos & Pipelines
+
+## cdc-lag — `cdc_lag_watch`
+- **Hook:** `cdc-lag-hot-degrade`
+- **KPI:** `cdc.lag.p95` ≤ 120 s (janela 15m)
+- **Ação automática:** `degrade_to_hot_table`
+- **Owner:** DATA
+- **Rollback:** quando lag ≤ 90 s por 3 janelas.
+
+**Checklist**
+1. Verificar DLQ e conectividade Debezium → Iceberg.
+2. Avaliar backlog de offsets; acionar `scripts/cdc/replay.sh` se necessário.
+3. Coordenar com DEC sobre consumo de hot tables e avisar stakeholders.
+4. Registrar incident no `data-contracts` board com evidências.
+
+## schema-drift — `schema_registry_drift_watch`
+- **Hook:** `schema-drift-blocker`
+- **KPI:** ausência de `schema.drift_detected` (janela 5m)
+- **Ação automática:** `block_deploy`
+- **Owner:** DATA
+- **Rollback:** após publicação de schema compatível e testes de contrato.
+
+**Checklist**
+1. Rodar `scripts/schema/compare.sh` para diff detalhado.
+2. Validar compatibilidade backward e publicar novo contrato no registry.
+3. Atualizar consumidores afetados e obter aprovação A87/A89.
+
+## dbt-tests — `dbt_test_failure_watch`
+- **Hook:** `dbt-test-rollback`
+- **KPI:** `dbt.tests.failure_rate` = 0 (janela 15m)
+- **Ação automática:** `rollback_transform`
+- **Owner:** DATA
+- **Rollback:** após rerun `dbt test` com sucesso.
+
+**Checklist**
+1. Executar `make data.dbt` local para reproduzir.
+2. Conferir alterações recentes de modelos e seeds.
+3. Aplicar hotfix ou rollback da run e comunicar release train.
+
+## contract-breach — `data_contract_break_watch`
+- **Hook:** `data-contract-breach-guard`
+- **KPI:** `data.contract.break` = 0 (janela 5m)
+- **Ação automática:** `trigger_contract_waiver`
+- **Owner:** DATA
+- **Rollback:** após waiver aprovado e contrato restaurado.
+
+**Checklist**
+1. Validar métricas de completude/freshness.
+2. Avaliar impacto em DEC/ML; se crítico, acionar degrade imediato.
+3. Atualizar contrato com versão corrigida e auditar no ACE.
+
+## doc-coverage — `doc_coverage_watch`
+- **Hook:** `doc-coverage-gap`
+- **KPI:** `data.doc.coverage` ≥ 95% (janela 24h)
+- **Ação:** `raise_doc_gap`
+- **Owner:** DATA
+- **Rollback:** não aplicável (processo contínuo).
+
+**Checklist**
+1. Gerar relatório de cobertura via `scripts/data/doc_coverage.py`.
+2. Priorizar gaps no board `DATA-TechDebt`.
+3. Incluir plano de ação no próximo weekly review.

--- a/docs/runbooks/dec_decision_pricing.md
+++ b/docs/runbooks/dec_decision_pricing.md
@@ -1,0 +1,29 @@
+# Runbook DEC — Decision & Pricing Core
+
+Este runbook cobre os watchers de DEC definidos em `ops/watchers/core.yaml` e os respectivos hooks A110.
+
+## metric-gap — `metrics_decision_hook_gap_watch`
+- **Hook:** `dec-latency-gap`
+- **KPI:** `dec.latency.p95` ≤ 800 ms (janela 5m)
+- **Ação automática:** `degrade_route`
+- **Owner:** SRE
+- **Rollback:** automático após estabilização (< 700 ms p95 por 2 janelas)
+
+**Procedimento**
+1. Verifique no painel `decision.core` se há saturação ou regressão recente.
+2. Confirme traces com `trace_id` do período para garantir que o fallback aplicou.
+3. Se o fallback não estabilizar em 2 janelas, acione `plat@creditengine` e prepare a reversão manual da última alteração.
+4. Documente no ACE o impacto e anexos de traces.
+
+## slo-burn — `slo_budget_breach_watch`
+- **Hook:** `slo-burn-rate-guard`
+- **KPI:** `slo.burn_rate` ≤ 1.0 (janela 60m)
+- **Ação automática:** `enforce_release_freeze`
+- **Owner:** SRE
+- **Rollback:** após burn rate < 0.8 por 3 janelas.
+
+**Procedimento**
+1. Avalie dashboards de erro/latência para identificar o serviço infrator.
+2. Habilite `feature flags` de degrade (ex.: `dec.degrade_to_baseline`).
+3. Valide se os hooks dependentes (PM/PLAT) estão sincronizados.
+4. Documente no runbook global de incidentes com timeline em até 4h.

--- a/docs/runbooks/fe_experience.md
+++ b/docs/runbooks/fe_experience.md
@@ -1,0 +1,25 @@
+# Runbook FE — Experiência & SDKs
+
+## web-cwv — `web_cwv_regression_watch`
+- **Hook:** `web-cwv-rollback`
+- **KPI:** `web.cwv.inp_p75` ≤ 200 ms (janela 24h)
+- **Ação automática:** `rollback_fe_release`
+- **Owner:** FE
+- **Rollback:** após INP ≤ 180 ms por 2 janelas.
+
+**Passos**
+1. Validar deploy recente (Next.js) e métricas de Web Vitals.
+2. Checar monitoramento RUM e comparar com canário.
+3. Aplique rollback via pipeline FE e comunique squads consumidores.
+
+## api-breaking — `api_breaking_change_watch`
+- **Hook:** `api-contract-block`
+- **KPI:** `api.contract.breaking_changes` = 0 (janela 5m)
+- **Ação automática:** `block_release`
+- **Owner:** INT + FE
+- **Rollback:** após publicação de contrato compatível e reexecução de testes.
+
+**Passos**
+1. Rodar suite de contract tests (`make be.contracts`).
+2. Verificar se houve alteração em SDK/FE e backend correspondente.
+3. Atualizar changelog e sinalizar nova versão do contrato.

--- a/docs/runbooks/int_integrations.md
+++ b/docs/runbooks/int_integrations.md
@@ -1,0 +1,37 @@
+# Runbook INT — Integrações & APIs
+
+## api-breaking — `api_breaking_change_watch`
+- **Hook:** `api-contract-block`
+- **KPI:** `api.contract.breaking_changes` = 0 (janela 5m)
+- **Ação automática:** `block_release`
+- **Owner:** INT
+- **Rollback:** após testes de contrato verdes e aprovação dos consumidores.
+
+**Passos**
+1. Executar `make be.contracts` e `make web.contracts` para reproduzir.
+2. Checar versionamento de SDKs e comunicação aos clientes internos.
+3. Ajustar payloads ou versionamento; publicar changelog.
+
+## cache-ttl — `cache_ttl_misuse_watch`
+- **Hook:** `cache-ttl-block`
+- **KPI:** `integration.cache_ttl_violation_pct` = 0 (janela 10m)
+- **Ação automática:** `block_release`
+- **Owner:** INT/Platform
+- **Rollback:** após correção de TTL e validação de headers.
+
+**Passos**
+1. Revisar configs de CDN/cache compartilhados.
+2. Ajustar TTL conforme contrato e purgar caches inválidos.
+3. Confirmar via logs que novos TTLs estão em vigor.
+
+## cls-payin — `cls_payin_cutoff_watch`
+- **Hook:** `cls-payin-cutover`
+- **KPI:** `integration.cls_payin_cutoff_delay_ms` ≤ 30000 (janela 5m)
+- **Ação automática:** `switch_to_manual_cutoff`
+- **Owner:** INT/Payments
+- **Rollback:** após automação normalizada (< 10.000 ms por 3 janelas).
+
+**Passos**
+1. Validar integrações com parceiros bancários e cron jobs.
+2. Ativar manualmente o cutoff enquanto investiga atraso.
+3. Comunicar Tesouraria e registrar ocorrência em `payments-incidents`.

--- a/docs/runbooks/ml_model_ops.md
+++ b/docs/runbooks/ml_model_ops.md
@@ -1,0 +1,50 @@
+# Runbook ML — Model Lifecycle
+
+## model-drift — `model_drift_watch`
+- **Hook:** `model-drift-rollback`
+- **KPI:** `model.psi` ≤ 0.2 (janela 24h)
+- **Ação automática:** `rollback_model`
+- **Owner:** ML
+- **Rollback:** automático após PSI ≤ 0.12 por 2 janelas e validação offline.
+
+**Passos**
+1. Validar PSI/KS por segmento e confirmar se há issue de entrada (DATA).
+2. Verificar experimentos ativos e toggles de modelo canário.
+3. Caso rollback ocorra, confirmar disponibilidade do baseline e recalcular métricas.
+4. Documentar comparação de distribuições e anexar no ACE.
+
+## srm — `ab_srm_watch`
+- **Hook:** `experiment-srm-guardrail`
+- **KPI:** `experiment.srm_pvalue` ≥ 0.01 (janela 24h)
+- **Ação automática:** `pause_experiment`
+- **Owner:** ML Experimentos
+- **Rollback:** retomar somente após SRM > 0.05 e auditoria estatística.
+
+**Passos**
+1. Rodar script `scripts/experiments/check_srm.py`.
+2. Validar randomização e event tracking com FE/INT.
+3. Emitir relatório de impacto e plano de correção.
+
+## runtime-eol — `runtime_eol_watch`
+- **Hook:** `runtime-eol-governance`
+- **KPI:** `runtime.support_gap_days` = 0 (janela 7d)
+- **Ação:** `schedule_runtime_upgrade`
+- **Owner:** PLAT + ML
+- **Rollback:** não aplicável (migração planejada).
+
+**Passos**
+1. Atualizar roadmap de upgrade e alinhar janela de manutenção.
+2. Garantir testes regressivos e SBOM atualizados.
+3. Comunicar stakeholders e publicar ADR/waiver se necessário.
+
+## image-vuln — `image_vuln_regression_watch`
+- **Hook:** `image-vuln-regression-block`
+- **KPI:** `image.critical_vuln_count` = 0 (janela 15m)
+- **Ação automática:** `block_release`
+- **Owner:** SEC + ML Ops
+- **Rollback:** após rebuild seguro e varredura limpa (Grype/Trivy).
+
+**Passos**
+1. Revisar pipeline de containerização e dependências afetadas.
+2. Rebuild da imagem com patches aplicados.
+3. Executar scanner e anexar relatório assinado.

--- a/docs/runbooks/plat_observability.md
+++ b/docs/runbooks/plat_observability.md
@@ -1,0 +1,52 @@
+# Runbook PLAT — Observabilidade & Confiabilidade
+
+## tracing-sampling — `tracing_sampling_watch`
+- **Hook:** `tracing-sampling-freeze`
+- **KPI:** `tracing.sampling_rate` ≥ 1% (janela 15m)
+- **Ação automática:** `block_release`
+- **Owner:** SRE
+- **Rollback:** após sampling ≥ 3% por 2 janelas.
+
+**Passos**
+1. Checar config do Otel Collector e limites de ingestão.
+2. Ajustar sampling dinâmico e confirmar em dashboards.
+3. Reabrir deploy apenas após verificação cruzada com DEC/PM.
+
+## alert-storm — `alert_storm_watch`
+- **Hook:** `alert-storm-suppressor`
+- **KPI:** `alerts.per_minute` ≤ 50 (janela 10m)
+- **Ação automática:** `enable_alert_mitigation`
+- **Owner:** SRE
+- **Rollback:** quando taxa ≤ 30 por 3 janelas.
+
+**Passos**
+1. Identificar origem (ruído ou incidente) analisando tags.
+2. Aplicar dedupe/quiet hours e alinhar com SecOps.
+3. Registrar follow-up para ajustar regras de alerta.
+
+## policy-violation — `policy_violation_watch`
+- **Hook:** `policy-violation-freeze`
+- **KPI:** `policy.violation_detected` = 0 (janela 5m)
+- **Ação automática:** `freeze_release`
+- **Owner:** SRE + Compliance
+- **Rollback:** após waiver aprovado e remediação aplicada.
+
+**Passos**
+1. Verificar política quebrada (RBAC, CIP, etc.).
+2. Aplicar mitigação e obter aprovação compliance.
+3. Atualizar auditoria e checklist ACE.
+
+## okr-alignment — `okr_risk_alignment_watch`
+- **Hook:** `okr-alignment-escalation`
+- **KPI:** `okr.risk_alignment_score` ≥ 0.8 (janela 7d)
+- **Ação:** `escalate_exec_review`
+- **Owner:** StrategyOps
+- **Rollback:** após score ≥ 0.9 confirmado em review.
+
+**Passos**
+1. Revisar KPIs impactados e riscos abertos.
+2. Preparar briefing executivo com ações corretivas.
+3. Acompanhar implementação e atualizar status semanalmente.
+
+## slo-burn — `slo_budget_breach_watch`
+Seguir instruções de `docs/runbooks/dec_decision_pricing.md#slo-burn` com foco em capacidade e erros infra.

--- a/docs/runbooks/pm_market_health.md
+++ b/docs/runbooks/pm_market_health.md
@@ -1,0 +1,43 @@
+# Runbook PM — Mercados & Sinais
+
+## oracle-divergence — `oracle_divergence_watch`
+- **Hook:** `oracle-staleness-failover`
+- **KPI:** `oracle.divergence_bps` ≤ 5 (janela 10m)
+- **Ação automática:** `switch_to_twap_failover`
+- **Owner:** PM/BC
+- **Rollback:** quando divergência ≤ 2 bps por 3 janelas.
+
+**Passos**
+1. Checar painel `oracles.staleness` e logs de TWAP.
+2. Validar feeds alternativos (CLS, CME) e registrar carimbos de tempo.
+3. Sincronizar com DEC para confirmar que preços degradados foram aplicados.
+4. Abrir ticket `PM-MKT` com análise de causa e anexar comparação de preços.
+
+## fx-delta — `fx_delta_benchmark_watch`
+- **Hook:** `fx-delta-benchmark-guard`
+- **KPI:** `fx.delta_vs_benchmark_bps` ≤ 15 (janela 10m)
+- **Ação automática:** `switch_to_reference_rate`
+- **Owner:** PM FX
+- **Rollback:** após delta ≤ 8 bps por 4 janelas.
+
+**Passos**
+1. Confirmar fonte de benchmark (ECB, BCB) e latência.
+2. Revisar filas de roteamento FX e spreads.
+3. Validar se experimentos abertos afetam spreads.
+4. Atualizar canal #pm-markets com status.
+
+## auction-invariant — `auction_invariant_breach_watch`
+- **Hook:** `auction-invariant-pause`
+- **KPI:** `auction.kkt_violation_pct` = 0 (janela 5m)
+- **Ação automática:** `pause_auction_stream`
+- **Owner:** PM Leilões
+- **Rollback:** após auditoria matemática e validação de curvas.
+
+**Passos**
+1. Avaliar logs de `auction.match` para violações.
+2. Executar script de verificação de convexidade (`scripts/check_convexity.py`).
+3. Confirmar com DATA se há inconsistências de input.
+4. Só retomar streaming após aprovação conjunta PM/DATA/SEC.
+
+## slo-burn — `slo_budget_breach_watch`
+Seguir plano descrito em `docs/runbooks/dec_decision_pricing.md#slo-burn` adicionando validações de mercado.

--- a/docs/runbooks/sec_privacy.md
+++ b/docs/runbooks/sec_privacy.md
@@ -1,0 +1,52 @@
+# Runbook SEC/PRIV — Segurança & Privacidade
+
+## dep-vuln — `dep_vuln_watch`
+- **Hook:** `dep-vuln-freeze`
+- **KPI:** `security.deps.critical_vulns` = 0 (janela 15m)
+- **Ação automática:** `block_release`
+- **Owner:** Security Engineering
+- **Rollback:** após mitigação e varredura limpa.
+
+**Passos**
+1. Consultar SBOM e scanner (Grype/Snyk) para lista de CVEs.
+2. Aplicar patch/upgrade ou waiver com aprovação CISO.
+3. Rodar `make security.scan` e anexar relatório.
+
+## image-vuln — `image_vuln_regression_watch`
+Seguir instruções do `docs/runbooks/ml_model_ops.md#image-vuln` com foco em supply chain.
+
+## dp-budget — `dp_budget_breach_watch`
+- **Hook:** `dp-budget-freeze`
+- **KPI:** `privacy.dp_budget_multiplier` ≤ 1.5 (janela 60m)
+- **Ação automática:** `freeze_processing`
+- **Owner:** Privacy Engineering
+- **Rollback:** após budget ≤ 1.2 por 2 janelas e revisão de auditoria.
+
+**Passos**
+1. Analisar logs de consultas DP e auditorias.
+2. Revisar ruído/epsilon aplicado e pausar cargas de alto custo.
+3. Documentar ajuste e liberar somente após aprovação do DPO.
+
+## idp-keys — `idp_keys_rotation_watch`
+- **Hook:** `idp-keys-rotation`
+- **KPI:** `security.idp.keys_age_days` ≤ 90 (janela 1d)
+- **Ação:** `rotate_idp_keys`
+- **Owner:** Security Engineering
+- **Rollback:** não aplicável.
+
+**Passos**
+1. Agendar rotação com IAM Ops e registrar mudança.
+2. Atualizar secrets, revogar chaves antigas e validar pipelines.
+3. Monitorar autenticação por 24h para garantir ausência de erros.
+
+## formal-verification — `formal_verification_gate_watch`
+- **Hook:** `formal-verification-freeze`
+- **KPI:** `formal.verification.failure` = 0 (janela 5m)
+- **Ação automática:** `freeze_pipeline`
+- **Owner:** Security Assurance
+- **Rollback:** após verificação rerun aprovada.
+
+**Passos**
+1. Revisar logs do verificador (Coq/Z3) e identificar regressões.
+2. Corrigir prova ou desabilitar mudança ofensora.
+3. Retomar pipeline somente com aprovação dupla (SEC + domínio).

--- a/ops/hooks/a110.yaml
+++ b/ops/hooks/a110.yaml
@@ -1,0 +1,343 @@
+{
+  "version": 1,
+  "hooks": [
+    {
+      "hook": "dec-latency-gap",
+      "watchers": [
+        "metrics_decision_hook_gap_watch"
+      ],
+      "kpi": "dec.latency.p95",
+      "threshold": "800ms",
+      "window": "5m",
+      "action": "degrade_route",
+      "owner": "SRE",
+      "rollback": true,
+      "playbook": "docs/runbooks/dec_decision_pricing.md#metric-gap"
+    },
+    {
+      "hook": "model-drift-rollback",
+      "watchers": [
+        "model_drift_watch"
+      ],
+      "kpi": "model.psi",
+      "threshold": 0.2,
+      "window": "24h",
+      "action": "rollback_model",
+      "owner": "ML",
+      "rollback": true,
+      "playbook": "docs/runbooks/ml_model_ops.md#model-drift"
+    },
+    {
+      "hook": "slo-burn-rate-guard",
+      "watchers": [
+        "slo_budget_breach_watch"
+      ],
+      "kpi": "slo.burn_rate",
+      "threshold": 1.0,
+      "window": "60m",
+      "action": "enforce_release_freeze",
+      "owner": "SRE",
+      "rollback": true,
+      "playbook": "docs/runbooks/plat_observability.md#slo-burn"
+    },
+    {
+      "hook": "oracle-staleness-failover",
+      "watchers": [
+        "oracle_divergence_watch"
+      ],
+      "kpi": "oracle.divergence_bps",
+      "threshold": 5,
+      "window": "10m",
+      "action": "switch_to_twap_failover",
+      "owner": "PM",
+      "rollback": true,
+      "playbook": "docs/runbooks/pm_market_health.md#oracle-divergence"
+    },
+    {
+      "hook": "fx-delta-benchmark-guard",
+      "watchers": [
+        "fx_delta_benchmark_watch"
+      ],
+      "kpi": "fx.delta_vs_benchmark_bps",
+      "threshold": 15,
+      "window": "10m",
+      "action": "switch_to_reference_rate",
+      "owner": "PM",
+      "rollback": true,
+      "playbook": "docs/runbooks/pm_market_health.md#fx-delta"
+    },
+    {
+      "hook": "auction-invariant-pause",
+      "watchers": [
+        "auction_invariant_breach_watch"
+      ],
+      "kpi": "auction.kkt_violation_pct",
+      "threshold": 0.0,
+      "window": "5m",
+      "action": "pause_auction_stream",
+      "owner": "PM",
+      "rollback": true,
+      "playbook": "docs/runbooks/pm_market_health.md#auction-invariant"
+    },
+    {
+      "hook": "experiment-srm-guardrail",
+      "watchers": [
+        "ab_srm_watch"
+      ],
+      "kpi": "experiment.srm_pvalue",
+      "threshold": 0.01,
+      "window": "24h",
+      "action": "pause_experiment",
+      "owner": "ML",
+      "rollback": true,
+      "playbook": "docs/runbooks/ml_model_ops.md#srm"
+    },
+    {
+      "hook": "runtime-eol-governance",
+      "watchers": [
+        "runtime_eol_watch"
+      ],
+      "kpi": "runtime.support_gap_days",
+      "threshold": 0,
+      "window": "7d",
+      "action": "schedule_runtime_upgrade",
+      "owner": "PLAT",
+      "rollback": false,
+      "playbook": "docs/runbooks/ml_model_ops.md#runtime-eol"
+    },
+    {
+      "hook": "image-vuln-regression-block",
+      "watchers": [
+        "image_vuln_regression_watch"
+      ],
+      "kpi": "image.critical_vuln_count",
+      "threshold": 0,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "SEC",
+      "rollback": true,
+      "playbook": "docs/runbooks/sec_privacy.md#image-vuln"
+    },
+    {
+      "hook": "cdc-lag-hot-degrade",
+      "watchers": [
+        "cdc_lag_watch"
+      ],
+      "kpi": "cdc.lag.p95",
+      "threshold": "120s",
+      "window": "15m",
+      "action": "degrade_to_hot_table",
+      "owner": "DATA",
+      "rollback": true,
+      "playbook": "docs/runbooks/data_contracts.md#cdc-lag"
+    },
+    {
+      "hook": "schema-drift-blocker",
+      "watchers": [
+        "schema_registry_drift_watch"
+      ],
+      "kpi": "schema.drift_detected",
+      "threshold": 1,
+      "window": "5m",
+      "action": "block_deploy",
+      "owner": "DATA",
+      "rollback": true,
+      "playbook": "docs/runbooks/data_contracts.md#schema-drift"
+    },
+    {
+      "hook": "dbt-test-rollback",
+      "watchers": [
+        "dbt_test_failure_watch"
+      ],
+      "kpi": "dbt.tests.failure_rate",
+      "threshold": 0,
+      "window": "15m",
+      "action": "rollback_transform",
+      "owner": "DATA",
+      "rollback": true,
+      "playbook": "docs/runbooks/data_contracts.md#dbt-tests"
+    },
+    {
+      "hook": "data-contract-breach-guard",
+      "watchers": [
+        "data_contract_break_watch"
+      ],
+      "kpi": "data.contract.break",
+      "threshold": 1,
+      "window": "5m",
+      "action": "trigger_contract_waiver",
+      "owner": "DATA",
+      "rollback": true,
+      "playbook": "docs/runbooks/data_contracts.md#contract-breach"
+    },
+    {
+      "hook": "doc-coverage-gap",
+      "watchers": [
+        "doc_coverage_watch"
+      ],
+      "kpi": "data.doc.coverage",
+      "threshold": 0.95,
+      "window": "24h",
+      "action": "raise_doc_gap",
+      "owner": "DATA",
+      "rollback": false,
+      "playbook": "docs/runbooks/data_contracts.md#doc-coverage"
+    },
+    {
+      "hook": "web-cwv-rollback",
+      "watchers": [
+        "web_cwv_regression_watch"
+      ],
+      "kpi": "web.cwv.inp_p75",
+      "threshold": "200ms",
+      "window": "24h",
+      "action": "rollback_fe_release",
+      "owner": "FE",
+      "rollback": true,
+      "playbook": "docs/runbooks/fe_experience.md#web-cwv"
+    },
+    {
+      "hook": "api-contract-block",
+      "watchers": [
+        "api_breaking_change_watch"
+      ],
+      "kpi": "api.contract.breaking_changes",
+      "threshold": 0,
+      "window": "5m",
+      "action": "block_release",
+      "owner": "INT",
+      "rollback": true,
+      "playbook": "docs/runbooks/int_integrations.md#api-breaking"
+    },
+    {
+      "hook": "formal-verification-freeze",
+      "watchers": [
+        "formal_verification_gate_watch"
+      ],
+      "kpi": "formal.verification.failure",
+      "threshold": 1,
+      "window": "5m",
+      "action": "freeze_pipeline",
+      "owner": "SEC",
+      "rollback": true,
+      "playbook": "docs/runbooks/sec_privacy.md#formal-verification"
+    },
+    {
+      "hook": "okr-alignment-escalation",
+      "watchers": [
+        "okr_risk_alignment_watch"
+      ],
+      "kpi": "okr.risk_alignment_score",
+      "threshold": 0.8,
+      "window": "7d",
+      "action": "escalate_exec_review",
+      "owner": "StrategyOps",
+      "rollback": false,
+      "playbook": "docs/runbooks/plat_observability.md#okr-alignment"
+    },
+    {
+      "hook": "dp-budget-freeze",
+      "watchers": [
+        "dp_budget_breach_watch"
+      ],
+      "kpi": "privacy.dp_budget_multiplier",
+      "threshold": 1.5,
+      "window": "60m",
+      "action": "freeze_processing",
+      "owner": "SEC",
+      "rollback": true,
+      "playbook": "docs/runbooks/sec_privacy.md#dp-budget"
+    },
+    {
+      "hook": "dep-vuln-freeze",
+      "watchers": [
+        "dep_vuln_watch"
+      ],
+      "kpi": "security.deps.critical_vulns",
+      "threshold": 0,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "SEC",
+      "rollback": true,
+      "playbook": "docs/runbooks/sec_privacy.md#dep-vuln"
+    },
+    {
+      "hook": "idp-keys-rotation",
+      "watchers": [
+        "idp_keys_rotation_watch"
+      ],
+      "kpi": "security.idp.keys_age_days",
+      "threshold": 90,
+      "window": "1d",
+      "action": "rotate_idp_keys",
+      "owner": "SEC",
+      "rollback": false,
+      "playbook": "docs/runbooks/sec_privacy.md#idp-keys"
+    },
+    {
+      "hook": "cache-ttl-block",
+      "watchers": [
+        "cache_ttl_misuse_watch"
+      ],
+      "kpi": "integration.cache_ttl_violation_pct",
+      "threshold": 0,
+      "window": "10m",
+      "action": "block_release",
+      "owner": "INT",
+      "rollback": true,
+      "playbook": "docs/runbooks/int_integrations.md#cache-ttl"
+    },
+    {
+      "hook": "cls-payin-cutover",
+      "watchers": [
+        "cls_payin_cutoff_watch"
+      ],
+      "kpi": "integration.cls_payin_cutoff_delay_ms",
+      "threshold": 30000,
+      "window": "5m",
+      "action": "switch_to_manual_cutoff",
+      "owner": "INT",
+      "rollback": true,
+      "playbook": "docs/runbooks/int_integrations.md#cls-payin"
+    },
+    {
+      "hook": "tracing-sampling-freeze",
+      "watchers": [
+        "tracing_sampling_watch"
+      ],
+      "kpi": "tracing.sampling_rate",
+      "threshold": 0.01,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "SRE",
+      "rollback": true,
+      "playbook": "docs/runbooks/plat_observability.md#tracing-sampling"
+    },
+    {
+      "hook": "alert-storm-suppressor",
+      "watchers": [
+        "alert_storm_watch"
+      ],
+      "kpi": "alerts.per_minute",
+      "threshold": 50,
+      "window": "10m",
+      "action": "enable_alert_mitigation",
+      "owner": "SRE",
+      "rollback": true,
+      "playbook": "docs/runbooks/plat_observability.md#alert-storm"
+    },
+    {
+      "hook": "policy-violation-freeze",
+      "watchers": [
+        "policy_violation_watch"
+      ],
+      "kpi": "policy.violation_detected",
+      "threshold": 1,
+      "window": "5m",
+      "action": "freeze_release",
+      "owner": "Compliance",
+      "rollback": true,
+      "playbook": "docs/runbooks/plat_observability.md#policy-violation"
+    }
+  ]
+}

--- a/ops/scripts/gate_a110.sh
+++ b/ops/scripts/gate_a110.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --check" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  --check)
+    python - <<'PY'
+import json
+from pathlib import Path
+import sys
+
+errors = []
+watchers_path = Path('ops/watchers/core.yaml')
+hooks_path = Path('ops/hooks/a110.yaml')
+
+if not watchers_path.exists():
+    errors.append(f"missing watchers file: {watchers_path}")
+if not hooks_path.exists():
+    errors.append(f"missing hooks file: {hooks_path}")
+
+if errors:
+    print("\n".join(errors))
+    sys.exit(1)
+
+with watchers_path.open() as fh:
+    watchers_data = json.load(fh)
+with hooks_path.open() as fh:
+    hooks_data = json.load(fh)
+
+expected_domains = ["DEC", "PM", "DATA", "ML", "FE", "SEC/PRIV", "PLAT", "INT"]
+domains = watchers_data.get("domains", {})
+if sorted(domains.keys()) != sorted(expected_domains):
+    errors.append(f"domains mismatch: expected {expected_domains}, found {sorted(domains.keys())}")
+
+watcher_defs = watchers_data.get("watchers", {})
+all_domain_watchers = []
+for domain, watchers in domains.items():
+    if not watchers:
+        errors.append(f"domain {domain} has no watchers configured")
+    for watcher in watchers:
+        all_domain_watchers.append(watcher)
+        if watcher not in watcher_defs:
+            errors.append(f"watcher {watcher} referenced in domain {domain} but missing definition")
+
+hooks = hooks_data.get("hooks", [])
+if not hooks:
+    errors.append("no hooks defined in ops/hooks/a110.yaml")
+
+hooks_by_name = {}
+watchers_with_hooks = set()
+for hook in hooks:
+    name = hook.get("hook")
+    if not name:
+        errors.append("found hook entry without name")
+        continue
+    if name in hooks_by_name:
+        errors.append(f"duplicate hook name detected: {name}")
+    hooks_by_name[name] = hook
+
+    for field in ("kpi", "threshold", "window", "owner", "rollback", "playbook"):
+        if field not in hook or hook[field] in (None, ""):
+            errors.append(f"hook {name} missing required field: {field}")
+    watcher_list = hook.get("watchers", [])
+    if not watcher_list:
+        errors.append(f"hook {name} missing watchers binding")
+        continue
+    for watcher in watcher_list:
+        watchers_with_hooks.add(watcher)
+        if watcher not in watcher_defs:
+            errors.append(f"hook {name} references unknown watcher {watcher}")
+
+    playbook = hook.get("playbook", "")
+    playbook_path = playbook.split('#', 1)[0]
+    if playbook_path:
+        pb_file = Path(playbook_path)
+        if not pb_file.exists():
+            errors.append(f"playbook path not found for hook {name}: {playbook_path}")
+    else:
+        errors.append(f"hook {name} missing playbook path")
+
+watchers_missing_hooks = sorted(set(all_domain_watchers) - watchers_with_hooks)
+if watchers_missing_hooks:
+    errors.append(f"watchers sem hook mapeado: {watchers_missing_hooks}")
+
+for watcher, meta in watcher_defs.items():
+    hook_name = meta.get("hook")
+    if not hook_name:
+        errors.append(f"watcher {watcher} sem hook configurado")
+        continue
+    if hook_name not in hooks_by_name:
+        errors.append(f"watcher {watcher} aponta para hook inexistente {hook_name}")
+
+if errors:
+    for err in errors:
+        print(f"[A110][ERROR] {err}")
+    sys.exit(1)
+
+print("[A110] Gate check passed: watchers, hooks e runbooks consistentes.")
+PY
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/ops/watchers/core.yaml
+++ b/ops/watchers/core.yaml
@@ -1,0 +1,210 @@
+{
+  "version": 1,
+  "domains": {
+    "DEC": [
+      "metrics_decision_hook_gap_watch",
+      "model_drift_watch",
+      "slo_budget_breach_watch"
+    ],
+    "PM": [
+      "oracle_divergence_watch",
+      "fx_delta_benchmark_watch",
+      "auction_invariant_breach_watch",
+      "slo_budget_breach_watch"
+    ],
+    "DATA": [
+      "cdc_lag_watch",
+      "schema_registry_drift_watch",
+      "dbt_test_failure_watch",
+      "data_contract_break_watch",
+      "doc_coverage_watch"
+    ],
+    "ML": [
+      "model_drift_watch",
+      "ab_srm_watch",
+      "runtime_eol_watch",
+      "image_vuln_regression_watch"
+    ],
+    "FE": [
+      "web_cwv_regression_watch",
+      "api_breaking_change_watch"
+    ],
+    "SEC/PRIV": [
+      "dep_vuln_watch",
+      "image_vuln_regression_watch",
+      "idp_keys_rotation_watch",
+      "dp_budget_breach_watch",
+      "formal_verification_gate_watch"
+    ],
+    "PLAT": [
+      "tracing_sampling_watch",
+      "alert_storm_watch",
+      "slo_budget_breach_watch",
+      "okr_risk_alignment_watch",
+      "policy_violation_watch"
+    ],
+    "INT": [
+      "api_breaking_change_watch",
+      "cache_ttl_misuse_watch",
+      "cls_payin_cutoff_watch"
+    ]
+  },
+  "watchers": {
+    "metrics_decision_hook_gap_watch": {
+      "description": "Garante que a latência DEC permaneça dentro dos limites antes de alterar rotas.",
+      "kpi": "dec.latency.p95",
+      "owner": "SRE",
+      "hook": "dec-latency-gap"
+    },
+    "model_drift_watch": {
+      "description": "Detecta drift estatístico relevante para decisões de crédito.",
+      "kpi": "model.psi",
+      "owner": "ML",
+      "hook": "model-drift-rollback"
+    },
+    "slo_budget_breach_watch": {
+      "description": "Monitora burn rate do SLO cross-domain.",
+      "kpi": "slo.burn_rate",
+      "owner": "SRE",
+      "hook": "slo-burn-rate-guard"
+    },
+    "oracle_divergence_watch": {
+      "description": "Detecta divergência de preço entre oráculos e referência.",
+      "kpi": "oracle.divergence_bps",
+      "owner": "PM",
+      "hook": "oracle-staleness-failover"
+    },
+    "fx_delta_benchmark_watch": {
+      "description": "Compara delta FX com benchmark para evitar arbitragem.",
+      "kpi": "fx.delta_vs_benchmark_bps",
+      "owner": "PM",
+      "hook": "fx-delta-benchmark-guard"
+    },
+    "auction_invariant_breach_watch": {
+      "description": "Fiscaliza invariantes KKT e convexidade nos leilões.",
+      "kpi": "auction.kkt_violation_pct",
+      "owner": "PM",
+      "hook": "auction-invariant-pause"
+    },
+    "ab_srm_watch": {
+      "description": "Detecta falhas de SRM em experimentos e testes AA.",
+      "kpi": "experiment.srm_pvalue",
+      "owner": "ML",
+      "hook": "experiment-srm-guardrail"
+    },
+    "runtime_eol_watch": {
+      "description": "Aponta runtimes em fim de vida para evitar builds inseguras.",
+      "kpi": "runtime.support_gap_days",
+      "owner": "PLAT",
+      "hook": "runtime-eol-governance"
+    },
+    "image_vuln_regression_watch": {
+      "description": "Bloqueia regressão de vulnerabilidades críticas em imagens.",
+      "kpi": "image.critical_vuln_count",
+      "owner": "SEC",
+      "hook": "image-vuln-regression-block"
+    },
+    "cdc_lag_watch": {
+      "description": "Acompanha lag CDC p95 contra o contrato de dados.",
+      "kpi": "cdc.lag.p95",
+      "owner": "DATA",
+      "hook": "cdc-lag-hot-degrade"
+    },
+    "schema_registry_drift_watch": {
+      "description": "Detecta incompatibilidades no schema registry.",
+      "kpi": "schema.drift_detected",
+      "owner": "DATA",
+      "hook": "schema-drift-blocker"
+    },
+    "dbt_test_failure_watch": {
+      "description": "Flag de falhas de testes dbt críticos.",
+      "kpi": "dbt.tests.failure_rate",
+      "owner": "DATA",
+      "hook": "dbt-test-rollback"
+    },
+    "data_contract_break_watch": {
+      "description": "Quebra de contrato de dados A106/A87/A89.",
+      "kpi": "data.contract.break",
+      "owner": "DATA",
+      "hook": "data-contract-breach-guard"
+    },
+    "doc_coverage_watch": {
+      "description": "Garante cobertura de documentação mínima das pipelines.",
+      "kpi": "data.doc.coverage",
+      "owner": "DATA",
+      "hook": "doc-coverage-gap"
+    },
+    "web_cwv_regression_watch": {
+      "description": "Observa regressões de Core Web Vitals (INP p75).",
+      "kpi": "web.cwv.inp_p75",
+      "owner": "FE",
+      "hook": "web-cwv-rollback"
+    },
+    "api_breaking_change_watch": {
+      "description": "Previne quebras de contrato de APIs públicas/internas.",
+      "kpi": "api.contract.breaking_changes",
+      "owner": "INT",
+      "hook": "api-contract-block"
+    },
+    "formal_verification_gate_watch": {
+      "description": "Sinaliza falha em gates formais (A108/segurança).",
+      "kpi": "formal.verification.failure",
+      "owner": "SEC",
+      "hook": "formal-verification-freeze"
+    },
+    "okr_risk_alignment_watch": {
+      "description": "Monitora desalinhamento de riscos com OKRs estratégicos.",
+      "kpi": "okr.risk_alignment_score",
+      "owner": "StrategyOps",
+      "hook": "okr-alignment-escalation"
+    },
+    "dp_budget_breach_watch": {
+      "description": "Garante que o budget de privacidade diferencial não estoure.",
+      "kpi": "privacy.dp_budget_multiplier",
+      "owner": "SEC",
+      "hook": "dp-budget-freeze"
+    },
+    "dep_vuln_watch": {
+      "description": "Bloqueia releases com vulnerabilidades críticas em dependências.",
+      "kpi": "security.deps.critical_vulns",
+      "owner": "SEC",
+      "hook": "dep-vuln-freeze"
+    },
+    "idp_keys_rotation_watch": {
+      "description": "Enforce rotação de chaves/segredos do IdP.",
+      "kpi": "security.idp.keys_age_days",
+      "owner": "SEC",
+      "hook": "idp-keys-rotation"
+    },
+    "cache_ttl_misuse_watch": {
+      "description": "Flag para TTL incorreto em caches compartilhados.",
+      "kpi": "integration.cache_ttl_violation_pct",
+      "owner": "INT",
+      "hook": "cache-ttl-block"
+    },
+    "cls_payin_cutoff_watch": {
+      "description": "Garante que o cutoff CLS payin seja seguido sem atraso.",
+      "kpi": "integration.cls_payin_cutoff_delay_ms",
+      "owner": "INT",
+      "hook": "cls-payin-cutover"
+    },
+    "tracing_sampling_watch": {
+      "description": "Monitora taxa de amostragem do tracing distribuído.",
+      "kpi": "tracing.sampling_rate",
+      "owner": "SRE",
+      "hook": "tracing-sampling-freeze"
+    },
+    "alert_storm_watch": {
+      "description": "Detecta tempestades de alertas indicando ruído ou incidentes generalizados.",
+      "kpi": "alerts.per_minute",
+      "owner": "SRE",
+      "hook": "alert-storm-suppressor"
+    },
+    "policy_violation_watch": {
+      "description": "Garante que políticas operacionais/compliance permaneçam sem violações.",
+      "kpi": "policy.violation_detected",
+      "owner": "Compliance",
+      "hook": "policy-violation-freeze"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define the domain-scoped watcher catalogue in `ops/watchers/core.yaml`
- add `ops/hooks/a110.yaml` with KPI/threshold/window/owner bindings and playbooks
- document the new actions via domain runbooks and validate with the gate script

## Testing
- `ops/scripts/gate_a110.sh --check`


------
https://chatgpt.com/codex/tasks/task_e_68d74a4df36c833086ed5546830502df