### PR TITLE
Add watcher governance and A110 hook validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: watchers.dry hooks.dry gate.a110
+
+watchers.dry:
+	./scripts/watchers_dry.py
+
+hooks.dry:
+	./scripts/hooks_dry.py
+
+gate.a110: watchers.dry hooks.dry
+	./scripts/a110_run_invariants.sh

--- a/README.md
+++ b/README.md
@@ -18,3 +18,37 @@ The full list of components is available in the [manifest](manifest.yaml)
 ### Rules for Component Inclusion
 
 - Include all extensions at [Alpha stability](https://github.com/open-telemetry/opentelemetry-collector#alpha) or higher and pipeline components that have at least 1 signal at [Alpha stability](https://github.com/open-telemetry/opentelemetry-collector#alpha) or higher.
+
+## Operational Governance: Watchers & Gate A110
+
+This repository now ships with first-class governance artifacts to guarantee that the mandatory watchers and A110 hooks defined in `agents.md` stay green across environments.
+
+### Inventory
+
+- **Watchers:** Domain-specific configurations live under [`ops/watchers/`](ops/watchers). Each file describes the KPI, window, action, owner, and rollback policy for the mandatory watches covering DEC, PM, ML, DATA, PLAT, FE, SEC/PRIV and INT domains.
+- **Gate A110 hooks:** The consolidated mapping is defined in [`ops/hooks/a110.yml`](ops/hooks/a110.yml). Every watcher is wired to the correct A110 hook, including the required thresholds and evidence links.
+
+### Local enablement
+
+1. Ensure Python 3.11+ is available (the same interpreter used for the existing automation).
+2. Run the dry-run validators before coding:
+
+   ```bash
+   make watchers.dry
+   make hooks.dry
+   ```
+
+   Both commands surface missing watchers, invalid parameters, or mismatched hook bindings with actionable error messages.
+3. For a full Gate A110 rehearsal (watchers + hooks + Rust invariants), execute:
+
+   ```bash
+   make gate.a110
+   ```
+
+   The script aborts immediately if any watcher or hook validation fails, ensuring issues are detected before the Rust suites start.
+
+### CI guidance
+
+- The canonical A110 pipeline (`scripts/a110_run_invariants.sh`) now invokes `watchers.dry` and `hooks.dry` automatically. Any gap in coverage causes the gate to fail with a non-zero exit code, guaranteeing enforcement during pull requests.
+- Integrate the Make targets above (or call the scripts directly) in bespoke CI systems to keep behaviour consistent between local, nightly, and production promotion flows.
+- When adding a new watcher or hook, commit the YAML changes together with updated documentation so that the dry-run validators remain the single source of truth.

--- a/ops/hooks/a110.yml
+++ b/ops/hooks/a110.yml
@@ -1,0 +1,137 @@
+[
+  {
+    "hook": "dec-latency-degrade",
+    "domain": "DEC",
+    "watchers": [
+      "metrics_decision_hook_gap_watch",
+      "model_drift_watch",
+      "slo_budget_breach_watch"
+    ],
+    "kpi": "dec.latency.p95",
+    "threshold": "800ms",
+    "window": "5m",
+    "action": "degrade_route",
+    "owner": "dec-duty@trendmarket",
+    "evidence": ["traces:decision.core"],
+    "rollback": "yes"
+  },
+  {
+    "hook": "pm-oracle-staleness",
+    "domain": "PM",
+    "watchers": [
+      "oracle_divergence_watch",
+      "fx_delta_benchmark_watch",
+      "auction_invariant_breach_watch",
+      "slo_budget_breach_watch"
+    ],
+    "kpi": "oracle.staleness_ms",
+    "threshold": "30000",
+    "window": "5m",
+    "action": "switch_to_twap_failover",
+    "owner": "pm-ops@trendmarket",
+    "evidence": ["audit:oracles/weekly"],
+    "rollback": "yes"
+  },
+  {
+    "hook": "ml-model-rollback",
+    "domain": "ML",
+    "watchers": [
+      "model_drift_watch",
+      "ab_srm_watch",
+      "runtime_eol_watch",
+      "image_vuln_regression_watch"
+    ],
+    "kpi": "ml.model.psi",
+    "threshold": "0.2",
+    "window": "24h",
+    "action": "rollback_model",
+    "owner": "ml-ops@trendmarket",
+    "evidence": ["metrics:ml.psi", "experiments:srm"],
+    "rollback": "yes"
+  },
+  {
+    "hook": "data-contract-rollback",
+    "domain": "DATA",
+    "watchers": [
+      "cdc_lag_watch",
+      "schema_registry_drift_watch",
+      "dbt_test_failure_watch",
+      "doc_coverage_watch",
+      "data_contract_break_watch"
+    ],
+    "kpi": "data.contracts.status",
+    "threshold": "breach",
+    "window": "15m",
+    "action": "rollback_and_timebox",
+    "owner": "data-quality@trendmarket",
+    "evidence": ["contracts:a106", "contracts:a87"],
+    "rollback": "yes"
+  },
+  {
+    "hook": "platform-sampling-guard",
+    "domain": "PLAT",
+    "watchers": [
+      "tracing_sampling_watch",
+      "alert_storm_watch",
+      "slo_budget_breach_watch",
+      "policy_violation_watch",
+      "okr_risk_alignment_watch"
+    ],
+    "kpi": "observability.traces.sampling_rate",
+    "threshold": "<0.98",
+    "window": "15m",
+    "action": "block_release",
+    "owner": "sre@trendmarket",
+    "evidence": ["traces:otel", "alerts:platform"],
+    "rollback": "yes"
+  },
+  {
+    "hook": "fe-cwv-regression",
+    "domain": "FE",
+    "watchers": [
+      "web_cwv_regression_watch",
+      "api_breaking_change_watch"
+    ],
+    "kpi": "web.inp.p75",
+    "threshold": "200ms",
+    "window": "24h",
+    "action": "rollback_fe_release",
+    "owner": "fe-core@trendmarket",
+    "evidence": ["lighthouse:cwv", "sdk:contract"],
+    "rollback": "yes"
+  },
+  {
+    "hook": "sec-privacy-freeze",
+    "domain": "SEC/PRIV",
+    "watchers": [
+      "dep_vuln_watch",
+      "image_vuln_regression_watch",
+      "idp_keys_rotation_watch",
+      "dp_budget_breach_watch",
+      "formal_verification_gate_watch"
+    ],
+    "kpi": "privacy.dp_budget_ratio",
+    "threshold": "1.5",
+    "window": "1h",
+    "action": "freeze_release",
+    "owner": "sec-priv@trendmarket",
+    "evidence": ["sbom:latest", "audit:privacy"],
+    "rollback": "yes"
+  },
+  {
+    "hook": "integration-contract-guard",
+    "domain": "INT",
+    "watchers": [
+      "api_breaking_change_watch",
+      "cache_ttl_misuse_watch",
+      "cls_payin_cutoff_watch"
+    ],
+    "kpi": "integration.contracts.fail_pct",
+    "threshold": ">0",
+    "window": "30m",
+    "action": "block_release",
+    "owner": "integration@trendmarket",
+    "evidence": ["tests:contract", "synthetics:cls"],
+    "rollback": "yes"
+  }
+]

--- a/ops/watchers/data.yml
+++ b/ops/watchers/data.yml
@@ -1,0 +1,50 @@
+{
+  "domain": "DATA",
+  "watchers": [
+    {
+      "name": "cdc_lag_watch",
+      "kpi": "cdc.lag.p95_seconds",
+      "threshold": ">=120",
+      "window": "15m",
+      "action": "degrade_to_hot_table",
+      "owner": "data-quality@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "schema_registry_drift_watch",
+      "kpi": "schema.registry.compatibility",
+      "threshold": "!=backward",
+      "window": "15m",
+      "action": "freeze_schema_migration",
+      "owner": "data-quality@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "dbt_test_failure_watch",
+      "kpi": "dbt.tests.failed",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "rollback_dbt_artifacts",
+      "owner": "data-quality@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "doc_coverage_watch",
+      "kpi": "data.contracts.documentation_coverage",
+      "threshold": "<0.95",
+      "window": "24h",
+      "action": "block_release",
+      "owner": "data-quality@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "data_contract_break_watch",
+      "kpi": "data.contracts.status",
+      "threshold": "breach",
+      "window": "15m",
+      "action": "rollback_contract_change",
+      "owner": "data-quality@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/ops/watchers/dec.yml
+++ b/ops/watchers/dec.yml
@@ -1,0 +1,32 @@
+{
+  "domain": "DEC",
+  "watchers": [
+    {
+      "name": "metrics_decision_hook_gap_watch",
+      "kpi": "dec.latency.hook_gap.p95",
+      "threshold": ">=200ms",
+      "window": "5m",
+      "action": "degrade_route",
+      "owner": "dec-duty@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "model_drift_watch",
+      "kpi": "ml.model.psi",
+      "threshold": ">0.2",
+      "window": "24h",
+      "action": "rollback_model",
+      "owner": "dec-duty@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "slo_budget_breach_watch",
+      "kpi": "dec.latency.burn_rate",
+      "threshold": ">1.0",
+      "window": "1h",
+      "action": "page_oncall",
+      "owner": "dec-duty@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/ops/watchers/fe.yml
+++ b/ops/watchers/fe.yml
@@ -1,0 +1,23 @@
+{
+  "domain": "FE",
+  "watchers": [
+    {
+      "name": "web_cwv_regression_watch",
+      "kpi": "web.inp.p75_ms",
+      "threshold": ">200",
+      "window": "24h",
+      "action": "rollback_fe_release",
+      "owner": "fe-core@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "api_breaking_change_watch",
+      "kpi": "sdk.contract.breaking_changes",
+      "threshold": ">0",
+      "window": "30m",
+      "action": "block_fe_release",
+      "owner": "fe-core@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/ops/watchers/int.yml
+++ b/ops/watchers/int.yml
@@ -1,0 +1,32 @@
+{
+  "domain": "INT",
+  "watchers": [
+    {
+      "name": "api_breaking_change_watch",
+      "kpi": "integration.contract.breaking_changes",
+      "threshold": ">0",
+      "window": "30m",
+      "action": "block_release",
+      "owner": "integration@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "cache_ttl_misuse_watch",
+      "kpi": "integration.cache.ttl_violation_rate",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "rollback_cache_config",
+      "owner": "integration@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "cls_payin_cutoff_watch",
+      "kpi": "integration.cls.payin_cutoff_miss",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "pause_cls_flows",
+      "owner": "integration@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/ops/watchers/ml.yml
+++ b/ops/watchers/ml.yml
@@ -1,0 +1,41 @@
+{
+  "domain": "ML",
+  "watchers": [
+    {
+      "name": "model_drift_watch",
+      "kpi": "ml.model.psi",
+      "threshold": ">0.2",
+      "window": "24h",
+      "action": "rollback_model",
+      "owner": "ml-ops@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "ab_srm_watch",
+      "kpi": "experiments.srm.p_value",
+      "threshold": "<=0.05",
+      "window": "1h",
+      "action": "pause_experiment",
+      "owner": "ml-ops@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "runtime_eol_watch",
+      "kpi": "serving.runtime.support_days",
+      "threshold": "<30",
+      "window": "24h",
+      "action": "schedule_runtime_upgrade",
+      "owner": "ml-ops@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "image_vuln_regression_watch",
+      "kpi": "serving.image.cvss_max",
+      "threshold": ">=7.0",
+      "window": "24h",
+      "action": "rollback_model_image",
+      "owner": "ml-ops@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/ops/watchers/plat.yml
+++ b/ops/watchers/plat.yml
@@ -1,0 +1,50 @@
+{
+  "domain": "PLAT",
+  "watchers": [
+    {
+      "name": "tracing_sampling_watch",
+      "kpi": "observability.traces.sampling_rate",
+      "threshold": "<0.98",
+      "window": "15m",
+      "action": "restore_sampling_defaults",
+      "owner": "sre@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "alert_storm_watch",
+      "kpi": "observability.alerts.per_minute",
+      "threshold": ">50",
+      "window": "30m",
+      "action": "throttle_alerts_and_page",
+      "owner": "sre@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "slo_budget_breach_watch",
+      "kpi": "platform.slo.burn_rate",
+      "threshold": ">1.0",
+      "window": "1h",
+      "action": "block_release",
+      "owner": "sre@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "policy_violation_watch",
+      "kpi": "platform.policy.violations",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "freeze_pipeline",
+      "owner": "sre@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "okr_risk_alignment_watch",
+      "kpi": "governance.okr.risk_alignment_score",
+      "threshold": "<0.9",
+      "window": "24h",
+      "action": "trigger_executive_review",
+      "owner": "sre@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/ops/watchers/pm.yml
+++ b/ops/watchers/pm.yml
@@ -1,0 +1,41 @@
+{
+  "domain": "PM",
+  "watchers": [
+    {
+      "name": "oracle_divergence_watch",
+      "kpi": "oracle.price.delta_bps",
+      "threshold": ">=10",
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "owner": "pm-ops@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "fx_delta_benchmark_watch",
+      "kpi": "fx.delta_vs_benchmark_bps",
+      "threshold": ">=15",
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "owner": "pm-ops@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "auction_invariant_breach_watch",
+      "kpi": "auction.no_arb_score",
+      "threshold": "<0",
+      "window": "15m",
+      "action": "pause_auction_stream",
+      "owner": "pm-ops@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "slo_budget_breach_watch",
+      "kpi": "pm.routing.latency.burn_rate",
+      "threshold": ">1.0",
+      "window": "1h",
+      "action": "escalate_oncall",
+      "owner": "pm-ops@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/ops/watchers/sec_priv.yml
+++ b/ops/watchers/sec_priv.yml
@@ -1,0 +1,50 @@
+{
+  "domain": "SEC/PRIV",
+  "watchers": [
+    {
+      "name": "dep_vuln_watch",
+      "kpi": "security.dependencies.cvss_max",
+      "threshold": ">=7.0",
+      "window": "24h",
+      "action": "block_release",
+      "owner": "sec-priv@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "image_vuln_regression_watch",
+      "kpi": "security.images.cvss_max",
+      "threshold": ">=7.0",
+      "window": "24h",
+      "action": "rollback_image",
+      "owner": "sec-priv@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "idp_keys_rotation_watch",
+      "kpi": "security.idp.keys_age_days",
+      "threshold": ">=75",
+      "window": "24h",
+      "action": "rotate_idp_keys",
+      "owner": "sec-priv@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "dp_budget_breach_watch",
+      "kpi": "privacy.dp_budget_ratio",
+      "threshold": ">1.5",
+      "window": "1h",
+      "action": "freeze_release",
+      "owner": "sec-priv@trendmarket",
+      "rollback": "yes"
+    },
+    {
+      "name": "formal_verification_gate_watch",
+      "kpi": "security.formal_verification_status",
+      "threshold": "failed",
+      "window": "24h",
+      "action": "block_release",
+      "owner": "sec-priv@trendmarket",
+      "rollback": "yes"
+    }
+  ]
+}

--- a/scripts/a110_run_invariants.sh
+++ b/scripts/a110_run_invariants.sh
@@ -180,6 +180,28 @@ fi
 
 set_proptest_defaults
 
+log_info 'Running watchers dry-run validation.'
+if ./scripts/watchers_dry.py; then
+  log_info 'watchers.dry completed successfully.'
+else
+  EXIT_NEXTEST=1
+  EXIT_CARGO=1
+  log_error 'watchers.dry failed; aborting Gate A110.'
+  finalize
+  exit 1
+fi
+
+log_info 'Running hooks dry-run validation.'
+if ./scripts/hooks_dry.py; then
+  log_info 'hooks.dry completed successfully.'
+else
+  EXIT_NEXTEST=1
+  EXIT_CARGO=1
+  log_error 'hooks.dry failed; aborting Gate A110.'
+  finalize
+  exit 1
+fi
+
 log_info 'Running cargo nextest invariants.'
 if cargo nextest run --all --all-features --no-fail-fast --junit-output artifacts/junit.xml; then
   EXIT_NEXTEST=0

--- a/scripts/hooks_dry.py
+++ b/scripts/hooks_dry.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Dry-run validator for A110 hook coverage."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Set, Tuple
+
+REQUIRED_HOOK_FIELDS = {
+    "hook",
+    "domain",
+    "watchers",
+    "kpi",
+    "threshold",
+    "window",
+    "action",
+    "owner",
+    "rollback",
+}
+VALID_ROLLBACK = {"yes", "no"}
+
+
+class WatcherValidationError(RuntimeError):
+    """Represents a validation error during watcher loading."""
+
+
+def _load_watchers_file(path: Path) -> Tuple[str, Set[str]]:
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise WatcherValidationError(f"{path}: invalid JSON/YAML payload: {exc}")
+
+    if not isinstance(payload, dict):
+        raise WatcherValidationError(f"{path}: expected a mapping with domain and watchers")
+
+    domain_raw = payload.get("domain")
+    domain = str(domain_raw).upper() if domain_raw else path.stem.upper()
+    watchers = payload.get("watchers")
+
+    if not isinstance(watchers, list) or not watchers:
+        raise WatcherValidationError(f"{path}: watchers must be a non-empty list")
+
+    names: Set[str] = set()
+    for idx, watcher in enumerate(watchers):
+        if not isinstance(watcher, dict):
+            raise WatcherValidationError(
+                f"{path}: watcher #{idx + 1} must be a mapping with required fields"
+            )
+        name = str(watcher.get("name", "")).strip()
+        if not name:
+            raise WatcherValidationError(f"{path}: watcher #{idx + 1} missing a valid name")
+        if name in names:
+            raise WatcherValidationError(
+                f"{path}: duplicated watcher entry '{name}' for domain '{domain}'"
+            )
+        names.add(name)
+
+    return domain, names
+
+
+def _load_watchers() -> Tuple[Dict[str, Set[str]], List[str]]:
+    watchers_dir = Path("ops/watchers")
+    if not watchers_dir.is_dir():
+        return {}, ["ops/watchers directory not found"]
+
+    errors: List[str] = []
+    domain_watchers: Dict[str, Set[str]] = {}
+
+    for path in sorted(watchers_dir.glob("*.yml")):
+        try:
+            domain, watchers = _load_watchers_file(path)
+        except WatcherValidationError as exc:
+            errors.append(str(exc))
+            continue
+
+        if domain in domain_watchers:
+            errors.append(f"duplicate watcher definition for domain '{domain}' in {path}")
+            continue
+
+        domain_watchers[domain] = watchers
+
+    return domain_watchers, errors
+
+
+def _summarize_hooks(domain_to_hook: Dict[str, Tuple[str, Set[str]]]) -> Iterable[str]:
+    for domain in sorted(domain_to_hook):
+        hook_name, watchers = domain_to_hook[domain]
+        watchers_list = ", ".join(sorted(watchers))
+        yield f"  - {domain} :: {hook_name} -> [{watchers_list}]"
+
+
+def main() -> int:
+    domain_watchers, watcher_errors = _load_watchers()
+    if watcher_errors:
+        print("[hooks.dry] unable to load watcher inventory:", file=sys.stderr)
+        for message in watcher_errors:
+            print(f"  - {message}", file=sys.stderr)
+        return 1
+
+    hooks_path = Path("ops/hooks/a110.yml")
+    if not hooks_path.is_file():
+        print("[hooks.dry] ops/hooks/a110.yml not found", file=sys.stderr)
+        return 1
+
+    try:
+        payload = json.loads(hooks_path.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"[hooks.dry] invalid JSON/YAML payload: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(payload, list) or not payload:
+        print("[hooks.dry] expected a non-empty list of hook mappings", file=sys.stderr)
+        return 1
+
+    errors: List[str] = []
+    domain_to_hook: Dict[str, Tuple[str, Set[str]]] = {}
+
+    for idx, entry in enumerate(payload):
+        if not isinstance(entry, dict):
+            errors.append(f"entry #{idx + 1} must be a mapping")
+            continue
+
+        missing = REQUIRED_HOOK_FIELDS - entry.keys()
+        if missing:
+            errors.append(
+                f"hook entry #{idx + 1} missing fields: {sorted(missing)}"
+            )
+            continue
+
+        hook_name = str(entry.get("hook", "")).strip()
+        domain = str(entry.get("domain", "")).upper()
+        watchers = entry.get("watchers")
+
+        if not hook_name:
+            errors.append(f"hook entry #{idx + 1} is missing a valid hook name")
+        if not domain:
+            errors.append(f"hook entry '{hook_name or idx + 1}' missing a domain identifier")
+
+        if not isinstance(watchers, list) or not watchers:
+            errors.append(f"hook '{hook_name or domain}' must declare at least one watcher")
+            continue
+
+        watcher_names: Set[str] = set()
+        for watcher in watchers:
+            if not isinstance(watcher, str) or not watcher.strip():
+                errors.append(
+                    f"hook '{hook_name or domain}' has an invalid watcher reference: {watcher!r}"
+                )
+                continue
+            watcher_names.add(watcher.strip())
+
+        rollback_value = str(entry.get("rollback", "")).lower()
+        if rollback_value not in VALID_ROLLBACK:
+            errors.append(
+                f"hook '{hook_name or domain}' has invalid rollback value '{entry.get('rollback')}'"
+            )
+
+        if domain in domain_to_hook:
+            errors.append(
+                f"duplicate hook definition for domain '{domain}' (hook '{hook_name}')"
+            )
+        else:
+            domain_to_hook[domain] = (hook_name, watcher_names)
+
+    watcher_domains = set(domain_watchers)
+    hook_domains = set(domain_to_hook)
+
+    missing_domains = watcher_domains - hook_domains
+    if missing_domains:
+        errors.append(
+            "hooks missing for domain(s): " + ", ".join(sorted(missing_domains))
+        )
+
+    extra_domains = hook_domains - watcher_domains
+    if extra_domains:
+        errors.append(
+            "hook(s) defined without watcher inventory: " + ", ".join(sorted(extra_domains))
+        )
+
+    for domain, watchers in domain_watchers.items():
+        hook_entry = domain_to_hook.get(domain)
+        if not hook_entry:
+            continue
+        hook_name, hook_watchers = hook_entry
+        missing = watchers - hook_watchers
+        if missing:
+            errors.append(
+                f"hook '{hook_name}' missing watcher(s) for domain '{domain}': "
+                + ", ".join(sorted(missing))
+            )
+        extra = hook_watchers - watchers
+        if extra:
+            errors.append(
+                f"hook '{hook_name}' references undefined watcher(s) for domain '{domain}': "
+                + ", ".join(sorted(extra))
+            )
+
+    if errors:
+        print("[hooks.dry] validation failed:", file=sys.stderr)
+        for message in errors:
+            print(f"  - {message}", file=sys.stderr)
+        return 1
+
+    print("[hooks.dry] hook coverage OK:")
+    for line in _summarize_hooks(domain_to_hook):
+        print(line)
+    print("[hooks.dry] all watchers are mapped to Gate A110 hooks.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/watchers_dry.py
+++ b/scripts/watchers_dry.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Dry-run validator for watcher coverage across domains."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, Set, Tuple
+
+EXPECTED_DOMAIN_WATCHERS: Dict[str, Set[str]] = {
+    "DEC": {
+        "metrics_decision_hook_gap_watch",
+        "model_drift_watch",
+        "slo_budget_breach_watch",
+    },
+    "PM": {
+        "oracle_divergence_watch",
+        "fx_delta_benchmark_watch",
+        "auction_invariant_breach_watch",
+        "slo_budget_breach_watch",
+    },
+    "ML": {
+        "model_drift_watch",
+        "ab_srm_watch",
+        "runtime_eol_watch",
+        "image_vuln_regression_watch",
+    },
+    "DATA": {
+        "cdc_lag_watch",
+        "schema_registry_drift_watch",
+        "dbt_test_failure_watch",
+        "doc_coverage_watch",
+        "data_contract_break_watch",
+    },
+    "PLAT": {
+        "tracing_sampling_watch",
+        "alert_storm_watch",
+        "slo_budget_breach_watch",
+        "policy_violation_watch",
+        "okr_risk_alignment_watch",
+    },
+    "FE": {
+        "web_cwv_regression_watch",
+        "api_breaking_change_watch",
+    },
+    "SEC/PRIV": {
+        "dep_vuln_watch",
+        "image_vuln_regression_watch",
+        "idp_keys_rotation_watch",
+        "dp_budget_breach_watch",
+        "formal_verification_gate_watch",
+    },
+    "INT": {
+        "api_breaking_change_watch",
+        "cache_ttl_misuse_watch",
+        "cls_payin_cutoff_watch",
+    },
+}
+
+MANDATORY_GLOBAL_WATCHERS: Set[str] = {
+    "api_breaking_change_watch",
+    "schema_registry_drift_watch",
+    "data_contract_break_watch",
+    "dbt_test_failure_watch",
+    "cdc_lag_watch",
+    "slo_budget_breach_watch",
+    "model_drift_watch",
+    "metrics_decision_hook_gap_watch",
+    "formal_verification_gate_watch",
+    "web_cwv_regression_watch",
+    "okr_risk_alignment_watch",
+    "dp_budget_breach_watch",
+    "runtime_eol_watch",
+    "dep_vuln_watch",
+    "oracle_divergence_watch",
+    "fx_delta_benchmark_watch",
+}
+
+REQUIRED_FIELDS = {"name", "kpi", "window", "action", "owner", "rollback"}
+VALID_ROLLBACK = {"yes", "no"}
+
+
+class WatcherValidationError(RuntimeError):
+    """Represents a validation error during watcher loading."""
+
+
+def _load_watchers_file(path: Path) -> Tuple[str, Set[str]]:
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise WatcherValidationError(f"{path}: invalid JSON/YAML payload: {exc}")
+
+    if not isinstance(payload, dict):
+        raise WatcherValidationError(f"{path}: expected a mapping with domain and watchers")
+
+    domain_raw = payload.get("domain")
+    domain = str(domain_raw).upper() if domain_raw else path.stem.upper()
+    watchers = payload.get("watchers")
+
+    if not isinstance(watchers, list) or not watchers:
+        raise WatcherValidationError(f"{path}: watchers must be a non-empty list")
+
+    seen: Set[str] = set()
+    for idx, watcher in enumerate(watchers):
+        if not isinstance(watcher, dict):
+            raise WatcherValidationError(
+                f"{path}: watcher #{idx + 1} must be a mapping with required fields"
+            )
+
+        missing = REQUIRED_FIELDS - watcher.keys()
+        if missing:
+            raise WatcherValidationError(
+                f"{path}: watcher '{watcher.get('name', '<unknown>')}' missing fields: {sorted(missing)}"
+            )
+
+        name = str(watcher.get("name")).strip()
+        if not name:
+            raise WatcherValidationError(f"{path}: watcher #{idx + 1} missing a valid name")
+
+        rollback_value = str(watcher.get("rollback")).lower()
+        if rollback_value not in VALID_ROLLBACK:
+            raise WatcherValidationError(
+                f"{path}: watcher '{name}' has invalid rollback value '{watcher.get('rollback')}'"
+            )
+
+        if name in seen:
+            raise WatcherValidationError(
+                f"{path}: duplicated watcher entry '{name}' for domain '{domain}'"
+            )
+
+        seen.add(name)
+
+    return domain, seen
+
+
+def _summarize_domain_counts(domain_watchers: Dict[str, Set[str]]) -> Iterable[str]:
+    for domain in sorted(domain_watchers):
+        yield f"  - {domain}: {len(domain_watchers[domain])} watcher(s)"
+
+
+def main() -> int:
+    watchers_dir = Path("ops/watchers")
+    if not watchers_dir.is_dir():
+        print("[watchers.dry] ops/watchers directory not found", file=sys.stderr)
+        return 1
+
+    errors = []
+    domain_watchers: Dict[str, Set[str]] = {}
+
+    for path in sorted(watchers_dir.glob("*.yml")):
+        try:
+            domain, watchers = _load_watchers_file(path)
+        except WatcherValidationError as exc:
+            errors.append(str(exc))
+            continue
+
+        if domain in domain_watchers:
+            errors.append(f"duplicate watcher definition for domain '{domain}' in {path}")
+            continue
+
+        domain_watchers[domain] = watchers
+
+    expected_domains = set(EXPECTED_DOMAIN_WATCHERS)
+
+    missing_domains = expected_domains - domain_watchers.keys()
+    if missing_domains:
+        errors.append(
+            "missing watcher definitions for domain(s): " + ", ".join(sorted(missing_domains))
+        )
+
+    extra_domains = domain_watchers.keys() - expected_domains
+    if extra_domains:
+        errors.append("unexpected watcher domains found: " + ", ".join(sorted(extra_domains)))
+
+    for domain, expected_watchers in EXPECTED_DOMAIN_WATCHERS.items():
+        actual = domain_watchers.get(domain, set())
+        missing = expected_watchers - actual
+        if missing:
+            errors.append(
+                f"domain '{domain}' missing required watcher(s): " + ", ".join(sorted(missing))
+            )
+
+    union_watchers: Set[str] = set()
+    for watchers in domain_watchers.values():
+        union_watchers.update(watchers)
+
+    missing_globals = MANDATORY_GLOBAL_WATCHERS - union_watchers
+    if missing_globals:
+        errors.append(
+            "mandatory watcher(s) absent from configuration: "
+            + ", ".join(sorted(missing_globals))
+        )
+
+    if errors:
+        print("[watchers.dry] validation failed:", file=sys.stderr)
+        for message in errors:
+            print(f"  - {message}", file=sys.stderr)
+        return 1
+
+    print("[watchers.dry] watcher coverage OK:")
+    for line in _summarize_domain_counts(domain_watchers):
+        print(line)
+    print(f"  - total unique watchers: {len(union_watchers)}")
+    print("[watchers.dry] all mandatory watchers are configured.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add watcher configuration files for DEC, PM, ML, DATA, PLAT, FE, SEC/PRIV, and INT with KPI, window, action, owner, and rollback metadata
- map every watcher to Gate A110 hooks and add Python dry-run validators invoked from the Makefile and gate script
- document how to run the new watchers and hook checks locally and in CI

## Testing
- make watchers.dry
- make hooks.dry

------
https://chatgpt.com/codex/tasks/task_e_68d7368489688330b65cc1042e5e2481