### PR TITLE
Ensure watchers dry-run enforces threshold field

### DIFF
--- a/scripts/watchers_dry.py
+++ b/scripts/watchers_dry.py
@@ -76,7 +76,15 @@ MANDATORY_GLOBAL_WATCHERS: Set[str] = {
     "fx_delta_benchmark_watch",
 }
 
-REQUIRED_FIELDS = {"name", "kpi", "window", "action", "owner", "rollback"}
+REQUIRED_FIELDS = {
+    "name",
+    "kpi",
+    "threshold",
+    "window",
+    "action",
+    "owner",
+    "rollback",
+}
 VALID_ROLLBACK = {"yes", "no"}
 
 


### PR DESCRIPTION
## Summary
- require the threshold attribute when validating watcher definitions so incomplete entries are rejected

## Testing
- python scripts/watchers_dry.py

------
https://chatgpt.com/codex/tasks/task_e_68d7887f3020833098dada862f699e29