### PR TITLE
Remove duplicate num dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,6 @@ uint = "0.9"
 proptest = "1"
 criterion = { version = "0.5", default-features = false }
 
-# (removed) golden_runner bin block
-num-bigint = "0.4"
-num-integer = "0.1"
-num-rational = "0.4"
-num-traits = "0.2"
-
 
 [lib]
 name = "credit_engine_core"


### PR DESCRIPTION
## Summary
- remove duplicate `num-*` crates from the dev-dependency list, relying on the existing main dependency definitions

## Testing
- `cargo metadata --format-version 1`

------
https://chatgpt.com/codex/tasks/task_e_68d783f8d6f08330b3f1a99455da0be9