### PR TITLE
Align FE CWV hook watcher mapping

### DIFF
--- a/ops/evidence/evidence.json
+++ b/ops/evidence/evidence.json
@@ -103,8 +103,8 @@
         "domain": "FE",
         "owner": "FE",
         "kpi": "web.cwv.inp_p75",
-        "hook": "web-cwv-rollback",
-        "hash": "10dc5fc4dc3c4f40beb91fed3f93e158c986ce819fec2c3ee03193f4d33a706d",
+        "hook": "fe-cwv-regression",
+        "hash": "9b421cdbff9a47f5a86cbbdca2df2c7b4137b863deec95bf2f40779098379042",
         "description": "Observa regressões de Core Web Vitals (INP p75).",
         "domains": ["FE"]
       },

--- a/ops/hooks/a110.yml
+++ b/ops/hooks/a110.yml
@@ -189,8 +189,7 @@
     {
       "hook": "fe-cwv-regression",
       "watchers": [
-        "web_cwv_regression_watch",
-        "api_breaking_change_watch"
+        "web_cwv_regression_watch"
       ],
       "kpi": "web.cwv.inp_p75",
       "threshold": "200ms",


### PR DESCRIPTION
## Summary
- remove `api_breaking_change_watch` from the `fe-cwv-regression` hook so it only follows the CWV watcher
- refresh evidence to reference the cleaned mapping and keep `api_breaking_change_watch` tied to `api-contract-block`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8630d94e88330b66b599c6a08c998