### PR TITLE
Fix k6 smoke test default base URL

### DIFF
--- a/ops/tests/README.md
+++ b/ops/tests/README.md
@@ -14,3 +14,7 @@ make test        # confirma targets essenciais no Makefile
 make build       # gera manifest com probes e cobertura
 make evidence    # publica evidências em ops/evidence/ops-tests.json
 ```
+
+## Variáveis de ambiente principais
+- `K6_BASE_URL`: raiz do serviço de decisão (padrão: `http://localhost:8080`).
+- `K6_QUOTE_ENDPOINT`: path relativo para cotação (padrão: `/pricing/quote`).

--- a/ops/tests/k6_smoke_test.js
+++ b/ops/tests/k6_smoke_test.js
@@ -12,8 +12,26 @@ export const options = {
   summaryTrendStats: ['min', 'avg', 'med', 'p(90)', 'p(95)', 'p(99)'],
 };
 
-const baseUrl = __ENV.K6_BASE_URL || 'http://localhost:8080/healthz';
-const quoteEndpoint = __ENV.K6_QUOTE_ENDPOINT || '/pricing/quote';
+const DEFAULT_BASE_URL = 'http://localhost:8080';
+const DEFAULT_QUOTE_ENDPOINT = '/pricing/quote';
+
+const baseUrl = __ENV.K6_BASE_URL || DEFAULT_BASE_URL;
+const quoteEndpoint = __ENV.K6_QUOTE_ENDPOINT || DEFAULT_QUOTE_ENDPOINT;
+
+function assertDefaultQuotePath(base, endpoint) {
+  if (base === DEFAULT_BASE_URL && endpoint === DEFAULT_QUOTE_ENDPOINT) {
+    const expectedUrl = `${DEFAULT_BASE_URL}${DEFAULT_QUOTE_ENDPOINT}`;
+    const actualUrl = `${base.replace(/\/$/, '')}${endpoint}`;
+
+    if (actualUrl !== expectedUrl) {
+      throw new Error(
+        `Expected default quote URL to be ${expectedUrl}, but received ${actualUrl}`,
+      );
+    }
+  }
+}
+
+assertDefaultQuotePath(baseUrl, quoteEndpoint);
 const latency = new Trend('decision_latency', true);
 
 function buildQuotePayload() {


### PR DESCRIPTION
## Summary
- point the k6 smoke test default base URL at the service root so the quote endpoint resolves correctly
- add a lightweight assertion to protect the default quote URL concatenation logic
- document the updated environment defaults for the k6 smoke test suite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77307dc548330a1249ea39d26a397