### PR TITLE
Make fix_crd_7_10 sed usage portable

### DIFF
--- a/scripts/fix_crd_7_10.sh
+++ b/scripts/fix_crd_7_10.sh
@@ -40,8 +40,9 @@ ensure_dep(){
     printf '%s = "%s"\n' "$crate" "$ver" >> Cargo.toml
   fi
 }
-# limpa entradas erradas em outras seções
-sed -i '' -E '/^[[:space:]]*num-(bigint|integer|rational|traits)[[:space:]]*=.*/d' Cargo.toml || true
+# limpa entradas erradas em outras seções (BSD/GNU compat)
+sed -i.bak -E '/^[[:space:]]*num-(bigint|integer|rational|traits)[[:space:]]*=.*/d' Cargo.toml || true
+rm -f Cargo.toml.bak
 ensure_dep num-bigint 0.4
 ensure_dep num-integer 0.1
 ensure_dep num-rational 0.4


### PR DESCRIPTION
## Summary
- replace the macOS-specific `sed -i ''` invocation in `fix_crd_7_10.sh` with a portable `sed -i.bak` call and clean-up

## Testing
- ran `bash scripts/fix_crd_7_10.sh` in a temporary project using GNU sed to confirm stray `num-*` lines are removed
- ran the script again with a BSD-style sed wrapper to confirm the same behavior on macOS sed semantics

------
https://chatgpt.com/codex/tasks/task_e_68d786424cb8833092213b90503b1e2d