### PR TITLE
Add ops dry run assets and k6 smoke test

### DIFF
--- a/ops/evidence/evidence.json
+++ b/ops/evidence/evidence.json
@@ -1,0 +1,217 @@
+{
+  "generated_at": "2025-09-27T02:26:12.499694+00:00",
+  "watchers_artifact": "/workspace/trendmarket/ops/reports/watchers_dry.json",
+  "hooks_artifact": "/workspace/trendmarket/ops/reports/hooks_dry.json",
+  "watchers_digest": "9fa2702d1c41d6b223c40a30a104731bf848d48d38fff5d8b8a20991dff2b72a",
+  "hooks_digest": "b614757127dbd9272a514321c06d92e16b2e5f6680ceb10a4e55379e79254f17",
+  "watchers_count": 16,
+  "hooks_count": 3,
+  "evidence": {
+    "watchers": [
+      {
+        "id": "api_breaking_change_watch",
+        "owner": "platform-sre",
+        "kpi": "api.contract.compatibility",
+        "threshold": 0,
+        "window": "5m",
+        "action": "block_release",
+        "description": "Detecta alterações incompatíveis de contrato nas APIs públicas",
+        "hash": "97fe7fab090601a1004035356caea0d24c53194010abd8b26608f2d138ae124d"
+      },
+      {
+        "id": "schema_registry_drift_watch",
+        "owner": "data-governance",
+        "kpi": "data.schema.drift",
+        "threshold": 0,
+        "window": "5m",
+        "action": "rollback_contract",
+        "description": "Monitora divergências de esquema registradas e validadas",
+        "hash": "7fb1e3d1b3fc8673070169cf0e0a06d7e470aec7bbf70fbba2000c6e227a93c5"
+      },
+      {
+        "id": "data_contract_break_watch",
+        "owner": "data-governance",
+        "kpi": "data.contract.breach",
+        "threshold": 0,
+        "window": "5m",
+        "action": "rollback_contract",
+        "description": "Alerta para violações de contratos A106/A87/A89",
+        "hash": "fdd17d3d5b8d8468cdbe66bec201d799e778ddb6c48182b459d26a6a6a8a8709"
+      },
+      {
+        "id": "dbt_test_failure_watch",
+        "owner": "analytics-engineering",
+        "kpi": "data.dbt.tests_failed",
+        "threshold": 0,
+        "window": "5m",
+        "action": "block_release",
+        "description": "Gatilha quando testes dbt críticos falham",
+        "hash": "22f4e2562f5b4b5876fd1af51d17a280857664a2b6966319daf7396b489603dd"
+      },
+      {
+        "id": "cdc_lag_watch",
+        "owner": "data-platform",
+        "kpi": "data.cdc.lag.p95",
+        "threshold": "120s",
+        "window": "5m",
+        "action": "degrade_to_hot_table",
+        "description": "Monitora lag de CDC p95 com orçamento de 120s",
+        "hash": "2999a797685b7571c9b6c785c83e123d524562c629c35c563fe01ce185d81173"
+      },
+      {
+        "id": "slo_budget_breach_watch",
+        "owner": "sre",
+        "kpi": "decision.slo.error_budget",
+        "threshold": 1.0,
+        "window": "30m",
+        "action": "trigger_degrade_route",
+        "description": "Observa burn rate do orçamento de erro das decisões",
+        "hash": "abb44d8c21089d85b07ca9fc5db93b2d871fe6dc872aa4dd4d50b3f95952aafe"
+      },
+      {
+        "id": "model_drift_watch",
+        "owner": "ml-ops",
+        "kpi": "model.drift.psi",
+        "threshold": 0.2,
+        "window": "24h",
+        "action": "rollback_model",
+        "description": "Aciona rollback se PSI/KS ultrapassar limites",
+        "hash": "28ba763cf1f501eb3fb131f8e4a30359fbe5eeadcf2f997d63e5849094e498db"
+      },
+      {
+        "id": "metrics_decision_hook_gap_watch",
+        "owner": "sre",
+        "kpi": "decision.hook.gap",
+        "threshold": 0,
+        "window": "15m",
+        "action": "escalate_to_owner",
+        "description": "Monitora lacunas entre métricas e hooks acionados",
+        "hash": "3bd7ae2537c70c12947073dd3d4fa452f8c81b0ca2720cdbf16eaa5e0ee0ca04"
+      },
+      {
+        "id": "formal_verification_gate_watch",
+        "owner": "security-architecture",
+        "kpi": "security.formal_verification.status",
+        "threshold": 1,
+        "window": "24h",
+        "action": "freeze_release",
+        "description": "Garante que verificações formais foram executadas",
+        "hash": "c93727a5617b7e70d5cdfb2ab6e971ba23ff8efde62dc75070471b6a9363c8f2"
+      },
+      {
+        "id": "web_cwv_regression_watch",
+        "owner": "frontend-platform",
+        "kpi": "web.cwv.inp.p75",
+        "threshold": "200ms",
+        "window": "24h",
+        "action": "rollback_frontend",
+        "description": "Sinaliza regressões em INP/LCP das experiências web",
+        "hash": "045ae8449b207e061541f2386d8594a4fc8b587e3519448681020d9178dd58b8"
+      },
+      {
+        "id": "okr_risk_alignment_watch",
+        "owner": "finance-ops",
+        "kpi": "org.okr.risk_alignment",
+        "threshold": 0.95,
+        "window": "24h",
+        "action": "trigger_risk_review",
+        "description": "Escuta desalinhamentos de risco e objetivos chave",
+        "hash": "405fe93d0cfcee27b4ad82e6927a990269c8d82205e42e6268045badaa42cdd7"
+      },
+      {
+        "id": "dp_budget_breach_watch",
+        "owner": "privacy-office",
+        "kpi": "privacy.dp.budget",
+        "threshold": 1.5,
+        "window": "1h",
+        "action": "freeze_processing",
+        "description": "Sinaliza excedentes no orçamento de privacidade",
+        "hash": "fdaba2653cd9ccd28e76a0415a1c43030f2d7b4c95d531b3ae89fbe45a45ee2a"
+      },
+      {
+        "id": "runtime_eol_watch",
+        "owner": "platform-ml",
+        "kpi": "ml.runtime.support.status",
+        "threshold": "30d",
+        "window": "24h",
+        "action": "plan_migration",
+        "description": "Monitora runtimes em fim de vida com risco de suporte",
+        "hash": "396ec0b1a8fba3bd55d6a96bb8627efcaea219ef71769d448b29a05eecee6ed1"
+      },
+      {
+        "id": "dep_vuln_watch",
+        "owner": "appsec",
+        "kpi": "security.dependency.vuln",
+        "threshold": 0,
+        "window": "1h",
+        "action": "block_release",
+        "description": "Analisa SBOM por vulnerabilidades ativas",
+        "hash": "9fb0729ea8510d30fab708c93737a0439faea6052f287e7a268adfd3b2c04ff5"
+      },
+      {
+        "id": "oracle_divergence_watch",
+        "owner": "treasury",
+        "kpi": "market.oracle.delta_bps",
+        "threshold": 10,
+        "window": "5m",
+        "action": "switch_to_twap_failover",
+        "description": "Monitora divergência de preço dos oráculos",
+        "hash": "68cd9b5402746639f1473cfb7a10c4ef70e8e1483dcbb505c8978897617631f8"
+      },
+      {
+        "id": "fx_delta_benchmark_watch",
+        "owner": "treasury",
+        "kpi": "market.fx.delta_bps",
+        "threshold": 5,
+        "window": "5m",
+        "action": "switch_to_twap_failover",
+        "description": "Garante paridade com benchmarks de FX",
+        "hash": "469265d4d6436386d3910107736f9f33db2ef63027c083dd5ea69ca30abd41f3"
+      }
+    ],
+    "hooks": [
+      {
+        "hook": "dec-latency-degrade",
+        "kpi": "dec.latency.p95",
+        "threshold": "800ms",
+        "window": "5m",
+        "action": "degrade_route",
+        "owner": "sre",
+        "rollback": true,
+        "evidence": {
+          "traces": "decision.core",
+          "audit": "ops/reports/dryrun.json"
+        },
+        "hash": "561062ca74690c58be408a647b98372890ccb4eb3c9a56ec04ed558cc851829c"
+      },
+      {
+        "hook": "oracle-stale-failover",
+        "kpi": "oracle.staleness_ms",
+        "threshold": 30000,
+        "window": "5m",
+        "action": "switch_to_twap_failover",
+        "owner": "bc",
+        "rollback": true,
+        "evidence": {
+          "traces": "oracle.fetch",
+          "audit": "ops/evidence/evidence.json"
+        },
+        "hash": "79a1c20e924ade5946c37ff0ce2acdb049c4f6c4683979be890e2c6cc2cec660"
+      },
+      {
+        "hook": "model-drift-rollback",
+        "kpi": "model.psi.p95",
+        "threshold": 0.2,
+        "window": "24h",
+        "action": "rollback_model",
+        "owner": "ml-ops",
+        "rollback": true,
+        "evidence": {
+          "traces": "inference.serving",
+          "audit": "ml/monitoring/psi.json"
+        },
+        "hash": "58011806d0d2f62ba39e7004a245f054fcc3e415f31f73be638485b89fa04440"
+      }
+    ]
+  }
+}

--- a/ops/hooks/a110_hooks.json
+++ b/ops/hooks/a110_hooks.json
@@ -1,0 +1,43 @@
+{
+  "hooks": [
+    {
+      "hook": "dec-latency-degrade",
+      "kpi": "dec.latency.p95",
+      "threshold": "800ms",
+      "window": "5m",
+      "action": "degrade_route",
+      "owner": "sre",
+      "evidence": {
+        "traces": "decision.core",
+        "audit": "ops/reports/dryrun.json"
+      },
+      "rollback": true
+    },
+    {
+      "hook": "oracle-stale-failover",
+      "kpi": "oracle.staleness_ms",
+      "threshold": 30000,
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "owner": "bc",
+      "evidence": {
+        "traces": "oracle.fetch",
+        "audit": "ops/evidence/evidence.json"
+      },
+      "rollback": true
+    },
+    {
+      "hook": "model-drift-rollback",
+      "kpi": "model.psi.p95",
+      "threshold": 0.2,
+      "window": "24h",
+      "action": "rollback_model",
+      "owner": "ml-ops",
+      "evidence": {
+        "traces": "inference.serving",
+        "audit": "ml/monitoring/psi.json"
+      },
+      "rollback": true
+    }
+  ]
+}

--- a/ops/reports/dryrun.json
+++ b/ops/reports/dryrun.json
@@ -1,0 +1,27 @@
+{
+  "executed_at": "2025-09-27T02:26:22.210784+00:00",
+  "worktree": "ephemeral",
+  "commands": [
+    {
+      "command": "make -f ops/scripts/Makefile watchers.dry",
+      "status": "success",
+      "artifacts": [
+        "ops/reports/watchers_dry.json"
+      ]
+    },
+    {
+      "command": "make -f ops/scripts/Makefile hooks.dry",
+      "status": "success",
+      "artifacts": [
+        "ops/reports/hooks_dry.json"
+      ]
+    },
+    {
+      "command": "make -f ops/scripts/Makefile evidence.publish",
+      "status": "success",
+      "artifacts": [
+        "ops/evidence/evidence.json"
+      ]
+    }
+  ]
+}

--- a/ops/reports/hooks_dry.json
+++ b/ops/reports/hooks_dry.json
@@ -1,0 +1,49 @@
+{
+  "generated_at": "2025-09-27T02:26:10.909257+00:00",
+  "source": "/workspace/trendmarket/ops/hooks/a110_hooks.json",
+  "total_hooks": 3,
+  "hooks": [
+    {
+      "hook": "dec-latency-degrade",
+      "kpi": "dec.latency.p95",
+      "threshold": "800ms",
+      "window": "5m",
+      "action": "degrade_route",
+      "owner": "sre",
+      "rollback": true,
+      "evidence": {
+        "traces": "decision.core",
+        "audit": "ops/reports/dryrun.json"
+      },
+      "hash": "561062ca74690c58be408a647b98372890ccb4eb3c9a56ec04ed558cc851829c"
+    },
+    {
+      "hook": "oracle-stale-failover",
+      "kpi": "oracle.staleness_ms",
+      "threshold": 30000,
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "owner": "bc",
+      "rollback": true,
+      "evidence": {
+        "traces": "oracle.fetch",
+        "audit": "ops/evidence/evidence.json"
+      },
+      "hash": "79a1c20e924ade5946c37ff0ce2acdb049c4f6c4683979be890e2c6cc2cec660"
+    },
+    {
+      "hook": "model-drift-rollback",
+      "kpi": "model.psi.p95",
+      "threshold": 0.2,
+      "window": "24h",
+      "action": "rollback_model",
+      "owner": "ml-ops",
+      "rollback": true,
+      "evidence": {
+        "traces": "inference.serving",
+        "audit": "ml/monitoring/psi.json"
+      },
+      "hash": "58011806d0d2f62ba39e7004a245f054fcc3e415f31f73be638485b89fa04440"
+    }
+  ]
+}

--- a/ops/reports/repo_audit.json
+++ b/ops/reports/repo_audit.json
@@ -1,0 +1,42 @@
+[
+  {
+    "command": "make watchers.dry",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/reports/watchers_dry.json"
+    ],
+    "recorded_at": "2025-09-27T02:26:03.336424+00:00"
+  },
+  {
+    "command": "make hooks.dry",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/reports/hooks_dry.json"
+    ],
+    "recorded_at": "2025-09-27T02:26:06.817114+00:00"
+  },
+  {
+    "command": "make watchers.dry",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/reports/watchers_dry.json"
+    ],
+    "recorded_at": "2025-09-27T02:26:10.076174+00:00"
+  },
+  {
+    "command": "make hooks.dry",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/reports/hooks_dry.json"
+    ],
+    "recorded_at": "2025-09-27T02:26:11.690009+00:00"
+  },
+  {
+    "command": "make evidence.publish",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/evidence/evidence.json"
+    ],
+    "recorded_at": "2025-09-27T02:26:13.291409+00:00"
+  }
+]

--- a/ops/reports/watchers_dry.json
+++ b/ops/reports/watchers_dry.json
@@ -1,0 +1,167 @@
+{
+  "generated_at": "2025-09-27T02:26:09.308120+00:00",
+  "source": "/workspace/trendmarket/ops/watchers/default_watchers.json",
+  "total_watchers": 16,
+  "watchers": [
+    {
+      "id": "api_breaking_change_watch",
+      "owner": "platform-sre",
+      "kpi": "api.contract.compatibility",
+      "threshold": 0,
+      "window": "5m",
+      "action": "block_release",
+      "description": "Detecta alterações incompatíveis de contrato nas APIs públicas",
+      "hash": "97fe7fab090601a1004035356caea0d24c53194010abd8b26608f2d138ae124d"
+    },
+    {
+      "id": "schema_registry_drift_watch",
+      "owner": "data-governance",
+      "kpi": "data.schema.drift",
+      "threshold": 0,
+      "window": "5m",
+      "action": "rollback_contract",
+      "description": "Monitora divergências de esquema registradas e validadas",
+      "hash": "7fb1e3d1b3fc8673070169cf0e0a06d7e470aec7bbf70fbba2000c6e227a93c5"
+    },
+    {
+      "id": "data_contract_break_watch",
+      "owner": "data-governance",
+      "kpi": "data.contract.breach",
+      "threshold": 0,
+      "window": "5m",
+      "action": "rollback_contract",
+      "description": "Alerta para violações de contratos A106/A87/A89",
+      "hash": "fdd17d3d5b8d8468cdbe66bec201d799e778ddb6c48182b459d26a6a6a8a8709"
+    },
+    {
+      "id": "dbt_test_failure_watch",
+      "owner": "analytics-engineering",
+      "kpi": "data.dbt.tests_failed",
+      "threshold": 0,
+      "window": "5m",
+      "action": "block_release",
+      "description": "Gatilha quando testes dbt críticos falham",
+      "hash": "22f4e2562f5b4b5876fd1af51d17a280857664a2b6966319daf7396b489603dd"
+    },
+    {
+      "id": "cdc_lag_watch",
+      "owner": "data-platform",
+      "kpi": "data.cdc.lag.p95",
+      "threshold": "120s",
+      "window": "5m",
+      "action": "degrade_to_hot_table",
+      "description": "Monitora lag de CDC p95 com orçamento de 120s",
+      "hash": "2999a797685b7571c9b6c785c83e123d524562c629c35c563fe01ce185d81173"
+    },
+    {
+      "id": "slo_budget_breach_watch",
+      "owner": "sre",
+      "kpi": "decision.slo.error_budget",
+      "threshold": 1.0,
+      "window": "30m",
+      "action": "trigger_degrade_route",
+      "description": "Observa burn rate do orçamento de erro das decisões",
+      "hash": "abb44d8c21089d85b07ca9fc5db93b2d871fe6dc872aa4dd4d50b3f95952aafe"
+    },
+    {
+      "id": "model_drift_watch",
+      "owner": "ml-ops",
+      "kpi": "model.drift.psi",
+      "threshold": 0.2,
+      "window": "24h",
+      "action": "rollback_model",
+      "description": "Aciona rollback se PSI/KS ultrapassar limites",
+      "hash": "28ba763cf1f501eb3fb131f8e4a30359fbe5eeadcf2f997d63e5849094e498db"
+    },
+    {
+      "id": "metrics_decision_hook_gap_watch",
+      "owner": "sre",
+      "kpi": "decision.hook.gap",
+      "threshold": 0,
+      "window": "15m",
+      "action": "escalate_to_owner",
+      "description": "Monitora lacunas entre métricas e hooks acionados",
+      "hash": "3bd7ae2537c70c12947073dd3d4fa452f8c81b0ca2720cdbf16eaa5e0ee0ca04"
+    },
+    {
+      "id": "formal_verification_gate_watch",
+      "owner": "security-architecture",
+      "kpi": "security.formal_verification.status",
+      "threshold": 1,
+      "window": "24h",
+      "action": "freeze_release",
+      "description": "Garante que verificações formais foram executadas",
+      "hash": "c93727a5617b7e70d5cdfb2ab6e971ba23ff8efde62dc75070471b6a9363c8f2"
+    },
+    {
+      "id": "web_cwv_regression_watch",
+      "owner": "frontend-platform",
+      "kpi": "web.cwv.inp.p75",
+      "threshold": "200ms",
+      "window": "24h",
+      "action": "rollback_frontend",
+      "description": "Sinaliza regressões em INP/LCP das experiências web",
+      "hash": "045ae8449b207e061541f2386d8594a4fc8b587e3519448681020d9178dd58b8"
+    },
+    {
+      "id": "okr_risk_alignment_watch",
+      "owner": "finance-ops",
+      "kpi": "org.okr.risk_alignment",
+      "threshold": 0.95,
+      "window": "24h",
+      "action": "trigger_risk_review",
+      "description": "Escuta desalinhamentos de risco e objetivos chave",
+      "hash": "405fe93d0cfcee27b4ad82e6927a990269c8d82205e42e6268045badaa42cdd7"
+    },
+    {
+      "id": "dp_budget_breach_watch",
+      "owner": "privacy-office",
+      "kpi": "privacy.dp.budget",
+      "threshold": 1.5,
+      "window": "1h",
+      "action": "freeze_processing",
+      "description": "Sinaliza excedentes no orçamento de privacidade",
+      "hash": "fdaba2653cd9ccd28e76a0415a1c43030f2d7b4c95d531b3ae89fbe45a45ee2a"
+    },
+    {
+      "id": "runtime_eol_watch",
+      "owner": "platform-ml",
+      "kpi": "ml.runtime.support.status",
+      "threshold": "30d",
+      "window": "24h",
+      "action": "plan_migration",
+      "description": "Monitora runtimes em fim de vida com risco de suporte",
+      "hash": "396ec0b1a8fba3bd55d6a96bb8627efcaea219ef71769d448b29a05eecee6ed1"
+    },
+    {
+      "id": "dep_vuln_watch",
+      "owner": "appsec",
+      "kpi": "security.dependency.vuln",
+      "threshold": 0,
+      "window": "1h",
+      "action": "block_release",
+      "description": "Analisa SBOM por vulnerabilidades ativas",
+      "hash": "9fb0729ea8510d30fab708c93737a0439faea6052f287e7a268adfd3b2c04ff5"
+    },
+    {
+      "id": "oracle_divergence_watch",
+      "owner": "treasury",
+      "kpi": "market.oracle.delta_bps",
+      "threshold": 10,
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "description": "Monitora divergência de preço dos oráculos",
+      "hash": "68cd9b5402746639f1473cfb7a10c4ef70e8e1483dcbb505c8978897617631f8"
+    },
+    {
+      "id": "fx_delta_benchmark_watch",
+      "owner": "treasury",
+      "kpi": "market.fx.delta_bps",
+      "threshold": 5,
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "description": "Garante paridade com benchmarks de FX",
+      "hash": "469265d4d6436386d3910107736f9f33db2ef63027c083dd5ea69ca30abd41f3"
+    }
+  ]
+}

--- a/ops/scripts/Makefile
+++ b/ops/scripts/Makefile
@@ -1,0 +1,28 @@
+ROOT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+PYTHON := python3
+REPORTS_DIR := $(ROOT_DIR)/reports
+EVIDENCE_DIR := $(ROOT_DIR)/evidence
+WATCHERS_CONFIG := $(ROOT_DIR)/watchers/default_watchers.json
+HOOKS_CONFIG := $(ROOT_DIR)/hooks/a110_hooks.json
+WATCHERS_REPORT := $(REPORTS_DIR)/watchers_dry.json
+HOOKS_REPORT := $(REPORTS_DIR)/hooks_dry.json
+REPO_AUDIT_LOG := $(REPORTS_DIR)/repo_audit.json
+
+.PHONY: watchers.dry hooks.dry evidence.publish
+
+watchers.dry:
+	@mkdir -p $(REPORTS_DIR)
+	@$(PYTHON) $(ROOT_DIR)/scripts/watchers_dry_run.py --config $(WATCHERS_CONFIG) --output $(WATCHERS_REPORT)
+	@$(PYTHON) $(ROOT_DIR)/scripts/repo_audit.py --log $(REPO_AUDIT_LOG) --command "make watchers.dry" --status success --artifact $(WATCHERS_REPORT)
+
+hooks.dry:
+	@mkdir -p $(REPORTS_DIR)
+	@$(PYTHON) $(ROOT_DIR)/scripts/hooks_dry_run.py --config $(HOOKS_CONFIG) --output $(HOOKS_REPORT)
+	@$(PYTHON) $(ROOT_DIR)/scripts/repo_audit.py --log $(REPO_AUDIT_LOG) --command "make hooks.dry" --status success --artifact $(HOOKS_REPORT)
+
+# Aggregate watchers/hooks evidence while guaranteeing artefacts exist
+# before publishing, em linha com o gate A110.
+evidence.publish: watchers.dry hooks.dry
+	@mkdir -p $(EVIDENCE_DIR)
+	@$(PYTHON) $(ROOT_DIR)/scripts/evidence_publish.py --watchers $(WATCHERS_REPORT) --hooks $(HOOKS_REPORT) --output $(EVIDENCE_DIR)/evidence.json
+	@$(PYTHON) $(ROOT_DIR)/scripts/repo_audit.py --log $(REPO_AUDIT_LOG) --command "make evidence.publish" --status success --artifact $(EVIDENCE_DIR)/evidence.json

--- a/ops/scripts/evidence_publish.py
+++ b/ops/scripts/evidence_publish.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Aggregate dry-run artefacts into an evidence bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+
+def _load_json(path: pathlib.Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Required artefact not found: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid JSON at {path}: {exc}") from exc
+
+
+def _digest(content: Dict[str, Any]) -> str:
+    encoded = json.dumps(content, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def aggregate(watchers_path: pathlib.Path, hooks_path: pathlib.Path) -> Dict[str, Any]:
+    watchers = _load_json(watchers_path)
+    hooks = _load_json(hooks_path)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "watchers_artifact": str(watchers_path),
+        "hooks_artifact": str(hooks_path),
+        "watchers_digest": _digest(watchers),
+        "hooks_digest": _digest(hooks),
+        "watchers_count": watchers.get("total_watchers", 0),
+        "hooks_count": hooks.get("total_hooks", 0),
+        "evidence": {
+            "watchers": watchers.get("watchers", []),
+            "hooks": hooks.get("hooks", []),
+        },
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--watchers", required=True, type=pathlib.Path)
+    parser.add_argument("--hooks", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+
+    bundle = aggregate(args.watchers, args.hooks)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(bundle, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ops/scripts/hooks_dry_run.py
+++ b/ops/scripts/hooks_dry_run.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Validate hook specifications for A110 dry-runs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+REQUIRED_FIELDS = {"hook", "kpi", "threshold", "window", "action", "owner", "rollback"}
+
+
+def _load_hooks(path: pathlib.Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Hook configuration not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    hooks = data.get("hooks") if isinstance(data, dict) else None
+    if not isinstance(hooks, list):
+        raise ValueError("Hook configuration must contain a 'hooks' list")
+    return hooks
+
+
+def _normalize(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.strip()
+    return value
+
+
+def _validate_hook(hook: Dict[str, Any]) -> Dict[str, Any]:
+    missing = REQUIRED_FIELDS - hook.keys()
+    if missing:
+        raise ValueError(f"Hook '{hook.get('hook')}' missing fields: {sorted(missing)}")
+    normalized = {key: _normalize(hook[key]) for key in sorted(REQUIRED_FIELDS)}
+    encoded = json.dumps(normalized, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    return {
+        "hook": normalized["hook"],
+        "kpi": normalized["kpi"],
+        "threshold": normalized["threshold"],
+        "window": normalized["window"],
+        "action": normalized["action"],
+        "owner": normalized["owner"],
+        "rollback": bool(normalized["rollback"]),
+        "evidence": hook.get("evidence", {}),
+        "hash": digest,
+    }
+
+
+def generate_report(config: pathlib.Path) -> Dict[str, Any]:
+    hooks = _load_hooks(config)
+    validated = [_validate_hook(h) for h in hooks]
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": str(config),
+        "total_hooks": len(validated),
+        "hooks": validated,
+    }
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+
+    report = generate_report(args.config)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ops/scripts/repo_audit.py
+++ b/ops/scripts/repo_audit.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Append command executions to the repository audit log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+from typing import List
+
+
+def load_entries(path: pathlib.Path) -> List[dict]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid audit log at {path}: {exc}") from exc
+    if not isinstance(data, list):
+        raise RuntimeError(f"Audit log must contain a list, found {type(data).__name__}")
+    return data
+
+
+def append_entry(path: pathlib.Path, command: str, status: str, artifacts: List[str]) -> None:
+    entries = load_entries(path)
+    entries.append(
+        {
+            "command": command,
+            "status": status,
+            "artifacts": artifacts,
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", required=True, type=pathlib.Path)
+    parser.add_argument("--command", required=True)
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--artifact", action="append", default=[])
+    args = parser.parse_args(argv)
+
+    append_entry(args.log, args.command, args.status, args.artifact)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ops/scripts/watchers_dry_run.py
+++ b/ops/scripts/watchers_dry_run.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Validate watcher specifications and emit a dry-run report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+REQUIRED_FIELDS = {"id", "owner", "kpi", "threshold", "window", "action"}
+
+
+def _load_watchers(path: pathlib.Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Watcher configuration not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    watchers = data.get("watchers") if isinstance(data, dict) else None
+    if not isinstance(watchers, list):
+        raise ValueError("Watcher configuration must contain a 'watchers' list")
+    return watchers
+
+
+def _normalize_field(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.strip()
+    return value
+
+
+def _validate_watcher(watcher: Dict[str, Any]) -> Dict[str, Any]:
+    missing = REQUIRED_FIELDS - watcher.keys()
+    if missing:
+        raise ValueError(f"Watcher '{watcher.get('id')}' missing fields: {sorted(missing)}")
+    normalized = {key: _normalize_field(watcher[key]) for key in sorted(REQUIRED_FIELDS)}
+    encoded = json.dumps(normalized, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    return {
+        "id": normalized["id"],
+        "owner": normalized["owner"],
+        "kpi": normalized["kpi"],
+        "threshold": normalized["threshold"],
+        "window": normalized["window"],
+        "action": normalized["action"],
+        "description": watcher.get("description", ""),
+        "hash": digest,
+    }
+
+
+def generate_report(config: pathlib.Path) -> Dict[str, Any]:
+    watchers = _load_watchers(config)
+    validated = [_validate_watcher(w) for w in watchers]
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": str(config),
+        "total_watchers": len(validated),
+        "watchers": validated,
+    }
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args(argv)
+
+    report = generate_report(args.config)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ops/tests/k6_smoke_test.js
+++ b/ops/tests/k6_smoke_test.js
@@ -1,0 +1,64 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+
+export const options = {
+  vus: Number(__ENV.K6_VUS || 5),
+  duration: __ENV.K6_DURATION || '30s',
+  thresholds: {
+    http_req_duration: ['p(95)<800', 'p(99)<1200'],
+    checks: ['rate>0.99'],
+  },
+  summaryTrendStats: ['min', 'avg', 'med', 'p(90)', 'p(95)', 'p(99)'],
+};
+
+const baseUrl = __ENV.K6_BASE_URL || 'http://localhost:8080/healthz';
+const quoteEndpoint = __ENV.K6_QUOTE_ENDPOINT || '/pricing/quote';
+const latency = new Trend('decision_latency', true);
+
+function buildQuotePayload() {
+  return {
+    app_id: 'smoke-app-001',
+    applicant: {
+      document: '00000000191',
+      income: 7200,
+      score: 712,
+    },
+    product: {
+      code: 'PX-001',
+      amount: 5000,
+      tenor_months: 12,
+    },
+    channel: 'ops-smoke-k6',
+  };
+}
+
+function requestQuote() {
+  const url = `${baseUrl.replace(/\/$/, '')}${quoteEndpoint}`;
+  const payload = JSON.stringify(buildQuotePayload());
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Feature-Flag': __ENV.K6_FEATURE_FLAG || 'ops-smoke',
+    },
+    timeout: __ENV.K6_TIMEOUT || '5s',
+  };
+
+  const response = http.post(url, payload, params);
+  latency.add(response.timings.duration);
+
+  const ok = check(response, {
+    'status is 2xx': (r) => r.status >= 200 && r.status < 300,
+    'has price payload': (r) => !!r.json('price.apr'),
+    'latency under p95 budget': (r) => r.timings.duration <= Number(__ENV.K6_LATENCY_BUDGET_MS || 800),
+  });
+
+  if (!ok) {
+    console.error(`Quote smoke failure: status=${response.status} body=${response.body}`);
+  }
+}
+
+export default function smoke() {
+  requestQuote();
+  sleep(Number(__ENV.K6_SLEEP_SECONDS || 1));
+}

--- a/ops/watchers/default_watchers.json
+++ b/ops/watchers/default_watchers.json
@@ -1,0 +1,164 @@
+{
+  "watchers": [
+    {
+      "id": "api_breaking_change_watch",
+      "domain": "FE",
+      "owner": "platform-sre",
+      "description": "Detecta alterações incompatíveis de contrato nas APIs públicas",
+      "kpi": "api.contract.compatibility",
+      "threshold": 0,
+      "window": "5m",
+      "action": "block_release"
+    },
+    {
+      "id": "schema_registry_drift_watch",
+      "domain": "DATA",
+      "owner": "data-governance",
+      "description": "Monitora divergências de esquema registradas e validadas",
+      "kpi": "data.schema.drift",
+      "threshold": 0,
+      "window": "5m",
+      "action": "rollback_contract"
+    },
+    {
+      "id": "data_contract_break_watch",
+      "domain": "DATA",
+      "owner": "data-governance",
+      "description": "Alerta para violações de contratos A106/A87/A89",
+      "kpi": "data.contract.breach",
+      "threshold": 0,
+      "window": "5m",
+      "action": "rollback_contract"
+    },
+    {
+      "id": "dbt_test_failure_watch",
+      "domain": "DATA",
+      "owner": "analytics-engineering",
+      "description": "Gatilha quando testes dbt críticos falham",
+      "kpi": "data.dbt.tests_failed",
+      "threshold": 0,
+      "window": "5m",
+      "action": "block_release"
+    },
+    {
+      "id": "cdc_lag_watch",
+      "domain": "DATA",
+      "owner": "data-platform",
+      "description": "Monitora lag de CDC p95 com orçamento de 120s",
+      "kpi": "data.cdc.lag.p95",
+      "threshold": "120s",
+      "window": "5m",
+      "action": "degrade_to_hot_table"
+    },
+    {
+      "id": "slo_budget_breach_watch",
+      "domain": "DEC",
+      "owner": "sre",
+      "description": "Observa burn rate do orçamento de erro das decisões",
+      "kpi": "decision.slo.error_budget",
+      "threshold": 1.0,
+      "window": "30m",
+      "action": "trigger_degrade_route"
+    },
+    {
+      "id": "model_drift_watch",
+      "domain": "ML",
+      "owner": "ml-ops",
+      "description": "Aciona rollback se PSI/KS ultrapassar limites",
+      "kpi": "model.drift.psi",
+      "threshold": 0.2,
+      "window": "24h",
+      "action": "rollback_model"
+    },
+    {
+      "id": "metrics_decision_hook_gap_watch",
+      "domain": "DEC",
+      "owner": "sre",
+      "description": "Monitora lacunas entre métricas e hooks acionados",
+      "kpi": "decision.hook.gap",
+      "threshold": 0,
+      "window": "15m",
+      "action": "escalate_to_owner"
+    },
+    {
+      "id": "formal_verification_gate_watch",
+      "domain": "SEC",
+      "owner": "security-architecture",
+      "description": "Garante que verificações formais foram executadas",
+      "kpi": "security.formal_verification.status",
+      "threshold": 1,
+      "window": "24h",
+      "action": "freeze_release"
+    },
+    {
+      "id": "web_cwv_regression_watch",
+      "domain": "FE",
+      "owner": "frontend-platform",
+      "description": "Sinaliza regressões em INP/LCP das experiências web",
+      "kpi": "web.cwv.inp.p75",
+      "threshold": "200ms",
+      "window": "24h",
+      "action": "rollback_frontend"
+    },
+    {
+      "id": "okr_risk_alignment_watch",
+      "domain": "SEC",
+      "owner": "finance-ops",
+      "description": "Escuta desalinhamentos de risco e objetivos chave",
+      "kpi": "org.okr.risk_alignment",
+      "threshold": 0.95,
+      "window": "24h",
+      "action": "trigger_risk_review"
+    },
+    {
+      "id": "dp_budget_breach_watch",
+      "domain": "PRIV",
+      "owner": "privacy-office",
+      "description": "Sinaliza excedentes no orçamento de privacidade",
+      "kpi": "privacy.dp.budget",
+      "threshold": 1.5,
+      "window": "1h",
+      "action": "freeze_processing"
+    },
+    {
+      "id": "runtime_eol_watch",
+      "domain": "ML",
+      "owner": "platform-ml",
+      "description": "Monitora runtimes em fim de vida com risco de suporte",
+      "kpi": "ml.runtime.support.status",
+      "threshold": "30d",
+      "window": "24h",
+      "action": "plan_migration"
+    },
+    {
+      "id": "dep_vuln_watch",
+      "domain": "SEC",
+      "owner": "appsec",
+      "description": "Analisa SBOM por vulnerabilidades ativas",
+      "kpi": "security.dependency.vuln",
+      "threshold": 0,
+      "window": "1h",
+      "action": "block_release"
+    },
+    {
+      "id": "oracle_divergence_watch",
+      "domain": "PM",
+      "owner": "treasury",
+      "description": "Monitora divergência de preço dos oráculos",
+      "kpi": "market.oracle.delta_bps",
+      "threshold": 10,
+      "window": "5m",
+      "action": "switch_to_twap_failover"
+    },
+    {
+      "id": "fx_delta_benchmark_watch",
+      "domain": "PM",
+      "owner": "treasury",
+      "description": "Garante paridade com benchmarks de FX",
+      "kpi": "market.fx.delta_bps",
+      "threshold": 5,
+      "window": "5m",
+      "action": "switch_to_twap_failover"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a parameterizable k6 smoke test that exercises the pricing quote endpoint and validates latency budgets
- codify watcher and hook inventories plus Python utilities to run dry-runs and publish evidence with repo audit logging
- check in generated dry-run artefacts (watchers, hooks, evidence bundle, audit trail) for reproducible ops reporting

## Testing
- make -f ops/scripts/Makefile watchers.dry
- make -f ops/scripts/Makefile hooks.dry
- make -f ops/scripts/Makefile evidence.publish


------
https://chatgpt.com/codex/tasks/task_e_68d74a4f6c048330a8cca50015f91baf