### PR TITLE
Align SEC/PRIV vulnerability watchers to critical counts

### DIFF
--- a/docs/runbooks/ml_model_ops.md
+++ b/docs/runbooks/ml_model_ops.md
@@ -39,7 +39,7 @@
 
 ## image-vuln — `image_vuln_regression_watch`
 - **Hook:** `image-vuln-regression-block`
-- **KPI:** `image.critical_vuln_count` = 0 (janela 15m)
+- **KPI:** `image.critical_vuln_count` > 0 (janela 15m; meta = 0)
 - **Ação automática:** `block_release`
 - **Owner:** SEC + ML Ops
 - **Rollback:** após rebuild seguro e varredura limpa (Grype/Trivy).

--- a/docs/runbooks/sec_privacy.md
+++ b/docs/runbooks/sec_privacy.md
@@ -2,7 +2,7 @@
 
 ## dep-vuln — `dep_vuln_watch`
 - **Hook:** `dep-vuln-freeze`
-- **KPI:** `security.deps.critical_vulns` = 0 (janela 15m)
+- **KPI:** `security.deps.critical_vulns` > 0 (janela 15m; meta = 0)
 - **Ação automática:** `block_release`
 - **Owner:** Security Engineering
 - **Rollback:** após mitigação e varredura limpa.
@@ -13,7 +13,7 @@
 3. Rodar `make security.scan` e anexar relatório.
 
 ## image-vuln — `image_vuln_regression_watch`
-Seguir instruções do `docs/runbooks/ml_model_ops.md#image-vuln` com foco em supply chain.
+Seguir instruções do `docs/runbooks/ml_model_ops.md#image-vuln` com foco em supply chain (gatilho quando `image.critical_vuln_count` > 0 na janela de 15m).
 
 ## dp-budget — `dp_budget_breach_watch`
 - **Hook:** `dp-budget-freeze`

--- a/ops/hooks/a110.yml
+++ b/ops/hooks/a110.yml
@@ -111,7 +111,7 @@
         "image_vuln_regression_watch"
       ],
       "kpi": "image.critical_vuln_count",
-      "threshold": 0,
+      "threshold": ">0",
       "window": "15m",
       "action": "block_release",
       "owner": "SEC",
@@ -254,7 +254,7 @@
         "dep_vuln_watch"
       ],
       "kpi": "security.deps.critical_vulns",
-      "threshold": 0,
+      "threshold": ">0",
       "window": "15m",
       "action": "block_release",
       "owner": "SEC",

--- a/ops/watchers/sec_priv.yml
+++ b/ops/watchers/sec_priv.yml
@@ -3,19 +3,19 @@
   "watchers": [
     {
       "name": "dep_vuln_watch",
-      "kpi": "security.dependencies.cvss_max",
-      "threshold": ">=7.0",
-      "window": "24h",
+      "kpi": "security.deps.critical_vulns",
+      "threshold": ">0",
+      "window": "15m",
       "action": "block_release",
       "owner": "sec-priv@trendmarket",
       "rollback": "yes"
     },
     {
       "name": "image_vuln_regression_watch",
-      "kpi": "security.images.cvss_max",
-      "threshold": ">=7.0",
-      "window": "24h",
-      "action": "rollback_image",
+      "kpi": "image.critical_vuln_count",
+      "threshold": ">0",
+      "window": "15m",
+      "action": "block_release",
       "owner": "sec-priv@trendmarket",
       "rollback": "yes"
     },


### PR DESCRIPTION
## Summary
- update SEC/PRIV watcher definitions to guard on critical vulnerability counts with 15m windows
- sync matching Gate A110 hooks to the same KPI and threshold semantics
- refresh SEC/PRIV and ML runbooks to describe the new >0 triggering behaviour

## Testing
- ./scripts/watchers_dry.py
- ./scripts/hooks_dry.py *(fails: ops/hooks/a110.yml is stored as an object with per-hook entries, so the validator that expects a domain-aggregated list still aborts before checking thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_68d79ca5de34833083c4cdc590e190ee