### PR TITLE
Handle aggregated watcher inventories

### DIFF
--- a/scripts/tests/test_watchers_dry.py
+++ b/scripts/tests/test_watchers_dry.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[1] / "watchers_dry.py"
+    spec = importlib.util.spec_from_file_location("watchers_dry", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Unable to load watchers_dry module")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+watchers_dry = _load_module()
+
+
+def _write_aggregated_inventory(base_dir: Path) -> Path:
+    watchers_dir = base_dir / "ops" / "watchers"
+    watchers_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "version": 1,
+        "domains": {
+            domain: sorted(expected)
+            for domain, expected in watchers_dry.EXPECTED_DOMAIN_WATCHERS.items()
+        },
+    }
+
+    path = watchers_dir / "core.yaml"
+    path.write_text(json.dumps(payload, indent=2))
+    return watchers_dir
+
+
+def _write_domain_file(watchers_dir: Path, domain: str) -> None:
+    domain_watchers = []
+    for name in sorted(watchers_dry.EXPECTED_DOMAIN_WATCHERS[domain]):
+        domain_watchers.append(
+            {
+                "name": name,
+                "kpi": "metric",
+                "threshold": "threshold",
+                "window": "5m",
+                "action": "action",
+                "owner": "owner@trendmarket",
+                "rollback": "yes",
+            }
+        )
+
+    payload = {"domain": domain, "watchers": domain_watchers}
+    (watchers_dir / f"{domain.lower()}.yml").write_text(json.dumps(payload, indent=2))
+
+
+def test_load_watchers_file_supports_aggregated_payload(tmp_path: Path) -> None:
+    payload = {"domains": {"DEC": ["a", "b"]}}
+    path = tmp_path / "core.yaml"
+    path.write_text(json.dumps(payload))
+
+    result = watchers_dry._load_watchers_file(path)
+
+    assert result == {"DEC": {"a", "b"}}
+
+
+def test_main_accepts_aggregated_inventory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_aggregated_inventory(tmp_path)
+
+    monkeypatch.chdir(tmp_path)
+    exit_code = watchers_dry.main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "[watchers.dry] watcher coverage OK:" in captured.out
+
+
+def test_main_allows_per_domain_files_with_aggregated_inventory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    watchers_dir = _write_aggregated_inventory(tmp_path)
+    _write_domain_file(watchers_dir, "DEC")
+
+    monkeypatch.chdir(tmp_path)
+    exit_code = watchers_dry.main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "DEC: 3 watcher(s)" in captured.out

--- a/scripts/watchers_dry.py
+++ b/scripts/watchers_dry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, Set, Tuple
+from typing import Dict, Iterable, Set
 
 EXPECTED_DOMAIN_WATCHERS: Dict[str, Set[str]] = {
     "DEC": {
@@ -92,7 +92,7 @@ class WatcherValidationError(RuntimeError):
     """Represents a validation error during watcher loading."""
 
 
-def _load_watchers_file(path: Path) -> Tuple[str, Set[str]]:
+def _load_watchers_file(path: Path) -> Dict[str, Set[str]]:
     try:
         payload = json.loads(path.read_text())
     except json.JSONDecodeError as exc:  # pragma: no cover - defensive
@@ -100,6 +100,46 @@ def _load_watchers_file(path: Path) -> Tuple[str, Set[str]]:
 
     if not isinstance(payload, dict):
         raise WatcherValidationError(f"{path}: expected a mapping with domain and watchers")
+
+    if "domains" in payload:
+        domains = payload.get("domains")
+        if not isinstance(domains, dict) or not domains:
+            raise WatcherValidationError(f"{path}: domains must be a non-empty mapping")
+
+        results: Dict[str, Set[str]] = {}
+        for domain_raw, watchers in domains.items():
+            domain = str(domain_raw or "").strip().upper()
+            if not domain:
+                raise WatcherValidationError(f"{path}: domain entries must have a valid name")
+
+            if not isinstance(watchers, list) or not watchers:
+                raise WatcherValidationError(
+                    f"{path}: domain '{domain}' must map to a non-empty watcher list"
+                )
+
+            names: Set[str] = set()
+            for idx, watcher in enumerate(watchers):
+                if not isinstance(watcher, str):
+                    raise WatcherValidationError(
+                        f"{path}: watcher #{idx + 1} for domain '{domain}' must be a string"
+                    )
+
+                name = watcher.strip()
+                if not name:
+                    raise WatcherValidationError(
+                        f"{path}: watcher #{idx + 1} for domain '{domain}' missing a valid name"
+                    )
+
+                if name in names:
+                    raise WatcherValidationError(
+                        f"{path}: duplicated watcher entry '{name}' for domain '{domain}'"
+                    )
+
+                names.add(name)
+
+            results[domain] = names
+
+        return results
 
     domain_raw = payload.get("domain")
     domain = str(domain_raw).upper() if domain_raw else path.stem.upper()
@@ -138,7 +178,7 @@ def _load_watchers_file(path: Path) -> Tuple[str, Set[str]]:
 
         seen.add(name)
 
-    return domain, seen
+    return {domain: seen}
 
 
 def _summarize_domain_counts(domain_watchers: Dict[str, Set[str]]) -> Iterable[str]:
@@ -154,19 +194,44 @@ def main() -> int:
 
     errors = []
     domain_watchers: Dict[str, Set[str]] = {}
+    aggregated_inventory = False
 
-    for path in sorted(watchers_dir.glob("*.yml")):
+    for path in sorted({path for path in watchers_dir.glob("*.yaml")}):
         try:
-            domain, watchers = _load_watchers_file(path)
+            domain_entries = _load_watchers_file(path)
         except WatcherValidationError as exc:
             errors.append(str(exc))
             continue
 
-        if domain in domain_watchers:
-            errors.append(f"duplicate watcher definition for domain '{domain}' in {path}")
+        if len(domain_entries) > 1:
+            aggregated_inventory = True
+
+        for domain, watchers in domain_entries.items():
+            if domain in domain_watchers:
+                errors.append(f"duplicate watcher definition for domain '{domain}' in {path}")
+                continue
+
+            domain_watchers[domain] = watchers
+
+    for path in sorted({path for path in watchers_dir.glob("*.yml")}):
+        try:
+            domain_entries = _load_watchers_file(path)
+        except WatcherValidationError as exc:
+            errors.append(str(exc))
             continue
 
-        domain_watchers[domain] = watchers
+        for domain, watchers in domain_entries.items():
+            if aggregated_inventory and domain in domain_watchers:
+                # Aggregated inventories already define this domain; keep the
+                # duplicate-domain guard behaviour for other cases while
+                # avoiding redundant definitions here.
+                continue
+
+            if domain in domain_watchers:
+                errors.append(f"duplicate watcher definition for domain '{domain}' in {path}")
+                continue
+
+            domain_watchers[domain] = watchers
 
     expected_domains = set(EXPECTED_DOMAIN_WATCHERS)
 


### PR DESCRIPTION
## Summary
- allow scripts/watchers_dry.py to load aggregated domain payloads and scan both *.yaml and *.yml files
- ensure aggregated watchers coexist with per-domain files without duplicate errors
- add pytest coverage for aggregated and per-domain watcher inputs

## Testing
- pytest scripts/tests/test_watchers_dry.py

------
https://chatgpt.com/codex/tasks/task_e_68d7957432a48330ae06037325aa8eee