### PR TITLE
Support list-based hook configs in dry-run helper

### DIFF
--- a/ops/scripts/hooks_dry_run.py
+++ b/ops/scripts/hooks_dry_run.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import hashlib
 import json
 import pathlib
@@ -14,13 +15,33 @@ from typing import Any, Dict, List
 REQUIRED_FIELDS = {"hook", "kpi", "threshold", "window", "action", "owner", "rollback"}
 
 
+def _load_parser():
+    spec = importlib.util.find_spec("yaml")
+    if spec is None:
+        return json.loads
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None  # for mypy/static analyzers
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module.safe_load  # type: ignore[attr-defined]
+
+
+_parse_config = _load_parser()
+
+
 def _load_hooks(path: pathlib.Path) -> List[Dict[str, Any]]:
     if not path.exists():
         raise FileNotFoundError(f"Hook configuration not found: {path}")
-    data = json.loads(path.read_text(encoding="utf-8"))
-    hooks = data.get("hooks") if isinstance(data, dict) else None
+    data = _parse_config(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        hooks = data
+    elif isinstance(data, dict):
+        hooks = data.get("hooks")
+    else:
+        hooks = None
     if not isinstance(hooks, list):
-        raise ValueError("Hook configuration must contain a 'hooks' list")
+        raise ValueError(
+            "Hook configuration must be a list or contain a 'hooks' list"
+        )
     return hooks
 
 

--- a/ops/scripts/tests/test_hooks_dry_run.py
+++ b/ops/scripts/tests/test_hooks_dry_run.py
@@ -38,6 +38,17 @@ def _build_hook(**overrides):
     return hook
 
 
+@pytest.fixture
+def list_config_path(tmp_path: pathlib.Path) -> pathlib.Path:
+    config_path = tmp_path / "hooks.yml"
+    hooks = [
+        _build_hook(hook="list-alpha", rollback=True),
+        _build_hook(hook="list-beta", rollback="no"),
+    ]
+    config_path.write_text(json.dumps(hooks), encoding="utf-8")
+    return config_path
+
+
 def test_validate_hook_accepts_string_no():
     hook = _build_hook(rollback="no")
     validated = hooks_dry_run._validate_hook(hook)
@@ -64,3 +75,10 @@ def test_generate_report_emits_boolean_for_string_no(tmp_path):
     report = hooks_dry_run.generate_report(config_path)
 
     assert report["hooks"][0]["rollback"] is False
+
+
+def test_generate_report_supports_top_level_list(list_config_path: pathlib.Path):
+    report = hooks_dry_run.generate_report(list_config_path)
+
+    assert report["total_hooks"] == 2
+    assert {entry["hook"] for entry in report["hooks"]} == {"list-alpha", "list-beta"}


### PR DESCRIPTION
## Summary
- allow the hooks dry-run helper to parse configurations provided as a top-level list or wrapped in a `hooks` mapping
- load a YAML parser when available so the CLI accepts JSON or YAML inputs consistently
- cover the new list-shaped config path with a regression test fixture

## Testing
- pytest ops/scripts/tests/test_hooks_dry_run.py
- python ops/scripts/hooks_dry_run.py --config ops/hooks/a110.yml --output /tmp/hooks.json

------
https://chatgpt.com/codex/tasks/task_e_68d79ca0c2e883308abe92aac07a9481