### PR TITLE
Sync JSON hook inventory with YAML definitions

### DIFF
--- a/ops/hooks/a110_hooks.json
+++ b/ops/hooks/a110_hooks.json
@@ -1,104 +1,406 @@
 {
   "hooks": [
     {
-      "hook": "dec-latency-degrade",
+      "hook": "dec-latency-gap",
+      "watchers": [
+        "metrics_decision_hook_gap_watch"
+      ],
       "kpi": "dec.latency.p95",
       "threshold": "800ms",
       "window": "5m",
       "action": "degrade_route",
       "owner": "dec-duty@trendmarket",
       "evidence": [
-        "traces:decision.core"
+        "traces:decision.core",
+        "playbook:docs/runbooks/dec_decision_pricing.md#metric-gap"
       ],
       "rollback": "yes"
     },
     {
-      "hook": "pm-oracle-staleness",
-      "kpi": "oracle.staleness_ms",
-      "threshold": "30000",
-      "window": "5m",
-      "action": "switch_to_twap_failover",
-      "owner": "pm-ops@trendmarket",
-      "evidence": [
-        "audit:oracles/weekly"
+      "hook": "model-drift-rollback",
+      "watchers": [
+        "model_drift_watch"
       ],
-      "rollback": "yes"
-    },
-    {
-      "hook": "ml-model-rollback",
-      "kpi": "ml.model.psi",
-      "threshold": "0.2",
+      "kpi": "model.psi",
+      "threshold": 0.2,
       "window": "24h",
       "action": "rollback_model",
       "owner": "ml-ops@trendmarket",
       "evidence": [
         "metrics:ml.psi",
-        "experiments:srm"
+        "experiments:srm",
+        "playbook:docs/runbooks/ml_model_ops.md#model-drift"
       ],
       "rollback": "yes"
     },
     {
-      "hook": "data-contract-rollback",
-      "kpi": "data.contracts.status",
-      "threshold": "breach",
+      "hook": "slo-burn-rate-guard",
+      "watchers": [
+        "slo_budget_breach_watch"
+      ],
+      "kpi": "slo.burn_rate",
+      "threshold": 1.0,
+      "window": "60m",
+      "action": "enforce_release_freeze",
+      "owner": "sre@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/plat_observability.md#slo-burn"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "oracle-staleness-failover",
+      "watchers": [
+        "oracle_divergence_watch"
+      ],
+      "kpi": "oracle.divergence_bps",
+      "threshold": 5,
+      "window": "10m",
+      "action": "switch_to_twap_failover",
+      "owner": "pm-ops@trendmarket",
+      "evidence": [
+        "audit:oracles/weekly",
+        "playbook:docs/runbooks/pm_market_health.md#oracle-divergence"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "fx-delta-benchmark-guard",
+      "watchers": [
+        "fx_delta_benchmark_watch"
+      ],
+      "kpi": "fx.delta_vs_benchmark_bps",
+      "threshold": 15,
+      "window": "10m",
+      "action": "switch_to_reference_rate",
+      "owner": "pm-ops@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/pm_market_health.md#fx-delta"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "auction-invariant-pause",
+      "watchers": [
+        "auction_invariant_breach_watch"
+      ],
+      "kpi": "auction.kkt_violation_pct",
+      "threshold": 0.0,
+      "window": "5m",
+      "action": "pause_auction_stream",
+      "owner": "pm-ops@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/pm_market_health.md#auction-invariant"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "experiment-srm-guardrail",
+      "watchers": [
+        "ab_srm_watch"
+      ],
+      "kpi": "experiment.srm_pvalue",
+      "threshold": 0.01,
+      "window": "24h",
+      "action": "pause_experiment",
+      "owner": "ml-ops@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/ml_model_ops.md#srm"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "runtime-eol-governance",
+      "watchers": [
+        "runtime_eol_watch"
+      ],
+      "kpi": "runtime.support_gap_days",
+      "threshold": 0,
+      "window": "7d",
+      "action": "schedule_runtime_upgrade",
+      "owner": "platform@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/ml_model_ops.md#runtime-eol"
+      ],
+      "rollback": "no"
+    },
+    {
+      "hook": "image-vuln-regression-block",
+      "watchers": [
+        "image_vuln_regression_watch"
+      ],
+      "kpi": "image.critical_vuln_count",
+      "threshold": 0,
       "window": "15m",
-      "action": "rollback_and_timebox",
+      "action": "block_release",
+      "owner": "sec-priv@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#image-vuln"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "cdc-lag-hot-degrade",
+      "watchers": [
+        "cdc_lag_watch"
+      ],
+      "kpi": "cdc.lag.p95",
+      "threshold": "120s",
+      "window": "15m",
+      "action": "degrade_to_hot_table",
+      "owner": "data-quality@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/data_contracts.md#cdc-lag"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "schema-drift-blocker",
+      "watchers": [
+        "schema_registry_drift_watch"
+      ],
+      "kpi": "schema.drift_detected",
+      "threshold": 1,
+      "window": "5m",
+      "action": "block_deploy",
+      "owner": "data-quality@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/data_contracts.md#schema-drift"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "dbt-test-rollback",
+      "watchers": [
+        "dbt_test_failure_watch"
+      ],
+      "kpi": "dbt.tests.failure_rate",
+      "threshold": 0,
+      "window": "15m",
+      "action": "rollback_transform",
+      "owner": "data-quality@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/data_contracts.md#dbt-tests"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "data-contract-breach-guard",
+      "watchers": [
+        "data_contract_break_watch"
+      ],
+      "kpi": "data.contract.break",
+      "threshold": 1,
+      "window": "5m",
+      "action": "trigger_contract_waiver",
       "owner": "data-quality@trendmarket",
       "evidence": [
         "contracts:a106",
-        "contracts:a87"
+        "contracts:a87",
+        "playbook:docs/runbooks/data_contracts.md#contract-breach"
       ],
       "rollback": "yes"
     },
     {
-      "hook": "platform-sampling-guard",
-      "kpi": "observability.traces.sampling_rate",
-      "threshold": "<0.98",
-      "window": "15m",
-      "action": "block_release",
-      "owner": "sre@trendmarket",
+      "hook": "doc-coverage-gap",
+      "watchers": [
+        "doc_coverage_watch"
+      ],
+      "kpi": "data.doc.coverage",
+      "threshold": 0.95,
+      "window": "24h",
+      "action": "raise_doc_gap",
+      "owner": "data-quality@trendmarket",
       "evidence": [
-        "traces:otel",
-        "alerts:platform"
+        "playbook:docs/runbooks/data_contracts.md#doc-coverage"
       ],
-      "rollback": "yes"
+      "rollback": "no"
     },
     {
-      "hook": "fe-cwv-regression",
-      "kpi": "web.inp.p75",
+      "hook": "web-cwv-rollback",
+      "watchers": [
+        "web_cwv_regression_watch"
+      ],
+      "kpi": "web.cwv.inp_p75",
       "threshold": "200ms",
       "window": "24h",
       "action": "rollback_fe_release",
       "owner": "fe-core@trendmarket",
       "evidence": [
         "lighthouse:cwv",
-        "sdk:contract"
+        "sdk:contract",
+        "playbook:docs/runbooks/fe_experience.md#web-cwv"
       ],
       "rollback": "yes"
     },
     {
-      "hook": "sec-privacy-freeze",
-      "kpi": "privacy.dp_budget_ratio",
-      "threshold": "1.5",
-      "window": "1h",
-      "action": "freeze_release",
-      "owner": "sec-priv@trendmarket",
-      "evidence": [
-        "sbom:latest",
-        "audit:privacy"
+      "hook": "api-contract-block",
+      "watchers": [
+        "api_breaking_change_watch"
       ],
-      "rollback": "yes"
-    },
-    {
-      "hook": "integration-contract-guard",
-      "kpi": "integration.contracts.fail_pct",
-      "threshold": ">0",
-      "window": "30m",
+      "kpi": "api.contract.breaking_changes",
+      "threshold": 0,
+      "window": "5m",
       "action": "block_release",
       "owner": "integration@trendmarket",
       "evidence": [
         "tests:contract",
-        "synthetics:cls"
+        "synthetics:cls",
+        "playbook:docs/runbooks/int_integrations.md#api-breaking"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "formal-verification-freeze",
+      "watchers": [
+        "formal_verification_gate_watch"
+      ],
+      "kpi": "formal.verification.failure",
+      "threshold": 1,
+      "window": "5m",
+      "action": "freeze_pipeline",
+      "owner": "sec-priv@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#formal-verification"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "okr-alignment-escalation",
+      "watchers": [
+        "okr_risk_alignment_watch"
+      ],
+      "kpi": "okr.risk_alignment_score",
+      "threshold": 0.8,
+      "window": "7d",
+      "action": "escalate_exec_review",
+      "owner": "strategyops@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/plat_observability.md#okr-alignment"
+      ],
+      "rollback": "no"
+    },
+    {
+      "hook": "dp-budget-freeze",
+      "watchers": [
+        "dp_budget_breach_watch"
+      ],
+      "kpi": "privacy.dp_budget_multiplier",
+      "threshold": 1.5,
+      "window": "60m",
+      "action": "freeze_processing",
+      "owner": "sec-priv@trendmarket",
+      "evidence": [
+        "sbom:latest",
+        "audit:privacy",
+        "playbook:docs/runbooks/sec_privacy.md#dp-budget"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "dep-vuln-freeze",
+      "watchers": [
+        "dep_vuln_watch"
+      ],
+      "kpi": "security.deps.critical_vulns",
+      "threshold": 0,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "sec-priv@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#dep-vuln"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "idp-keys-rotation",
+      "watchers": [
+        "idp_keys_rotation_watch"
+      ],
+      "kpi": "security.idp.keys_age_days",
+      "threshold": 90,
+      "window": "1d",
+      "action": "rotate_idp_keys",
+      "owner": "sec-priv@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#idp-keys"
+      ],
+      "rollback": "no"
+    },
+    {
+      "hook": "cache-ttl-block",
+      "watchers": [
+        "cache_ttl_misuse_watch"
+      ],
+      "kpi": "integration.cache_ttl_violation_pct",
+      "threshold": 0,
+      "window": "10m",
+      "action": "block_release",
+      "owner": "integration@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/int_integrations.md#cache-ttl"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "cls-payin-cutover",
+      "watchers": [
+        "cls_payin_cutoff_watch"
+      ],
+      "kpi": "integration.cls_payin_cutoff_delay_ms",
+      "threshold": 30000,
+      "window": "5m",
+      "action": "switch_to_manual_cutoff",
+      "owner": "integration@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/int_integrations.md#cls-payin"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "tracing-sampling-freeze",
+      "watchers": [
+        "tracing_sampling_watch"
+      ],
+      "kpi": "tracing.sampling_rate",
+      "threshold": 0.01,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "sre@trendmarket",
+      "evidence": [
+        "traces:otel",
+        "alerts:platform",
+        "playbook:docs/runbooks/plat_observability.md#tracing-sampling"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "alert-storm-suppressor",
+      "watchers": [
+        "alert_storm_watch"
+      ],
+      "kpi": "alerts.per_minute",
+      "threshold": 50,
+      "window": "10m",
+      "action": "enable_alert_mitigation",
+      "owner": "sre@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/plat_observability.md#alert-storm"
+      ],
+      "rollback": "yes"
+    },
+    {
+      "hook": "policy-violation-freeze",
+      "watchers": [
+        "policy_violation_watch"
+      ],
+      "kpi": "policy.violation_detected",
+      "threshold": 1,
+      "window": "5m",
+      "action": "freeze_release",
+      "owner": "compliance@trendmarket",
+      "evidence": [
+        "playbook:docs/runbooks/plat_observability.md#policy-violation"
       ],
       "rollback": "yes"
     }


### PR DESCRIPTION
## Summary
- align ops/hooks/a110_hooks.json with the hooks defined in ops/hooks/a110.yml
- add watcher bindings and playbook evidence entries for the expanded hook set
- retain owner, rollback, and KPI metadata so downstream tooling can consume the inventory

## Testing
- python ops/scripts/hooks_dry_run.py --config ops/hooks/a110_hooks.json --output /tmp/hooks.json

------
https://chatgpt.com/codex/tasks/task_e_68d79ca037ac83309f08781a168965d2