### PR TITLE
Fix rollback boolean handling in hooks dry run

### DIFF
--- a/ops/scripts/hooks_dry_run.py
+++ b/ops/scripts/hooks_dry_run.py
@@ -30,11 +30,26 @@ def _normalize(value: Any) -> Any:
     return value
 
 
+def _coerce_rollback(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "yes":
+            return True
+        if normalized == "no":
+            return False
+    raise ValueError(
+        "Rollback flag must be a boolean or the string 'yes'/'no'"
+    )
+
+
 def _validate_hook(hook: Dict[str, Any]) -> Dict[str, Any]:
     missing = REQUIRED_FIELDS - hook.keys()
     if missing:
         raise ValueError(f"Hook '{hook.get('hook')}' missing fields: {sorted(missing)}")
     normalized = {key: _normalize(hook[key]) for key in sorted(REQUIRED_FIELDS)}
+    normalized["rollback"] = _coerce_rollback(normalized["rollback"])
     encoded = json.dumps(normalized, sort_keys=True, ensure_ascii=False).encode("utf-8")
     digest = hashlib.sha256(encoded).hexdigest()
     return {

--- a/ops/scripts/tests/test_hooks_dry_run.py
+++ b/ops/scripts/tests/test_hooks_dry_run.py
@@ -1,0 +1,66 @@
+"""Tests for the hooks dry-run validation helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "hooks_dry_run.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("hooks_dry_run", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load hooks_dry_run module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+hooks_dry_run = _load_module()
+
+
+def _build_hook(**overrides):
+    hook = {
+        "hook": "sample",
+        "kpi": "metric",
+        "threshold": "1",
+        "window": "5m",
+        "action": "noop",
+        "owner": "SRE",
+        "rollback": "yes",
+    }
+    hook.update(overrides)
+    return hook
+
+
+def test_validate_hook_accepts_string_no():
+    hook = _build_hook(rollback="no")
+    validated = hooks_dry_run._validate_hook(hook)
+    assert validated["rollback"] is False
+
+
+def test_validate_hook_accepts_string_yes_case_insensitive():
+    hook = _build_hook(rollback="YeS")
+    validated = hooks_dry_run._validate_hook(hook)
+    assert validated["rollback"] is True
+
+
+def test_validate_hook_rejects_unexpected_string():
+    hook = _build_hook(rollback="maybe")
+    with pytest.raises(ValueError):
+        hooks_dry_run._validate_hook(hook)
+
+
+def test_generate_report_emits_boolean_for_string_no(tmp_path):
+    config_path = tmp_path / "hooks.json"
+    config = {"hooks": [_build_hook(rollback="no")]}
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    report = hooks_dry_run.generate_report(config_path)
+
+    assert report["hooks"][0]["rollback"] is False


### PR DESCRIPTION
## Summary
- coerce the rollback flag to a real boolean, accepting booleans and yes/no strings
- add regression tests covering the coercion logic and report output

## Testing
- pytest ops/scripts/tests -q
- python ops/scripts/hooks_dry_run.py --config ops/hooks/a110.yaml --output /tmp/foo.json

------
https://chatgpt.com/codex/tasks/task_e_68d77cbd08bc8330a90d375f3c1c79b7