### PR TITLE
Improve hooks watcher merging and add tests

### DIFF
--- a/scripts/hooks_dry.py
+++ b/scripts/hooks_dry.py
@@ -102,9 +102,16 @@ def _load_watchers() -> Tuple[Dict[str, Set[str]], List[str]]:
 
     errors: List[str] = []
     domain_watchers: Dict[str, Set[str]] = {}
+    provenance: Dict[str, Dict[str, Set[str]]] = {}
+    yaml_sources: Dict[str, str] = {}
+    yml_sources: Dict[str, str] = {}
+
+    def _record(domain: str, watchers: Set[str], source: Path) -> None:
+        source_key = str(source)
+        domain_watchers.setdefault(domain, set()).update(watchers)
+        provenance.setdefault(domain, {})[source_key] = set(watchers)
 
     yaml_paths = sorted({path for path in watchers_dir.glob("*.yaml")})
-    aggregated_inventory = False
 
     for path in yaml_paths:
         try:
@@ -113,17 +120,15 @@ def _load_watchers() -> Tuple[Dict[str, Set[str]], List[str]]:
             errors.append(str(exc))
             continue
 
-        if len(domain_entries) > 1:
-            aggregated_inventory = True
-
         for domain, watchers in domain_entries.items():
-            if domain in domain_watchers:
+            if domain in yaml_sources:
                 errors.append(
                     f"duplicate watcher definition for domain '{domain}' in {path}"
                 )
                 continue
 
-            domain_watchers[domain] = watchers
+            yaml_sources[domain] = str(path)
+            _record(domain, watchers, path)
 
     yml_paths = sorted({path for path in watchers_dir.glob("*.yml")})
 
@@ -135,19 +140,48 @@ def _load_watchers() -> Tuple[Dict[str, Set[str]], List[str]]:
             continue
 
         for domain, watchers in domain_entries.items():
-            if aggregated_inventory and domain in domain_watchers:
-                # Aggregated inventory already defines this domain; keep the
-                # duplicate-domain guard behaviour for other cases while
-                # avoiding redundant definitions here.
-                continue
-
-            if domain in domain_watchers:
+            if domain in yml_sources:
                 errors.append(
                     f"duplicate watcher definition for domain '{domain}' in {path}"
                 )
                 continue
 
-            domain_watchers[domain] = watchers
+            yml_sources[domain] = str(path)
+            _record(domain, watchers, path)
+
+    for domain, sources in provenance.items():
+        if len(sources) <= 1:
+            continue
+
+        # Prefer the aggregated inventory ("*.yaml") as the baseline when present.
+        sorted_sources = sorted(
+            sources.items(),
+            key=lambda item: (0 if item[0].endswith(".yaml") else 1, item[0]),
+        )
+
+        baseline_source, baseline_watchers = sorted_sources[0]
+        for source, watchers in sorted_sources[1:]:
+            missing_in_source = baseline_watchers - watchers
+            missing_in_baseline = watchers - baseline_watchers
+            if not missing_in_source and not missing_in_baseline:
+                continue
+
+            diff_parts: List[str] = []
+            if missing_in_source:
+                formatted = ", ".join(sorted(missing_in_source))
+                diff_parts.append(
+                    f"{source} missing [{formatted}] compared to {baseline_source}"
+                )
+            if missing_in_baseline:
+                formatted = ", ".join(sorted(missing_in_baseline))
+                diff_parts.append(
+                    f"{baseline_source} missing [{formatted}] compared to {source}"
+                )
+
+            message = "; ".join(diff_parts)
+            errors.append(
+                f"watcher mismatch for domain '{domain}': {message}"
+            )
 
     return domain_watchers, errors
 

--- a/scripts/tests/test_hooks_dry.py
+++ b/scripts/tests/test_hooks_dry.py
@@ -1,0 +1,112 @@
+import importlib.util
+import json
+import pathlib
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "hooks_dry.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("hooks_dry", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load hooks_dry module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+hooks_dry = _load_module()
+
+
+def _write_json(path: pathlib.Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_load_watchers_combines_core_and_domain(tmp_path, monkeypatch):
+    watchers_dir = tmp_path / "ops" / "watchers"
+    watchers_dir.mkdir(parents=True)
+
+    _write_json(
+        watchers_dir / "core.yaml",
+        {
+            "domains": {
+                "DEC": ["metrics_decision_hook_gap_watch", "model_drift_watch"],
+            }
+        },
+    )
+
+    _write_json(
+        watchers_dir / "dec.yml",
+        {
+            "domain": "DEC",
+            "watchers": [
+                {"name": "metrics_decision_hook_gap_watch"},
+                {"name": "model_drift_watch"},
+            ],
+        },
+    )
+
+    hooks_dir = tmp_path / "ops" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    _write_json(
+        hooks_dir / "a110.yml",
+        [
+            {
+                "hook": "dec-latency-degrade",
+                "domain": "DEC",
+                "watchers": [
+                    "metrics_decision_hook_gap_watch",
+                    "model_drift_watch",
+                ],
+                "kpi": "dec.latency.p95",
+                "threshold": "800ms",
+                "window": "5m",
+                "action": "degrade_route",
+                "owner": "dec-duty@trendmarket",
+                "rollback": "yes",
+            }
+        ],
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    watchers, errors = hooks_dry._load_watchers()
+    assert errors == []
+    assert watchers == {
+        "DEC": {"metrics_decision_hook_gap_watch", "model_drift_watch"}
+    }
+
+    assert hooks_dry.main() == 0
+
+
+def test_hooks_dry_fails_when_core_and_domain_watchers_diverge(tmp_path, monkeypatch):
+    watchers_dir = tmp_path / "ops" / "watchers"
+    watchers_dir.mkdir(parents=True)
+
+    _write_json(
+        watchers_dir / "core.yaml",
+        {
+            "domains": {
+                "DEC": ["metrics_decision_hook_gap_watch", "model_drift_watch"],
+            }
+        },
+    )
+
+    _write_json(
+        watchers_dir / "dec.yml",
+        {
+            "domain": "DEC",
+            "watchers": [
+                {"name": "metrics_decision_hook_gap_watch"},
+                {"name": "slo_budget_breach_watch"},
+            ],
+        },
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    watchers, errors = hooks_dry._load_watchers()
+    assert "DEC" in watchers
+    assert any("watcher mismatch for domain 'DEC'" in message for message in errors)
+
+    # hooks_dry.main() should abort before reading hooks due to the mismatch
+    assert hooks_dry.main() == 1


### PR DESCRIPTION
## Summary
- merge watcher inventories from the aggregated core list and the per-domain files, keeping domain unions while flagging mismatches
- make hooks_dry.py fail fast when core.yaml and domain definitions diverge so hooks cannot be validated on stale watcher data
- add pytest coverage exercising the happy path and the mismatch failure scenario

## Testing
- pytest scripts/tests ops/scripts/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d7959b7b148330abd031351512de99