### PR TITLE
Align default watchers with domain definitions

### DIFF
--- a/ops/scripts/watchers_dry_run.py
+++ b/ops/scripts/watchers_dry_run.py
@@ -50,13 +50,37 @@ def _load_watchers_from_file(path: pathlib.Path) -> List[Dict[str, Any]]:
     data = _parse_config(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"Watcher configuration must be a mapping: {path}")
+
+    # Allow both per-domain configs (with a single domain) and aggregated JSON
+    # inventories where each watcher already declares its domain.
     domain = data.get("domain")
-    if not isinstance(domain, str) or not domain.strip():
-        raise ValueError(f"Watcher configuration missing 'domain': {path}")
     watchers = data.get("watchers")
-    if not isinstance(watchers, list):
-        raise ValueError(f"Watcher configuration must contain a 'watchers' list: {path}")
-    return [_coerce_watcher(domain.strip(), watcher) for watcher in watchers]
+    if isinstance(domain, str) and domain.strip():
+        if not isinstance(watchers, list):
+            raise ValueError(
+                f"Watcher configuration must contain a 'watchers' list: {path}"
+            )
+        return [_coerce_watcher(domain.strip(), watcher) for watcher in watchers]
+
+    if isinstance(watchers, list):
+        entries: List[Dict[str, Any]] = []
+        for watcher in watchers:
+            if not isinstance(watcher, dict):
+                raise ValueError(
+                    f"Aggregated watcher entries must be objects: {path}"
+                )
+            watcher_domain = watcher.get("domain")
+            if not isinstance(watcher_domain, str) or not watcher_domain.strip():
+                raise ValueError(
+                    f"Aggregated watcher missing domain information: {watcher}"
+                )
+            entries.append(_coerce_watcher(watcher_domain.strip(), watcher))
+        if entries:
+            return entries
+
+    raise ValueError(
+        f"Watcher configuration missing 'domain' or 'watchers' list: {path}"
+    )
 
 
 def _load_watchers(path: pathlib.Path) -> List[Dict[str, Any]]:

--- a/ops/watchers/default_watchers.json
+++ b/ops/watchers/default_watchers.json
@@ -1,0 +1,315 @@
+{
+  "version": 1,
+  "watchers": [
+    {
+      "id": "cdc_lag_watch",
+      "domain": "DATA",
+      "owner": "data-quality@trendmarket",
+      "kpi": "cdc.lag.p95_seconds",
+      "threshold": ">=120",
+      "window": "15m",
+      "action": "degrade_to_hot_table",
+      "rollback": "yes"
+    },
+    {
+      "id": "data_contract_break_watch",
+      "domain": "DATA",
+      "owner": "data-quality@trendmarket",
+      "kpi": "data.contracts.status",
+      "threshold": "breach",
+      "window": "15m",
+      "action": "rollback_contract_change",
+      "rollback": "yes"
+    },
+    {
+      "id": "dbt_test_failure_watch",
+      "domain": "DATA",
+      "owner": "data-quality@trendmarket",
+      "kpi": "dbt.tests.failed",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "rollback_dbt_artifacts",
+      "rollback": "yes"
+    },
+    {
+      "id": "doc_coverage_watch",
+      "domain": "DATA",
+      "owner": "data-quality@trendmarket",
+      "kpi": "data.contracts.documentation_coverage",
+      "threshold": "<0.95",
+      "window": "24h",
+      "action": "block_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "schema_registry_drift_watch",
+      "domain": "DATA",
+      "owner": "data-quality@trendmarket",
+      "kpi": "schema.registry.compatibility",
+      "threshold": "!=backward",
+      "window": "15m",
+      "action": "freeze_schema_migration",
+      "rollback": "yes"
+    },
+    {
+      "id": "metrics_decision_hook_gap_watch",
+      "domain": "DEC",
+      "owner": "dec-duty@trendmarket",
+      "kpi": "dec.latency.hook_gap.p95",
+      "threshold": ">=200ms",
+      "window": "5m",
+      "action": "degrade_route",
+      "rollback": "yes"
+    },
+    {
+      "id": "model_drift_watch",
+      "domain": "DEC",
+      "owner": "dec-duty@trendmarket",
+      "kpi": "ml.model.psi",
+      "threshold": ">0.2",
+      "window": "24h",
+      "action": "rollback_model",
+      "rollback": "yes"
+    },
+    {
+      "id": "slo_budget_breach_watch",
+      "domain": "DEC",
+      "owner": "dec-duty@trendmarket",
+      "kpi": "dec.latency.burn_rate",
+      "threshold": ">1.0",
+      "window": "1h",
+      "action": "page_oncall",
+      "rollback": "yes"
+    },
+    {
+      "id": "api_breaking_change_watch",
+      "domain": "FE",
+      "owner": "fe-core@trendmarket",
+      "kpi": "sdk.contract.breaking_changes",
+      "threshold": ">0",
+      "window": "30m",
+      "action": "block_fe_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "web_cwv_regression_watch",
+      "domain": "FE",
+      "owner": "fe-core@trendmarket",
+      "kpi": "web.inp.p75_ms",
+      "threshold": ">200",
+      "window": "24h",
+      "action": "rollback_fe_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "api_breaking_change_watch",
+      "domain": "INT",
+      "owner": "integration@trendmarket",
+      "kpi": "integration.contract.breaking_changes",
+      "threshold": ">0",
+      "window": "30m",
+      "action": "block_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "cache_ttl_misuse_watch",
+      "domain": "INT",
+      "owner": "integration@trendmarket",
+      "kpi": "integration.cache.ttl_violation_rate",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "rollback_cache_config",
+      "rollback": "yes"
+    },
+    {
+      "id": "cls_payin_cutoff_watch",
+      "domain": "INT",
+      "owner": "integration@trendmarket",
+      "kpi": "integration.cls.payin_cutoff_miss",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "pause_cls_flows",
+      "rollback": "yes"
+    },
+    {
+      "id": "ab_srm_watch",
+      "domain": "ML",
+      "owner": "ml-ops@trendmarket",
+      "kpi": "experiments.srm.p_value",
+      "threshold": "<=0.05",
+      "window": "1h",
+      "action": "pause_experiment",
+      "rollback": "yes"
+    },
+    {
+      "id": "image_vuln_regression_watch",
+      "domain": "ML",
+      "owner": "ml-ops@trendmarket",
+      "kpi": "serving.image.cvss_max",
+      "threshold": ">=7.0",
+      "window": "24h",
+      "action": "rollback_model_image",
+      "rollback": "yes"
+    },
+    {
+      "id": "model_drift_watch",
+      "domain": "ML",
+      "owner": "ml-ops@trendmarket",
+      "kpi": "ml.model.psi",
+      "threshold": ">0.2",
+      "window": "24h",
+      "action": "rollback_model",
+      "rollback": "yes"
+    },
+    {
+      "id": "runtime_eol_watch",
+      "domain": "ML",
+      "owner": "ml-ops@trendmarket",
+      "kpi": "serving.runtime.support_days",
+      "threshold": "<30",
+      "window": "24h",
+      "action": "schedule_runtime_upgrade",
+      "rollback": "yes"
+    },
+    {
+      "id": "alert_storm_watch",
+      "domain": "PLAT",
+      "owner": "sre@trendmarket",
+      "kpi": "observability.alerts.per_minute",
+      "threshold": ">50",
+      "window": "30m",
+      "action": "throttle_alerts_and_page",
+      "rollback": "yes"
+    },
+    {
+      "id": "okr_risk_alignment_watch",
+      "domain": "PLAT",
+      "owner": "sre@trendmarket",
+      "kpi": "governance.okr.risk_alignment_score",
+      "threshold": "<0.9",
+      "window": "24h",
+      "action": "trigger_executive_review",
+      "rollback": "yes"
+    },
+    {
+      "id": "policy_violation_watch",
+      "domain": "PLAT",
+      "owner": "sre@trendmarket",
+      "kpi": "platform.policy.violations",
+      "threshold": ">0",
+      "window": "1h",
+      "action": "freeze_pipeline",
+      "rollback": "yes"
+    },
+    {
+      "id": "slo_budget_breach_watch",
+      "domain": "PLAT",
+      "owner": "sre@trendmarket",
+      "kpi": "platform.slo.burn_rate",
+      "threshold": ">1.0",
+      "window": "1h",
+      "action": "block_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "tracing_sampling_watch",
+      "domain": "PLAT",
+      "owner": "sre@trendmarket",
+      "kpi": "observability.traces.sampling_rate",
+      "threshold": "<0.98",
+      "window": "15m",
+      "action": "restore_sampling_defaults",
+      "rollback": "yes"
+    },
+    {
+      "id": "auction_invariant_breach_watch",
+      "domain": "PM",
+      "owner": "pm-ops@trendmarket",
+      "kpi": "auction.no_arb_score",
+      "threshold": "<0",
+      "window": "15m",
+      "action": "pause_auction_stream",
+      "rollback": "yes"
+    },
+    {
+      "id": "fx_delta_benchmark_watch",
+      "domain": "PM",
+      "owner": "pm-ops@trendmarket",
+      "kpi": "fx.delta_vs_benchmark_bps",
+      "threshold": ">=15",
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "rollback": "yes"
+    },
+    {
+      "id": "oracle_divergence_watch",
+      "domain": "PM",
+      "owner": "pm-ops@trendmarket",
+      "kpi": "oracle.price.delta_bps",
+      "threshold": ">=10",
+      "window": "5m",
+      "action": "switch_to_twap_failover",
+      "rollback": "yes"
+    },
+    {
+      "id": "slo_budget_breach_watch",
+      "domain": "PM",
+      "owner": "pm-ops@trendmarket",
+      "kpi": "pm.routing.latency.burn_rate",
+      "threshold": ">1.0",
+      "window": "1h",
+      "action": "escalate_oncall",
+      "rollback": "yes"
+    },
+    {
+      "id": "dep_vuln_watch",
+      "domain": "SEC/PRIV",
+      "owner": "sec-priv@trendmarket",
+      "kpi": "security.dependencies.cvss_max",
+      "threshold": ">=7.0",
+      "window": "24h",
+      "action": "block_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "dp_budget_breach_watch",
+      "domain": "SEC/PRIV",
+      "owner": "sec-priv@trendmarket",
+      "kpi": "privacy.dp_budget_ratio",
+      "threshold": ">1.5",
+      "window": "1h",
+      "action": "freeze_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "formal_verification_gate_watch",
+      "domain": "SEC/PRIV",
+      "owner": "sec-priv@trendmarket",
+      "kpi": "security.formal_verification_status",
+      "threshold": "failed",
+      "window": "24h",
+      "action": "block_release",
+      "rollback": "yes"
+    },
+    {
+      "id": "idp_keys_rotation_watch",
+      "domain": "SEC/PRIV",
+      "owner": "sec-priv@trendmarket",
+      "kpi": "security.idp.keys_age_days",
+      "threshold": ">=75",
+      "window": "24h",
+      "action": "rotate_idp_keys",
+      "rollback": "yes"
+    },
+    {
+      "id": "image_vuln_regression_watch",
+      "domain": "SEC/PRIV",
+      "owner": "sec-priv@trendmarket",
+      "kpi": "security.images.cvss_max",
+      "threshold": ">=7.0",
+      "window": "24h",
+      "action": "rollback_image",
+      "rollback": "yes"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a default watcher inventory JSON that mirrors every per-domain watcher definition
- update the validation script to load aggregated watcher inventories alongside the existing per-domain YAML files

## Testing
- python ops/scripts/watchers_dry_run.py --config ops/watchers/default_watchers.json --output /tmp/watchers.json

------
https://chatgpt.com/codex/tasks/task_e_68d79c9f1e1c8330967ceb1389d26746