### PR TITLE
Use python3 in bootstrap scripts

### DIFF
--- a/be/scripts/bootstrap.sh
+++ b/be/scripts/bootstrap.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 COMMAND="${1:-}"
 DOMAIN_SLUG="be"
 OWNER="DEC"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 WATCHERS_JSON='["api_breaking_change_watch","metrics_decision_hook_gap_watch","slo_budget_breach_watch","runtime_eol_watch","dep_vuln_watch"]'
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -18,7 +19,7 @@ USAGE
 }
 
 ensure_inventory() {
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from pathlib import Path
 slug = "${DOMAIN_SLUG}"
@@ -43,7 +44,7 @@ PY
 
 write_manifest() {
   mkdir -p "$BUILD_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -63,7 +64,7 @@ PY
 
 publish_evidence() {
   mkdir -p "$EVIDENCE_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -85,7 +86,7 @@ PY
 case "$COMMAND" in
   lint)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 readme = Path("be/README.md")
 required = ["Watchers", "Owner", "Makefile"]
@@ -98,7 +99,7 @@ PY
     ;;
   test)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 makefile = Path("be/Makefile").read_text()
 for target in ("lint", "test", "build", "evidence", "hooks.dry", "watchers.dry"):
@@ -117,13 +118,13 @@ PY
     ;;
   hooks.dry|watchers.dry)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[hooks/watchers] verificação sintética concluída")
 PY
     ;;
   run)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[run] ambiente ainda não possui serviço levantado; usar uv/fastapi no commit seguinte")
 PY
     ;;

--- a/data/scripts/bootstrap.sh
+++ b/data/scripts/bootstrap.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 COMMAND="${1:-}"
 DOMAIN_SLUG="data"
 OWNER="DATA"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 WATCHERS_JSON='["data_contract_break_watch","schema_registry_drift_watch","cdc_lag_watch","dbt_test_failure_watch"]'
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -19,7 +20,7 @@ USAGE
 }
 
 ensure_inventory() {
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from pathlib import Path
 slug = "${DOMAIN_SLUG}"
@@ -43,7 +44,7 @@ PY
 
 write_manifest() {
   mkdir -p "$BUILD_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -64,7 +65,7 @@ PY
 
 publish_evidence() {
   mkdir -p "$EVIDENCE_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -94,7 +95,7 @@ case "$COMMAND" in
   lint)
     ensure_inventory
     check_lock
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 text = Path("data/README.md").read_text()
 if "CDC" not in text or "dbt" not in text:
@@ -104,7 +105,7 @@ PY
     ;;
   test)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 makefile = Path("data/Makefile").read_text()
 required = ["lint", "test", "build", "evidence"]
@@ -125,13 +126,13 @@ PY
     ;;
   hooks.dry|watchers.dry)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[hooks/watchers] simulação concluída para DATA")
 PY
     ;;
   run)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[run] utilize \"make data.dbt\" quando os modelos estiverem disponíveis")
 PY
     ;;

--- a/infra/scripts/bootstrap.sh
+++ b/infra/scripts/bootstrap.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 COMMAND="${1:-}"
 DOMAIN_SLUG="infra"
 OWNER="SRE"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 WATCHERS_JSON='["slo_budget_breach_watch","runtime_eol_watch","dep_vuln_watch","alert_storm_watch"]'
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -19,7 +20,7 @@ USAGE
 }
 
 ensure_inventory() {
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from pathlib import Path
 slug = "${DOMAIN_SLUG}"
@@ -43,7 +44,7 @@ PY
 
 write_manifest() {
   mkdir -p "$BUILD_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -66,7 +67,7 @@ PY
 
 publish_evidence() {
   mkdir -p "$EVIDENCE_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -96,7 +97,7 @@ case "$COMMAND" in
   lint)
     ensure_inventory
     check_lock
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 text = Path("infra/README.md").read_text()
 if "IaC" not in text or "SLO" not in text:
@@ -106,7 +107,7 @@ PY
     ;;
   test)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 makefile = Path("infra/Makefile").read_text()
 required = ["lint", "test", "build", "evidence"]
@@ -127,13 +128,13 @@ PY
     ;;
   hooks.dry|watchers.dry)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[hooks/watchers] simulação concluída para Infra")
 PY
     ;;
   run)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[run] execute pipelines Terraform/Terragrunt conforme o ambiente")
 PY
     ;;

--- a/ml/scripts/bootstrap.sh
+++ b/ml/scripts/bootstrap.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 COMMAND="${1:-}"
 DOMAIN_SLUG="ml"
 OWNER="ML"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 WATCHERS_JSON='["model_drift_watch","ab_srm_watch","runtime_eol_watch","dep_vuln_watch"]'
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -19,7 +20,7 @@ USAGE
 }
 
 ensure_inventory() {
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from pathlib import Path
 slug = "${DOMAIN_SLUG}"
@@ -43,7 +44,7 @@ PY
 
 write_manifest() {
   mkdir -p "$BUILD_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -64,7 +65,7 @@ PY
 
 publish_evidence() {
   mkdir -p "$EVIDENCE_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -94,7 +95,7 @@ case "$COMMAND" in
   lint)
     ensure_inventory
     check_lock
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 text = Path("ml/README.md").read_text()
 for keyword in ("PSI", "KS", "rollback"):
@@ -105,7 +106,7 @@ PY
     ;;
   test)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 makefile = Path("ml/Makefile").read_text()
 required = ["lint", "test", "build", "evidence"]
@@ -126,13 +127,13 @@ PY
     ;;
   hooks.dry|watchers.dry)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[hooks/watchers] simulação concluída para ML")
 PY
     ;;
   run)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[run] execute \"uv run tritonserver\" após empacotar o modelo")
 PY
     ;;

--- a/ops/tests/scripts/bootstrap.sh
+++ b/ops/tests/scripts/bootstrap.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 COMMAND="${1:-}"
 DOMAIN_SLUG="ops-tests"
 OWNER="SRE-QA"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 WATCHERS_JSON='["metrics_decision_hook_gap_watch","slo_budget_breach_watch","formal_verification_gate_watch"]'
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -19,7 +20,7 @@ USAGE
 }
 
 ensure_inventory() {
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from pathlib import Path
 slug = "${DOMAIN_SLUG}"
@@ -43,7 +44,7 @@ PY
 
 write_manifest() {
   mkdir -p "$BUILD_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -65,7 +66,7 @@ PY
 
 publish_evidence() {
   mkdir -p "$EVIDENCE_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -95,7 +96,7 @@ case "$COMMAND" in
   lint)
     ensure_inventory
     check_lock
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 text = Path("ops/tests/README.md").read_text()
 if "probes" not in text.lower():
@@ -105,7 +106,7 @@ PY
     ;;
   test)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 makefile = Path("ops/tests/Makefile").read_text()
 required = ["lint", "test", "build", "evidence"]
@@ -126,13 +127,13 @@ PY
     ;;
   hooks.dry|watchers.dry)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[hooks/watchers] simulação concluída para ops/tests")
 PY
     ;;
   run)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[run] execute probes sintéticas via make hooks.dry")
 PY
     ;;

--- a/specs/scripts/bootstrap.sh
+++ b/specs/scripts/bootstrap.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 COMMAND="${1:-}"
 DOMAIN_SLUG="specs"
 OWNER="PMO"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 WATCHERS_JSON='["formal_verification_gate_watch","okr_risk_alignment_watch","policy_violation_watch"]'
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -19,7 +20,7 @@ USAGE
 }
 
 ensure_inventory() {
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from pathlib import Path
 slug = "${DOMAIN_SLUG}"
@@ -43,7 +44,7 @@ PY
 
 write_manifest() {
   mkdir -p "$BUILD_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -64,7 +65,7 @@ PY
 
 publish_evidence() {
   mkdir -p "$EVIDENCE_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -94,7 +95,7 @@ case "$COMMAND" in
   lint)
     ensure_inventory
     check_lock
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 text = Path("specs/README.md").read_text()
 for keyword in ("A110", "ADR", "hook"):
@@ -105,7 +106,7 @@ PY
     ;;
   test)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 makefile = Path("specs/Makefile").read_text()
 required = ["lint", "test", "build", "evidence"]
@@ -126,13 +127,13 @@ PY
     ;;
   hooks.dry|watchers.dry)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[hooks/watchers] simulação concluída para Specs")
 PY
     ;;
   run)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[run] gere ADRs via templates padronizados")
 PY
     ;;

--- a/web/scripts/bootstrap.sh
+++ b/web/scripts/bootstrap.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 COMMAND="${1:-}"
 DOMAIN_SLUG="web"
 OWNER="FE"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 WATCHERS_JSON='["web_cwv_regression_watch","api_breaking_change_watch","dep_vuln_watch"]'
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 REPO_ROOT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel)"
@@ -19,7 +20,7 @@ USAGE
 }
 
 ensure_inventory() {
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from pathlib import Path
 slug = "${DOMAIN_SLUG}"
@@ -43,7 +44,7 @@ PY
 
 write_manifest() {
   mkdir -p "$BUILD_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -64,7 +65,7 @@ PY
 
 publish_evidence() {
   mkdir -p "$EVIDENCE_DIR"
-  python - <<PY
+  "$PYTHON_BIN" - <<PY
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -94,7 +95,7 @@ case "$COMMAND" in
   lint)
     ensure_inventory
     check_lock
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 if "web_cwv_regression_watch" not in Path("web/README.md").read_text():
     raise SystemExit("README precisa documentar watchers FE")
@@ -103,7 +104,7 @@ PY
     ;;
   test)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 from pathlib import Path
 makefile = Path("web/Makefile").read_text()
 required = ["lint", "test", "build", "evidence"]
@@ -124,13 +125,13 @@ PY
     ;;
   hooks.dry|watchers.dry)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[hooks/watchers] simulação concluída para FE")
 PY
     ;;
   run)
     ensure_inventory
-    python - <<'PY'
+    "$PYTHON_BIN" - <<'PY'
 print("[run] utilize \"pnpm dev\" após provisionar o app")
 PY
     ;;


### PR DESCRIPTION
## Summary
- default each bootstrap script to a PYTHON_BIN that falls back to python3
- replace inline python invocations with the configurable interpreter across backend, data, ML, infra, specs, web, and ops test scripts

## Testing
- be/scripts/bootstrap.sh lint

------
https://chatgpt.com/codex/tasks/task_e_68d786443e7883309eb16d1373e5142a