### PR TITLE
Require domain field in watcher dry-run validation

### DIFF
--- a/ops/scripts/tests/test_watchers_dry_run.py
+++ b/ops/scripts/tests/test_watchers_dry_run.py
@@ -1,0 +1,57 @@
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "watchers_dry_run.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("watchers_dry_run", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load watchers_dry_run module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+watchers_dry_run = _load_module()
+
+
+def _build_watcher(**overrides):
+    watcher = {
+        "id": "sample",
+        "domain": "DEC",
+        "owner": "owner",
+        "kpi": "metric",
+        "threshold": "1",
+        "window": "5m",
+        "action": "noop",
+    }
+    watcher.update(overrides)
+    return watcher
+
+
+def test_validate_watcher_requires_domain():
+    watcher = _build_watcher()
+    watcher.pop("domain")
+
+    with pytest.raises(ValueError) as excinfo:
+        watchers_dry_run._validate_watcher(watcher)
+
+    message = str(excinfo.value)
+    assert "missing fields" in message
+    assert "'domain'" in message
+
+
+def test_validate_watcher_normalizes_domain(tmp_path):
+    watcher = _build_watcher(domain="  DEC  ")
+    config_path = tmp_path / "watchers.json"
+    config = {"watchers": [watcher]}
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    report = watchers_dry_run.generate_report(config_path)
+
+    assert report["watchers"][0]["domain"] == "DEC"

--- a/ops/scripts/watchers_dry_run.py
+++ b/ops/scripts/watchers_dry_run.py
@@ -11,7 +11,7 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
-REQUIRED_FIELDS = {"id", "owner", "kpi", "threshold", "window", "action"}
+REQUIRED_FIELDS = {"id", "domain", "owner", "kpi", "threshold", "window", "action"}
 
 
 def _load_watchers(path: pathlib.Path) -> List[Dict[str, Any]]:
@@ -39,6 +39,7 @@ def _validate_watcher(watcher: Dict[str, Any]) -> Dict[str, Any]:
     digest = hashlib.sha256(encoded).hexdigest()
     return {
         "id": normalized["id"],
+        "domain": normalized["domain"],
         "owner": normalized["owner"],
         "kpi": normalized["kpi"],
         "threshold": normalized["threshold"],


### PR DESCRIPTION
## Summary
- require watcher configurations to define a domain and propagate it in the dry-run report
- add unit tests covering the new validation rule and normalization behaviour

## Testing
- pytest ops/scripts/tests/test_watchers_dry_run.py

------
https://chatgpt.com/codex/tasks/task_e_68d7887fe8a4833091824b4de53bc4c4