### PR TITLE
Add PSI artifact export for working backwards experiments

### DIFF
--- a/docs/notebooks/artifacts/latency_summary.json
+++ b/docs/notebooks/artifacts/latency_summary.json
@@ -1,0 +1,18 @@
+{
+  "baseline_latency_share": {
+    "0-200ms": 0.42,
+    "200-400ms": 0.37,
+    "400ms+": 0.21
+  },
+  "current_latency_share": {
+    "0-200ms": 0.4,
+    "200-400ms": 0.38,
+    "400ms+": 0.22
+  },
+  "experiment_id": "working_backwards_experiments",
+  "generated_at": "2025-09-27T03:22:59Z",
+  "metrics": {
+    "psi": 0.0017076859105591795,
+    "psi_threshold": 0.2
+  }
+}

--- a/docs/notebooks/working_backwards_experiments.ipynb
+++ b/docs/notebooks/working_backwards_experiments.ipynb
@@ -1,0 +1,84 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Working Backwards Experiments\n",
+        "This notebook recomputes the latency distribution experiment and persists the Population Stability Index (PSI) so downstream reports can consume a numeric value.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from __future__ import annotations\n",
+        "\n",
+        "import json\n",
+        "from datetime import datetime\n",
+        "from pathlib import Path\n",
+        "from math import log\n",
+        "\n",
+        "baseline_latency = {\"0-200ms\": 0.42, \"200-400ms\": 0.37, \"400ms+\": 0.21}\n",
+        "current_latency = {\"0-200ms\": 0.40, \"200-400ms\": 0.38, \"400ms+\": 0.22}\n",
+        "\n",
+        "def calculate_psi(baseline: dict[str, float], current: dict[str, float], *, epsilon: float = 1e-6) -> float:\n",
+        "    \"\"\"Compute PSI with a guard for empty buckets.\"\"\"\n",
+        "    psi = 0.0\n",
+        "    for bucket, baseline_share in baseline.items():\n",
+        "        current_share = current.get(bucket, epsilon)\n",
+        "        baseline_adj = baseline_share if baseline_share > 0 else epsilon\n",
+        "        current_adj = current_share if current_share > 0 else epsilon\n",
+        "        psi += (current_adj - baseline_adj) * log(current_adj / baseline_adj)\n",
+        "    return psi\n",
+        "\n",
+        "psi_value = calculate_psi(baseline_latency, current_latency)\n",
+        "psi_value\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "artifact_path = Path(\"docs/notebooks/artifacts/latency_summary.json\")\n",
+        "artifact_path.parent.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "latency_summary = {\n",
+        "    \"experiment_id\": \"working_backwards_experiments\",\n",
+        "    \"generated_at\": datetime.utcnow().replace(microsecond=0).isoformat() + \"Z\",\n",
+        "    \"baseline_latency_share\": baseline_latency,\n",
+        "    \"current_latency_share\": current_latency,\n",
+        "    \"metrics\": {\n",
+        "        \"psi\": psi_value,\n",
+        "        \"psi_threshold\": 0.2\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "with artifact_path.open(\"w\", encoding=\"utf-8\") as fp:\n",
+        "    json.dump(latency_summary, fp, indent=2, sort_keys=True)\n",
+        "\n",
+        "latency_summary\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/ops/reports/repo_audit.json
+++ b/ops/reports/repo_audit.json
@@ -1,0 +1,12 @@
+{
+  "artifacts": {
+    "latency_summary": {
+      "path": "docs/notebooks/artifacts/latency_summary.json",
+      "psi": 0.0017076859105591795,
+      "psi_threshold": 0.2,
+      "status": "within_threshold"
+    }
+  },
+  "generated_at": "2025-09-27T03:23:07Z",
+  "report": "repo_audit"
+}


### PR DESCRIPTION
## Summary
- add a notebook that calculates the working backwards latency PSI and persists it as a JSON artifact
- capture the regenerated latency_summary.json with the PSI metric for downstream consumption
- wire the repo_audit report to reference the numeric PSI value instead of a placeholder

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7580094c083309ebbd6ac4c44f632