### PR TITLE
Add metadata to latency summary notebook artifact

### DIFF
--- a/docs/notebooks/artifacts/latency_summary.json
+++ b/docs/notebooks/artifacts/latency_summary.json
@@ -1,0 +1,14 @@
+{
+  "notebook": "docs/notebooks/working_backwards_experiments.ipynb",
+  "seed": 20240919,
+  "runs": 500,
+  "latency_ms": {
+    "mean": 319.958,
+    "median": 319.57,
+    "p75": 349.695,
+    "p90": 374.634,
+    "p95": 389.272,
+    "min": 201.79,
+    "max": 467.41
+  }
+}

--- a/docs/notebooks/working_backwards_experiments.ipynb
+++ b/docs/notebooks/working_backwards_experiments.ipynb
@@ -1,0 +1,147 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Working Backwards Experiments\n",
+        "\n",
+        "This notebook generates synthetic latency samples for exploration and exports summary metrics to `docs/notebooks/artifacts/latency_summary.json`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from __future__ import annotations\n",
+        "\n",
+        "from pathlib import Path\n",
+        "import json\n",
+        "import math\n",
+        "import random\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[309.04, 294.35, 282.19, 325.45, 323.86]"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "NOTEBOOK_PATH = Path(\"docs/notebooks/working_backwards_experiments.ipynb\")\n",
+        "ARTIFACT_PATH = Path(\"docs/notebooks/artifacts/latency_summary.json\")\n",
+        "SEED = 20240919\n",
+        "SAMPLE_SIZE = 500\n",
+        "\n",
+        "random.seed(SEED)\n",
+        "latency_samples = [max(0.0, round(random.gauss(320, 45), 2)) for _ in range(SAMPLE_SIZE)]\n",
+        "latency_samples[:5]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'notebook': 'docs/notebooks/working_backwards_experiments.ipynb', 'seed': 20240919, 'runs': 500, 'latency_ms': {'mean': 319.958, 'median': 319.57, 'p75': 349.695, 'p90': 374.634, 'p95': 389.272, 'min': 201.79, 'max': 467.41}}"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "sorted_samples = sorted(latency_samples)\n",
+        "\n",
+        "def percentile(sorted_data, p):\n",
+        "    if len(sorted_data) == 1:\n",
+        "        return float(sorted_data[0])\n",
+        "    if not 0 <= p <= 100:\n",
+        "        raise ValueError(\"percentile must be between 0 and 100\")\n",
+        "\n",
+        "    k = (len(sorted_data) - 1) * (p / 100)\n",
+        "    f = int(k)\n",
+        "    c = min(f + 1, len(sorted_data) - 1)\n",
+        "    if f == c:\n",
+        "        return float(sorted_data[f])\n",
+        "    remainder = k - f\n",
+        "    return float(sorted_data[f] + (sorted_data[c] - sorted_data[f]) * remainder)\n",
+        "\n",
+        "metrics = {\n",
+        "    \"notebook\": str(NOTEBOOK_PATH),\n",
+        "    \"seed\": SEED,\n",
+        "    \"runs\": len(latency_samples),\n",
+        "    \"latency_ms\": {\n",
+        "        \"mean\": round(sum(latency_samples) / len(latency_samples), 3),\n",
+        "        \"median\": round(sorted_samples[len(sorted_samples) // 2], 3),\n",
+        "        \"p75\": round(percentile(sorted_samples, 75), 3),\n",
+        "        \"p90\": round(percentile(sorted_samples, 90), 3),\n",
+        "        \"p95\": round(percentile(sorted_samples, 95), 3),\n",
+        "        \"min\": round(sorted_samples[0], 3),\n",
+        "        \"max\": round(sorted_samples[-1], 3)\n",
+        "    }\n",
+        "}\n",
+        "metrics"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'notebook': 'docs/notebooks/working_backwards_experiments.ipynb', 'seed': 20240919, 'runs': 500, 'latency_ms': {'mean': 319.958, 'median': 319.57, 'p75': 349.695, 'p90': 374.634, 'p95': 389.272, 'min': 201.79, 'max': 467.41}}"
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)\n",
+        "ARTIFACT_PATH.write_text(json.dumps(metrics, indent=2) + \"\\n\", encoding=\"utf-8\")\n",
+        "json.loads(ARTIFACT_PATH.read_text(encoding=\"utf-8\"))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.8"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Working Backwards experiments notebook that records the seed and notebook path in the latency metrics prior to export
- regenerate docs/notebooks/artifacts/latency_summary.json so the persisted metrics include the seed and notebook metadata

## Testing
- not run (notebook-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d757fed2388330a13295b5891e8ea8