### PR TITLE
Add CLS payin hook and refresh evidence

### DIFF
--- a/ops/evidence/evidence.json
+++ b/ops/evidence/evidence.json
@@ -1,272 +1,329 @@
 {
-  "generated_at": "2025-09-27T20:10:26.318716+00:00",
-  "watchers_artifact": "ops/reports/watchers_dry.json",
-  "hooks_artifact": "ops/reports/hooks_dry.json",
-  "watchers_digest": "acc7e3641e7d0a0ba521176db8b857cad617c5a40e79ac3b1b6efe3534eaa5a6",
-  "hooks_digest": "69198f64b92da4213cb5fd251f78a9fa92c3847745c9ed3079c20c9933157a9b",
-  "watchers_count": 31,
+  "generated_at": "2025-09-27T22:22:24.436867+00:00",
+  "watchers_artifact": "/workspace/trendmarket/ops/reports/watchers_dry.json",
+  "hooks_artifact": "/workspace/trendmarket/ops/reports/hooks_dry.json",
+  "watchers_digest": "0205abb9399a5004413a78e859967abff199b04ab0cc25b1e9cb4fe544e82e88",
+  "hooks_digest": "e8d4ab90d40477f5f9fe4e79874d9574023b9ccf529b0e4e3fdfef83d0611674",
+  "watchers_count": 26,
   "hooks_count": 26,
   "evidence": {
     "watchers": [
       {
-        "id": "cdc_lag_watch",
-        "domain": "DATA",
-        "owner": "DATA",
-        "kpi": "cdc.lag.p95",
-        "hook": "cdc-lag-hot-degrade",
-        "hash": "15fd7ba001ba83c9dff823bbb0985133afe7d8fc8fcdb62f3f412d13488fe684",
         "description": "Acompanha lag CDC p95 contra o contrato de dados.",
-        "domains": ["DATA"]
+        "domain": "DATA",
+        "domains": [
+          "DATA"
+        ],
+        "hook_id": "cdc-lag-hot-degrade",
+        "id": "cdc_lag_watch",
+        "kpi": "cdc.lag.p95",
+        "owner": "DATA",
+        "hash": "0dc8811eb1e1894ea6f1c12e5adf9347223377db1b718231d2a35d0295da3203"
       },
       {
-        "id": "data_contract_break_watch",
-        "domain": "DATA",
-        "owner": "DATA",
-        "kpi": "data.contract.break",
-        "hook": "data-contract-breach-guard",
-        "hash": "ae1cffab19691d69984313e78e699b21a26b9fcb32ddf8ab5484f51d5618f657",
         "description": "Quebra de contrato de dados A106/A87/A89.",
-        "domains": ["DATA"]
+        "domain": "DATA",
+        "domains": [
+          "DATA"
+        ],
+        "hook_id": "data-contract-breach-guard",
+        "id": "data_contract_break_watch",
+        "kpi": "data.contract.break",
+        "owner": "DATA",
+        "hash": "0e451f1ed0cd8a2f4ed1e81e484cac7aa94bb9010450122df6c6b39ec5ecf775"
       },
       {
-        "id": "dbt_test_failure_watch",
-        "domain": "DATA",
-        "owner": "DATA",
-        "kpi": "dbt.tests.failure_rate",
-        "hook": "dbt-test-rollback",
-        "hash": "fb02c04d8d9983bd0052edc1fedccdd699366ccef890723fb2f113c37e5f8c10",
         "description": "Flag de falhas de testes dbt críticos.",
-        "domains": ["DATA"]
+        "domain": "DATA",
+        "domains": [
+          "DATA"
+        ],
+        "hook_id": "dbt-test-rollback",
+        "id": "dbt_test_failure_watch",
+        "kpi": "dbt.tests.failure_rate",
+        "owner": "DATA",
+        "hash": "512d106e1ff2db263cbc11eda962890b7b683e976f559dc07cade7a1a709a404"
       },
       {
-        "id": "doc_coverage_watch",
-        "domain": "DATA",
-        "owner": "DATA",
-        "kpi": "data.doc.coverage",
-        "hook": "doc-coverage-gap",
-        "hash": "53940df6c56bff0ae118e5e965b50cf0bfb3f44c4f201debe3bd3f6953ff2914",
         "description": "Garante cobertura de documentação mínima das pipelines.",
-        "domains": ["DATA"]
-      },
-      {
-        "id": "schema_registry_drift_watch",
         "domain": "DATA",
+        "domains": [
+          "DATA"
+        ],
+        "hook_id": "doc-coverage-gap",
+        "id": "doc_coverage_watch",
+        "kpi": "data.doc.coverage",
         "owner": "DATA",
-        "kpi": "schema.drift_detected",
-        "hook": "schema-drift-blocker",
-        "hash": "42e20d0cb3b3c898ae785b21371fc34b665947f7478ba6553f0ce7baaa150b0c",
+        "hash": "4fc16321f4e4bc063b0b5ba1e19e57c399a82c2e9a96e0eada7059c23b8cecf7"
+      },
+      {
         "description": "Detecta incompatibilidades no schema registry.",
-        "domains": ["DATA"]
+        "domain": "DATA",
+        "domains": [
+          "DATA"
+        ],
+        "hook_id": "schema-drift-blocker",
+        "id": "schema_registry_drift_watch",
+        "kpi": "schema.drift_detected",
+        "owner": "DATA",
+        "hash": "7df43024fac63c8f62e6f9dde45f2e008be400b56b3fa74bfbbc0c625914264c"
       },
       {
-        "id": "metrics_decision_hook_gap_watch",
-        "domain": "DEC",
-        "owner": "SRE",
-        "kpi": "dec.latency.p95",
-        "hook": "dec-latency-gap",
-        "hash": "795bfb476e5cce514ed1f7e1353e0932c0210fb3ddeffdadf0a7670d14dfdc28",
         "description": "Garante que a latência DEC permaneça dentro dos limites antes de alterar rotas.",
-        "domains": ["DEC"]
+        "domain": "DEC",
+        "domains": [
+          "DEC"
+        ],
+        "hook_id": "dec-latency-degrade",
+        "id": "metrics_decision_hook_gap_watch",
+        "kpi": "dec.latency.p95",
+        "owner": "SRE",
+        "hash": "df96683c39890d93d60a9d06123722898bc89752af504420eb42b1b21307a48c"
       },
       {
-        "id": "model_drift_watch",
-        "domain": "DEC",
-        "owner": "ML",
-        "kpi": "model.psi",
-        "hook": "model-drift-rollback",
-        "hash": "1d1f27faf6da3d14ba450fc433b33d81306c3289bc72d7f3f0375a4cd1058ead",
         "description": "Detecta drift estatístico relevante para decisões de crédito.",
-        "domains": ["DEC", "ML"]
-      },
-      {
-        "id": "slo_budget_breach_watch",
         "domain": "DEC",
-        "owner": "SRE",
-        "kpi": "slo.burn_rate",
-        "hook": "slo-burn-rate-guard",
-        "hash": "57a9e2c019f2f9db385c1af6d5278f732a9cfbe11ea9f4288eba0d71e0a5816e",
-        "description": "Monitora burn rate do SLO cross-domain.",
-        "domains": ["DEC", "PLAT", "PM"]
-      },
-      {
-        "id": "api_breaking_change_watch",
-        "domain": "FE",
-        "owner": "INT",
-        "kpi": "api.contract.breaking_changes",
-        "hook": "api-contract-block",
-        "hash": "5d7bbadfeee5467c5b361d093fe9611f630a00fec367b4b0d23364b5f85a2d91",
-        "description": "Previne quebras de contrato de APIs públicas/internas.",
-        "domains": ["FE", "INT"]
-      },
-      {
-        "id": "web_cwv_regression_watch",
-        "domain": "FE",
-        "owner": "FE",
-        "kpi": "web.cwv.inp_p75",
-        "hook": "web-cwv-rollback",
-        "hash": "10dc5fc4dc3c4f40beb91fed3f93e158c986ce819fec2c3ee03193f4d33a706d",
-        "description": "Observa regressões de Core Web Vitals (INP p75).",
-        "domains": ["FE"]
-      },
-      {
-        "id": "cache_ttl_misuse_watch",
-        "domain": "INT",
-        "owner": "INT",
-        "kpi": "integration.cache_ttl_violation_pct",
-        "hook": "cache-ttl-block",
-        "hash": "ba92c760699093a33d14a3e9fa487df06bca5b7daf69321b936625e4e9c656ea",
-        "description": "Flag para TTL incorreto em caches compartilhados.",
-        "domains": ["INT"]
-      },
-      {
-        "id": "cls_payin_cutoff_watch",
-        "domain": "INT",
-        "owner": "INT",
-        "kpi": "integration.cls_payin_cutoff_delay_ms",
-        "hook": "cls-payin-cutover",
-        "hash": "f527e8075db337277afe9da71e456ead04f9f320b1e0a8547a52f64efdd401ba",
-        "description": "Garante que o cutoff CLS payin seja seguido sem atraso.",
-        "domains": ["INT"]
-      },
-      {
-        "id": "ab_srm_watch",
-        "domain": "ML",
+        "domains": [
+          "DEC",
+          "ML"
+        ],
+        "hook_id": "dec-latency-degrade",
+        "id": "model_drift_watch",
+        "kpi": "model.psi",
         "owner": "ML",
-        "kpi": "experiment.srm_pvalue",
-        "hook": "experiment-srm-guardrail",
-        "hash": "90ea6b211ecf6502e88a5606471d17b6b7e6ffd1e1f58f6d0773b0725eeba31d",
+        "hash": "1eef2a5f2bca037d8dbd5f943836b34dfbecb82b116421321a76aa5b719b2b42"
+      },
+      {
+        "description": "Monitora burn rate do SLO cross-domain.",
+        "domain": "DEC",
+        "domains": [
+          "DEC",
+          "PM",
+          "PLAT"
+        ],
+        "hook_id": "slo-burn-rate-guard",
+        "id": "slo_budget_breach_watch",
+        "kpi": "slo.burn_rate",
+        "owner": "SRE",
+        "hash": "654f18ce37feada1539b0ec58eb70ff0ff16e5ff80e0206da653fe189744a07b"
+      },
+      {
+        "description": "Previne quebras de contrato de APIs públicas/internas.",
+        "domain": "FE",
+        "domains": [
+          "FE",
+          "INT"
+        ],
+        "hook_id": "api-contract-block",
+        "id": "api_breaking_change_watch",
+        "kpi": "api.contract.breaking_changes",
+        "owner": "INT",
+        "hash": "843bc0690412d9a155bd1da88b6bd1d34f72ae70c67ed49494d034831f8c5911"
+      },
+      {
+        "description": "Observa regressões de Core Web Vitals (INP p75).",
+        "domain": "FE",
+        "domains": [
+          "FE"
+        ],
+        "hook_id": "fe-cwv-regression",
+        "id": "web_cwv_regression_watch",
+        "kpi": "web.cwv.inp_p75",
+        "owner": "FE",
+        "hash": "0ba2ee6d268cee8299b772c276909094cfa6a6b925e2a6329482c4dcb2bbc9d8"
+      },
+      {
+        "description": "Flag para TTL incorreto em caches compartilhados.",
+        "domain": "INT",
+        "domains": [
+          "INT"
+        ],
+        "hook_id": "cache-ttl-block",
+        "id": "cache_ttl_misuse_watch",
+        "kpi": "integration.cache_ttl_violation_pct",
+        "owner": "INT",
+        "hash": "a29a9396679cc710af1d62d56f69fee163476d63611ee3b0bf5d88b081c86860"
+      },
+      {
+        "description": "Garante que o cutoff CLS payin seja seguido sem atraso.",
+        "domain": "INT",
+        "domains": [
+          "INT"
+        ],
+        "hook_id": "cls-payin-cutover",
+        "id": "cls_payin_cutoff_watch",
+        "kpi": "integration.cls_payin_cutoff_delay_ms",
+        "owner": "INT",
+        "hash": "e7ba374a1b1816860de09880dfd42900d539bcf10c35c90953f7c3d9e2d475e8"
+      },
+      {
         "description": "Detecta falhas de SRM em experimentos e testes AA.",
-        "domains": ["ML"]
+        "domain": "ML",
+        "domains": [
+          "ML"
+        ],
+        "hook_id": "experiment-srm-guardrail",
+        "id": "ab_srm_watch",
+        "kpi": "experiment.srm_pvalue",
+        "owner": "ML",
+        "hash": "40c34cb4f5fc4efaf75af08c8f596717fedddfbe72f4b787a1b5f9b6e80d5a40"
       },
       {
-        "id": "image_vuln_regression_watch",
-        "domain": "ML",
-        "owner": "SEC",
-        "kpi": "image.critical_vuln_count",
-        "hook": "image-vuln-regression-block",
-        "hash": "0be058a3cf16abeabc2ea872a4615b8edb1b4e7fe55921e2f1c90cc2558fbc9b",
         "description": "Bloqueia regressão de vulnerabilidades críticas em imagens.",
-        "domains": ["ML", "SEC/PRIV"]
-      },
-      {
-        "id": "runtime_eol_watch",
         "domain": "ML",
-        "owner": "PLAT",
-        "kpi": "runtime.support_gap_days",
-        "hook": "runtime-eol-governance",
-        "hash": "8bb782ef243c4a433542fb0be2b4e1e33eb75107c2c276b66394548b60846060",
+        "domains": [
+          "ML",
+          "SEC/PRIV"
+        ],
+        "hook_id": "image-vuln-regression-block",
+        "id": "image_vuln_regression_watch",
+        "kpi": "image.critical_vuln_count",
+        "owner": "SEC",
+        "hash": "293a4790a7e43e8985be136eab9551cd898962a481a069eafc94183e5ca1a662"
+      },
+      {
         "description": "Aponta runtimes em fim de vida para evitar builds inseguras.",
-        "domains": ["ML"]
+        "domain": "ML",
+        "domains": [
+          "ML"
+        ],
+        "hook_id": "runtime-eol-governance",
+        "id": "runtime_eol_watch",
+        "kpi": "runtime.support_gap_days",
+        "owner": "PLAT",
+        "hash": "097ac976a804480f39645e2094f7d24b52e103519ea0e41ff4328972e1e9e03d"
       },
       {
-        "id": "alert_storm_watch",
-        "domain": "PLAT",
-        "owner": "SRE",
-        "kpi": "alerts.per_minute",
-        "hook": "alert-storm-suppressor",
-        "hash": "32f699dad27858c69d17b1707111661d6fc46d0b7022e9a7f2b223fe0f0aa2bf",
         "description": "Detecta tempestades de alertas indicando ruído ou incidentes generalizados.",
-        "domains": ["PLAT"]
-      },
-      {
-        "id": "okr_risk_alignment_watch",
         "domain": "PLAT",
-        "owner": "StrategyOps",
-        "kpi": "okr.risk_alignment_score",
-        "hook": "okr-alignment-escalation",
-        "hash": "d5238e8583445b6e91743f2b4e6b15cc8829b1fa719dc2cf8263ddfdfcad8ee5",
-        "description": "Monitora desalinhamento de riscos com OKRs estratégicos.",
-        "domains": ["PLAT"]
-      },
-      {
-        "id": "policy_violation_watch",
-        "domain": "PLAT",
-        "owner": "Compliance",
-        "kpi": "policy.violation_detected",
-        "hook": "policy-violation-freeze",
-        "hash": "f4fa82cb5d3993cb8ee4cbc1f93c32595fcbe0e5d7db726713fc478fd5a2d662",
-        "description": "Garante que políticas operacionais/compliance permaneçam sem violações.",
-        "domains": ["PLAT"]
-      },
-      {
-        "id": "tracing_sampling_watch",
-        "domain": "PLAT",
+        "domains": [
+          "PLAT"
+        ],
+        "hook_id": "alert-storm-suppressor",
+        "id": "alert_storm_watch",
+        "kpi": "alerts.per_minute",
         "owner": "SRE",
-        "kpi": "tracing.sampling_rate",
-        "hook": "tracing-sampling-freeze",
-        "hash": "2214975b95da58de23f0e5f68e77af241e6241851aa17c45ffd4d1bf9b07c68c",
+        "hash": "427bdd3d4096cea9646d40b4c782f74d1a8adffdf03b6877a7e5b7db8e57800d"
+      },
+      {
+        "description": "Monitora desalinhamento de riscos com OKRs estratégicos.",
+        "domain": "PLAT",
+        "domains": [
+          "PLAT"
+        ],
+        "hook_id": "okr-alignment-escalation",
+        "id": "okr_risk_alignment_watch",
+        "kpi": "okr.risk_alignment_score",
+        "owner": "StrategyOps",
+        "hash": "cd0f778ba38ea88b8b376f5b39ec9affe6e5e15649f28493cab47fb43f87a6bd"
+      },
+      {
+        "description": "Garante que políticas operacionais/compliance permaneçam sem violações.",
+        "domain": "PLAT",
+        "domains": [
+          "PLAT"
+        ],
+        "hook_id": "policy-violation-freeze",
+        "id": "policy_violation_watch",
+        "kpi": "policy.violation_detected",
+        "owner": "Compliance",
+        "hash": "9670730d1d52af8176b20429e4957d2da30acffae70c58c615be3ad2c7c18d45"
+      },
+      {
         "description": "Monitora taxa de amostragem do tracing distribuído.",
-        "domains": ["PLAT"]
+        "domain": "PLAT",
+        "domains": [
+          "PLAT"
+        ],
+        "hook_id": "tracing-sampling-freeze",
+        "id": "tracing_sampling_watch",
+        "kpi": "tracing.sampling_rate",
+        "owner": "SRE",
+        "hash": "290852a0d647d1724f286caec2aa7c3d2fa5d3310e8fb750fb1f838f1bd3baa2"
       },
       {
-        "id": "auction_invariant_breach_watch",
-        "domain": "PM",
-        "owner": "PM",
-        "kpi": "auction.kkt_violation_pct",
-        "hook": "auction-invariant-pause",
-        "hash": "37c3882cc16ee5ef241f4c760ca125a89b29ae93f945e14faebbb937882dbc9b",
         "description": "Fiscaliza invariantes KKT e convexidade nos leilões.",
-        "domains": ["PM"]
+        "domain": "PM",
+        "domains": [
+          "PM"
+        ],
+        "hook_id": "auction-invariant-pause",
+        "id": "auction_invariant_breach_watch",
+        "kpi": "auction.kkt_violation_pct",
+        "owner": "PM",
+        "hash": "aa6e89c0bd50288e013457b46b8a0847729eb96b581fa1b9b0ba184b13704a32"
       },
       {
-        "id": "fx_delta_benchmark_watch",
-        "domain": "PM",
-        "owner": "PM",
-        "kpi": "fx.delta_vs_benchmark_bps",
-        "hook": "fx-delta-benchmark-guard",
-        "hash": "8f47bec24244e9092048358b6cab353cbe1e025d0909f72806f8dd109fdb2541",
         "description": "Compara delta FX com benchmark para evitar arbitragem.",
-        "domains": ["PM"]
-      },
-      {
-        "id": "oracle_divergence_watch",
         "domain": "PM",
+        "domains": [
+          "PM"
+        ],
+        "hook_id": "fx-delta-benchmark-guard",
+        "id": "fx_delta_benchmark_watch",
+        "kpi": "fx.delta_vs_benchmark_bps",
         "owner": "PM",
-        "kpi": "oracle.divergence_bps",
-        "hook": "oracle-staleness-failover",
-        "hash": "045a11e3dc6701614358513489313219f84929700b112245e9da7fa1061c9897",
+        "hash": "1fa7cf27227865e006043d0ce78692767d3b948503fcf74d84daa7ecc93cc498"
+      },
+      {
         "description": "Detecta divergência de preço entre oráculos e referência.",
-        "domains": ["PM"]
+        "domain": "PM",
+        "domains": [
+          "PM"
+        ],
+        "hook_id": "pm-oracle-staleness",
+        "id": "oracle_divergence_watch",
+        "kpi": "oracle.divergence_bps",
+        "owner": "PM",
+        "hash": "3e81a13ec7634e94d0eb0906813d7488137c9d702c1719d7a0c1d9570ada7b79"
       },
       {
-        "id": "dep_vuln_watch",
-        "domain": "SEC/PRIV",
-        "owner": "SEC",
-        "kpi": "security.deps.critical_vulns",
-        "hook": "dep-vuln-freeze",
-        "hash": "8d894368d04d7e40defb617fabb4414dfa56bab70dc5880fec1b7e17e79ec2d3",
         "description": "Bloqueia releases com vulnerabilidades críticas em dependências.",
-        "domains": ["SEC/PRIV"]
+        "domain": "SEC/PRIV",
+        "domains": [
+          "SEC/PRIV"
+        ],
+        "hook_id": "dep-vuln-freeze",
+        "id": "dep_vuln_watch",
+        "kpi": "security.deps.critical_vulns",
+        "owner": "SEC",
+        "hash": "7d6d684abafee8dc8b2bbf0a40df91dd849fe898433fe237595df4777bfc69ec"
       },
       {
-        "id": "dp_budget_breach_watch",
-        "domain": "SEC/PRIV",
-        "owner": "SEC",
-        "kpi": "privacy.dp_budget_multiplier",
-        "hook": "dp-budget-freeze",
-        "hash": "64d4a05f5cc5f1944acbb35409e5d5255ff4d2182dde0b939fbf0e8d4a5929fa",
         "description": "Garante que o budget de privacidade diferencial não estoure.",
-        "domains": ["SEC/PRIV"]
+        "domain": "SEC/PRIV",
+        "domains": [
+          "SEC/PRIV"
+        ],
+        "hook_id": "dp-budget-freeze",
+        "id": "dp_budget_breach_watch",
+        "kpi": "privacy.dp_budget_multiplier",
+        "owner": "SEC",
+        "hash": "d79b6636d58ce2790bd3a74f3370c4a386ba6cf6edee725139137046fdfe3b7f"
       },
       {
-        "id": "formal_verification_gate_watch",
-        "domain": "SEC/PRIV",
-        "owner": "SEC",
-        "kpi": "formal.verification.failure",
-        "hook": "formal-verification-freeze",
-        "hash": "e57aefa70c3c2f641f70053ad2bb7e60186b8c8a5a6fa4c19fe6335796f9efb3",
         "description": "Sinaliza falha em gates formais (A108/segurança).",
-        "domains": ["SEC/PRIV"]
+        "domain": "SEC/PRIV",
+        "domains": [
+          "SEC/PRIV"
+        ],
+        "hook_id": "formal-verification-freeze",
+        "id": "formal_verification_gate_watch",
+        "kpi": "formal.verification.failure",
+        "owner": "SEC",
+        "hash": "d91a2613e2b71cf0b5d11ef4cc2d0506a600e38bb2f0ee8ac6314b1a5dde7b61"
       },
       {
-        "id": "idp_keys_rotation_watch",
-        "domain": "SEC/PRIV",
-        "owner": "SEC",
-        "kpi": "security.idp.keys_age_days",
-        "hook": "idp-keys-rotation",
-        "hash": "afcb896d9604c656132ac220732a68ebc70fcf0e86b407222833d5ecd9a6dc3e",
         "description": "Enforce rotação de chaves/segredos do IdP.",
-        "domains": ["SEC/PRIV"]
+        "domain": "SEC/PRIV",
+        "domains": [
+          "SEC/PRIV"
+        ],
+        "hook_id": "idp-keys-rotation",
+        "id": "idp_keys_rotation_watch",
+        "kpi": "security.idp.keys_age_days",
+        "owner": "SEC",
+        "hash": "194244934af32923c6792db2d3533e693b2d18171f20ed70199ab67fc45c9db6"
       }
     ],
     "hooks": [
@@ -276,16 +333,15 @@
         "threshold": "800ms",
         "window": "5m",
         "action": "degrade_route",
-        "owner": "dec-duty@trendmarket",
+        "owner": "SRE",
         "rollback": true,
         "evidence": [
-          "traces:decision.core",
-          "playbook:docs/runbooks/dec_decision_pricing.md#metric-gap"
+          "playbook:docs/runbooks/dec_decision_pricing.md#model-drift-dec"
         ],
-        "hash": "4f388f4a01aa9b5a1c92808b8bcb0b5cb0fb5bc1a85b7bed18da327c59c56cf8"
+        "hash": "f7b399c53d02a7b2117c280cba600f3a470d9f686539aaeef5ac74358e8be78e"
       },
       {
-        "hook": "model-drift-rollback",
+        "hook": "ml-model-rollback",
         "kpi": "model.psi",
         "threshold": 0.2,
         "window": "24h",
@@ -293,6 +349,333 @@
         "owner": "ml-ops@trendmarket",
         "rollback": true,
         "evidence": [
-          "metrics:ml.psi",
-          "experiments:srm",
-          "playbook:docs/runbooks/ml_model_ops
+          "playbook:docs/runbooks/ml_model_ops.md#model-drift"
+        ],
+        "hash": "563ea0dbb87b4469082f19cb87788923d6c2411135eb6b0bd26dbfc8d3cf3f84"
+      },
+      {
+        "hook": "slo-burn-rate-guard",
+        "kpi": "slo.burn_rate",
+        "threshold": 1.0,
+        "window": "60m",
+        "action": "enforce_release_freeze",
+        "owner": "sre@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/plat_observability.md#slo-burn"
+        ],
+        "hash": "4978e54ef08c3ac405272db66eca36306827cee7e6ebbc024b3d865a91bd1f8e"
+      },
+      {
+        "hook": "oracle-staleness-failover",
+        "kpi": "oracle.divergence_bps",
+        "threshold": 5,
+        "window": "10m",
+        "action": "switch_to_twap_failover",
+        "owner": "PM",
+        "rollback": true,
+        "evidence": [
+          "audit:oracles/weekly",
+          "playbook:docs/runbooks/pm_market_health.md#oracle-divergence"
+        ],
+        "hash": "ae2582a4579bc794c4645da7cbee914c3ecb64e9103d88bb4e79d09c2e1b2266"
+      },
+      {
+        "hook": "fx-delta-benchmark-guard",
+        "kpi": "fx.delta_vs_benchmark_bps",
+        "threshold": 15,
+        "window": "10m",
+        "action": "switch_to_reference_rate",
+        "owner": "pm-ops@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/pm_market_health.md#fx-delta"
+        ],
+        "hash": "a4021eb32c14179fa4001f0afcb8ee49168507cbc50b626bd2af254c99bc4830"
+      },
+      {
+        "hook": "auction-invariant-pause",
+        "kpi": "auction.kkt_violation_pct",
+        "threshold": 0.0,
+        "window": "5m",
+        "action": "pause_auction_stream",
+        "owner": "pm-ops@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/pm_market_health.md#auction-invariant"
+        ],
+        "hash": "ec6b1f2612f2fea4e393578a0cf92e52743f0ad618ee4b89c067f2ccee2b6ea8"
+      },
+      {
+        "hook": "experiment-srm-guardrail",
+        "kpi": "experiment.srm_pvalue",
+        "threshold": 0.01,
+        "window": "24h",
+        "action": "pause_experiment",
+        "owner": "ml-ops@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/ml_model_ops.md#srm"
+        ],
+        "hash": "33dabf513a34d8d8a50430a7a2be7258d9054b02c1960fd349104037e4967a84"
+      },
+      {
+        "hook": "runtime-eol-governance",
+        "kpi": "runtime.support_gap_days",
+        "threshold": 0,
+        "window": "7d",
+        "action": "schedule_runtime_upgrade",
+        "owner": "platform@trendmarket",
+        "rollback": false,
+        "evidence": [
+          "playbook:docs/runbooks/ml_model_ops.md#runtime-eol"
+        ],
+        "hash": "7d682944c100af58e81c02cf1607d1856ea3dcd36192ee923ba2d29603c8d737"
+      },
+      {
+        "hook": "image-vuln-regression-block",
+        "kpi": "image.critical_vuln_count",
+        "threshold": 0,
+        "window": "15m",
+        "action": "block_release",
+        "owner": "sec-priv@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/sec_privacy.md#image-vuln"
+        ],
+        "hash": "605160d59f1398348a0e67361e545bfe058985ac6a4f1c5d9dfb9f9e4cb3f039"
+      },
+      {
+        "hook": "cdc-lag-hot-degrade",
+        "kpi": "cdc.lag.p95",
+        "threshold": "120s",
+        "window": "15m",
+        "action": "degrade_to_hot_table",
+        "owner": "data-quality@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/data_contracts.md#cdc-lag"
+        ],
+        "hash": "5e26d03530f29ea1ebe330cc7c120a43afae5865bfa4b29fa93531b80a1c93c8"
+      },
+      {
+        "hook": "schema-drift-blocker",
+        "kpi": "schema.drift_detected",
+        "threshold": 1,
+        "window": "5m",
+        "action": "block_deploy",
+        "owner": "data-quality@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/data_contracts.md#schema-drift"
+        ],
+        "hash": "804f435279eefc6febed7b229a7e65e0d420e43de3b2d23be70eba0a8b52b868"
+      },
+      {
+        "hook": "dbt-test-rollback",
+        "kpi": "dbt.tests.failure_rate",
+        "threshold": 0,
+        "window": "15m",
+        "action": "rollback_transform",
+        "owner": "data-quality@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/data_contracts.md#dbt-tests"
+        ],
+        "hash": "0c57ad0e0c2c005a7974b3fcf3a86ff3fee7d5316206c4da1488ebfa912a9646"
+      },
+      {
+        "hook": "data-contract-breach-guard",
+        "kpi": "data.contract.break",
+        "threshold": 1,
+        "window": "5m",
+        "action": "trigger_contract_waiver",
+        "owner": "data-quality@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "contracts:a106",
+          "contracts:a87",
+          "playbook:docs/runbooks/data_contracts.md#contract-breach"
+        ],
+        "hash": "894a155c61a90103d291dfb19c9b8704151a4d006ae45c66dff4391c6a184866"
+      },
+      {
+        "hook": "doc-coverage-gap",
+        "kpi": "data.doc.coverage",
+        "threshold": 0.95,
+        "window": "24h",
+        "action": "raise_doc_gap",
+        "owner": "data-quality@trendmarket",
+        "rollback": false,
+        "evidence": [
+          "playbook:docs/runbooks/data_contracts.md#doc-coverage"
+        ],
+        "hash": "f1033f1940777f7a39d44f9818fe38a7197d3cd55ae4109e8a6526df7c0e4551"
+      },
+      {
+        "hook": "web-cwv-rollback",
+        "kpi": "web.cwv.inp_p75",
+        "threshold": "200ms",
+        "window": "24h",
+        "action": "rollback_fe_release",
+        "owner": "FE",
+        "rollback": true,
+        "evidence": [
+          "lighthouse:cwv",
+          "sdk:contract",
+          "playbook:docs/runbooks/fe_experience.md#web-cwv"
+        ],
+        "hash": "c0d333b6c4566970893218feb09937f03cc118d3886a39453e8182c6403d2e12"
+      },
+      {
+        "hook": "api-contract-block",
+        "kpi": "api.contract.breaking_changes",
+        "threshold": 0,
+        "window": "5m",
+        "action": "block_release",
+        "owner": "integration@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "tests:contract",
+          "synthetics:cls",
+          "playbook:docs/runbooks/int_integrations.md#api-breaking"
+        ],
+        "hash": "d02cf5ee4a1abfb8d82cb76fca8050ee1c6dd1c7c3659a4fca44d297637e7ac0"
+      },
+      {
+        "hook": "formal-verification-freeze",
+        "kpi": "formal.verification.failure",
+        "threshold": 1,
+        "window": "5m",
+        "action": "freeze_pipeline",
+        "owner": "sec-priv@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/sec_privacy.md#formal-verification"
+        ],
+        "hash": "9cb072ce7f233edce7e68f302639e54712bcd1dfa21d1dd4960fdfe614eb0a45"
+      },
+      {
+        "hook": "okr-alignment-escalation",
+        "kpi": "okr.risk_alignment_score",
+        "threshold": 0.8,
+        "window": "7d",
+        "action": "escalate_exec_review",
+        "owner": "strategyops@trendmarket",
+        "rollback": false,
+        "evidence": [
+          "playbook:docs/runbooks/plat_observability.md#okr-alignment"
+        ],
+        "hash": "ea84483b6ddce6866d83a9cb767bcd3c44e768d6c09c5a7292b33dfd817624e6"
+      },
+      {
+        "hook": "dp-budget-freeze",
+        "kpi": "privacy.dp_budget_multiplier",
+        "threshold": 1.5,
+        "window": "60m",
+        "action": "freeze_processing",
+        "owner": "sec-priv@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "sbom:latest",
+          "audit:privacy",
+          "playbook:docs/runbooks/sec_privacy.md#dp-budget"
+        ],
+        "hash": "6dc7ce38c44d902c2d5f7b13b7c46bdd776410389b10dcb0761216d718700e47"
+      },
+      {
+        "hook": "dep-vuln-freeze",
+        "kpi": "security.deps.critical_vulns",
+        "threshold": 0,
+        "window": "15m",
+        "action": "block_release",
+        "owner": "sec-priv@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/sec_privacy.md#dep-vuln"
+        ],
+        "hash": "6f9a07cb2739097dd119c9b7b0cafdbac85fbfdb42cf3871cef44904a4496686"
+      },
+      {
+        "hook": "idp-keys-rotation",
+        "kpi": "security.idp.keys_age_days",
+        "threshold": 90,
+        "window": "1d",
+        "action": "rotate_idp_keys",
+        "owner": "sec-priv@trendmarket",
+        "rollback": false,
+        "evidence": [
+          "playbook:docs/runbooks/sec_privacy.md#idp-keys"
+        ],
+        "hash": "dae3d2c51923b9c5e851c29ce16a3839c823a8ce3f86e59768471e690fb691b2"
+      },
+      {
+        "hook": "cache-ttl-block",
+        "kpi": "integration.cache_ttl_violation_pct",
+        "threshold": 0,
+        "window": "10m",
+        "action": "block_release",
+        "owner": "integration@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/int_integrations.md#cache-ttl"
+        ],
+        "hash": "cd7de4f4f302aa8b516c22725dcfd1440540b71d08e58a8ee5b4c33dc928ffde"
+      },
+      {
+        "hook": "cls-payin-cutover",
+        "kpi": "integration.cls_payin_cutoff_delay_ms",
+        "threshold": 30000,
+        "window": "5m",
+        "action": "switch_to_manual_cutoff",
+        "owner": "integration@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/int_integrations.md#cls-payin"
+        ],
+        "hash": "f9657723871f0893c3f37446fe00b338c1d51ced81bb24513a61a97aa5df388c"
+      },
+      {
+        "hook": "tracing-sampling-freeze",
+        "kpi": "tracing.sampling_rate",
+        "threshold": 0.01,
+        "window": "15m",
+        "action": "block_release",
+        "owner": "sre@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "traces:otel",
+          "alerts:platform",
+          "playbook:docs/runbooks/plat_observability.md#tracing-sampling"
+        ],
+        "hash": "ab2efe08b78eeb866305723f0b866597871e0eaa7a3ad346f10755b84d51b1d8"
+      },
+      {
+        "hook": "alert-storm-suppressor",
+        "kpi": "alerts.per_minute",
+        "threshold": 50,
+        "window": "10m",
+        "action": "enable_alert_mitigation",
+        "owner": "sre@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/plat_observability.md#alert-storm"
+        ],
+        "hash": "8b96c5a5e5337cdcbbe4ba1c0c7509fa10e09966f5bf0962a6bbc4d62f88f1a1"
+      },
+      {
+        "hook": "policy-violation-freeze",
+        "kpi": "policy.violation_detected",
+        "threshold": 1,
+        "window": "5m",
+        "action": "freeze_release",
+        "owner": "compliance@trendmarket",
+        "rollback": true,
+        "evidence": [
+          "playbook:docs/runbooks/plat_observability.md#policy-violation"
+        ],
+        "hash": "4e7f0764fede446f682f071040640800fd3eca363f3a3b5b90f960ffe6589c84"
+      }
+    ]
+  }
+}

--- a/ops/hooks/a110.yml
+++ b/ops/hooks/a110.yml
@@ -214,6 +214,19 @@
       "playbook": "docs/runbooks/int_integrations.md#api-breaking"
     },
     {
+      "hook": "cls-payin-cutover",
+      "watchers": [
+        "cls_payin_cutoff_watch"
+      ],
+      "kpi": "integration.cls_payin_cutoff_delay_ms",
+      "threshold": 30000,
+      "window": "5m",
+      "action": "switch_to_manual_cutoff",
+      "owner": "INT/Payments",
+      "rollback": true,
+      "playbook": "docs/runbooks/int_integrations.md#cls-payin"
+    },
+    {
       "hook": "formal-verification-freeze",
       "watchers": [
         "formal_verification_gate_watch"
@@ -237,3 +250,7 @@
       "action": "escalate_exec_review",
       "owner": "StrategyOps",
       "rollback": false,
+      "playbook": "docs/runbooks/plat_observability.md#okr-alignment"
+    }
+  ]
+}

--- a/ops/reports/hooks_dry.json
+++ b/ops/reports/hooks_dry.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2025-09-27T20:15:00+00:00",
-  "source": "ops/hooks/a110.yml",
-  "total_hooks": 29,
+  "generated_at": "2025-09-27T22:22:22.800739+00:00",
+  "source": "/workspace/trendmarket/ops/hooks/a110_hooks.json",
+  "total_hooks": 26,
   "hooks": [
     {
       "hook": "dec-latency-gap",
@@ -12,22 +12,9 @@
       "owner": "SRE",
       "rollback": true,
       "evidence": [
-        "playbook:docs/runbooks/dec_decision_pricing.md#metric-gap"
-      ],
-      "hash": "f7b399c53d02a7b2117c280cba600f3a470d9f686539aaeef5ac74358e8be78e"
-    },
-    {
-      "hook": "dec-latency-degrade",
-      "kpi": "dec.latency.p95",
-      "threshold": "800ms",
-      "window": "5m",
-      "action": "degrade_route",
-      "owner": "SRE",
-      "rollback": true,
-      "evidence": [
         "playbook:docs/runbooks/dec_decision_pricing.md#model-drift-dec"
       ],
-      "hash": "cf694130d460480b4ed3ab64f2dcc0bd4e8843a966fdf920ef87d4796023bca9"
+      "hash": "f7b399c53d02a7b2117c280cba600f3a470d9f686539aaeef5ac74358e8be78e"
     },
     {
       "hook": "ml-model-rollback",
@@ -35,12 +22,12 @@
       "threshold": 0.2,
       "window": "24h",
       "action": "rollback_model",
-      "owner": "ML",
+      "owner": "ml-ops@trendmarket",
       "rollback": true,
       "evidence": [
         "playbook:docs/runbooks/ml_model_ops.md#model-drift"
       ],
-      "hash": "6546739abb03fb41321221447521cd09dd3a51ad7be350fa4ed390a4f7b7cbfe"
+      "hash": "563ea0dbb87b4469082f19cb87788923d6c2411135eb6b0bd26dbfc8d3cf3f84"
     },
     {
       "hook": "slo-burn-rate-guard",
@@ -48,12 +35,12 @@
       "threshold": 1.0,
       "window": "60m",
       "action": "enforce_release_freeze",
-      "owner": "SRE",
+      "owner": "sre@trendmarket",
       "rollback": true,
       "evidence": [
         "playbook:docs/runbooks/plat_observability.md#slo-burn"
       ],
-      "hash": "22c4c33291d27dc0d62a01f6b11017b66a5ac8c7f02a956a4e0bf27aa031def6"
+      "hash": "4978e54ef08c3ac405272db66eca36306827cee7e6ebbc024b3d865a91bd1f8e"
     },
     {
       "hook": "oracle-staleness-failover",
@@ -64,22 +51,10 @@
       "owner": "PM",
       "rollback": true,
       "evidence": [
+        "audit:oracles/weekly",
         "playbook:docs/runbooks/pm_market_health.md#oracle-divergence"
       ],
       "hash": "ae2582a4579bc794c4645da7cbee914c3ecb64e9103d88bb4e79d09c2e1b2266"
-    },
-    {
-      "hook": "pm-oracle-staleness",
-      "kpi": "oracle.staleness_ms",
-      "threshold": "30000",
-      "window": "5m",
-      "action": "switch_to_twap_failover",
-      "owner": "PM",
-      "rollback": true,
-      "evidence": [
-        "playbook:docs/runbooks/pm_market_health.md#slo-burn"
-      ],
-      "hash": "c5777a0942e43a73c24d105f72bc68720b476e90c57ce17e6a9cba0885e0398e"
     },
     {
       "hook": "fx-delta-benchmark-guard",
@@ -87,12 +62,12 @@
       "threshold": 15,
       "window": "10m",
       "action": "switch_to_reference_rate",
-      "owner": "PM",
+      "owner": "pm-ops@trendmarket",
       "rollback": true,
       "evidence": [
         "playbook:docs/runbooks/pm_market_health.md#fx-delta"
       ],
-      "hash": "2cead07ab36d3faadbad53622384ef8e00b777a0caa1de1f43cc91ba78c0c9a3"
+      "hash": "a4021eb32c14179fa4001f0afcb8ee49168507cbc50b626bd2af254c99bc4830"
     },
     {
       "hook": "auction-invariant-pause",
@@ -100,12 +75,12 @@
       "threshold": 0.0,
       "window": "5m",
       "action": "pause_auction_stream",
-      "owner": "PM",
+      "owner": "pm-ops@trendmarket",
       "rollback": true,
       "evidence": [
         "playbook:docs/runbooks/pm_market_health.md#auction-invariant"
       ],
-      "hash": "aa362df1fbd865b48eb59f256c36db8c878887dd27a9fe23ebaf5a0c24588ff7"
+      "hash": "ec6b1f2612f2fea4e393578a0cf92e52743f0ad618ee4b89c067f2ccee2b6ea8"
     },
     {
       "hook": "experiment-srm-guardrail",
@@ -113,12 +88,12 @@
       "threshold": 0.01,
       "window": "24h",
       "action": "pause_experiment",
-      "owner": "ML",
+      "owner": "ml-ops@trendmarket",
       "rollback": true,
       "evidence": [
         "playbook:docs/runbooks/ml_model_ops.md#srm"
       ],
-      "hash": "0bbd0162771429e92184886f9cf44af10e8e627016b333d098bfc800a1685cec"
+      "hash": "33dabf513a34d8d8a50430a7a2be7258d9054b02c1960fd349104037e4967a84"
     },
     {
       "hook": "runtime-eol-governance",
@@ -126,13 +101,256 @@
       "threshold": 0,
       "window": "7d",
       "action": "schedule_runtime_upgrade",
-      "owner": "PLAT",
+      "owner": "platform@trendmarket",
       "rollback": false,
       "evidence": [
         "playbook:docs/runbooks/ml_model_ops.md#runtime-eol"
       ],
-      "hash": "436e9fb108365037f424a94ae6f12e3ba4bbc40069720848c1d245b45b646f46"
+      "hash": "7d682944c100af58e81c02cf1607d1856ea3dcd36192ee923ba2d29603c8d737"
+    },
+    {
+      "hook": "image-vuln-regression-block",
+      "kpi": "image.critical_vuln_count",
+      "threshold": 0,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "sec-priv@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#image-vuln"
+      ],
+      "hash": "605160d59f1398348a0e67361e545bfe058985ac6a4f1c5d9dfb9f9e4cb3f039"
+    },
+    {
+      "hook": "cdc-lag-hot-degrade",
+      "kpi": "cdc.lag.p95",
+      "threshold": "120s",
+      "window": "15m",
+      "action": "degrade_to_hot_table",
+      "owner": "data-quality@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/data_contracts.md#cdc-lag"
+      ],
+      "hash": "5e26d03530f29ea1ebe330cc7c120a43afae5865bfa4b29fa93531b80a1c93c8"
+    },
+    {
+      "hook": "schema-drift-blocker",
+      "kpi": "schema.drift_detected",
+      "threshold": 1,
+      "window": "5m",
+      "action": "block_deploy",
+      "owner": "data-quality@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/data_contracts.md#schema-drift"
+      ],
+      "hash": "804f435279eefc6febed7b229a7e65e0d420e43de3b2d23be70eba0a8b52b868"
+    },
+    {
+      "hook": "dbt-test-rollback",
+      "kpi": "dbt.tests.failure_rate",
+      "threshold": 0,
+      "window": "15m",
+      "action": "rollback_transform",
+      "owner": "data-quality@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/data_contracts.md#dbt-tests"
+      ],
+      "hash": "0c57ad0e0c2c005a7974b3fcf3a86ff3fee7d5316206c4da1488ebfa912a9646"
+    },
+    {
+      "hook": "data-contract-breach-guard",
+      "kpi": "data.contract.break",
+      "threshold": 1,
+      "window": "5m",
+      "action": "trigger_contract_waiver",
+      "owner": "data-quality@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "contracts:a106",
+        "contracts:a87",
+        "playbook:docs/runbooks/data_contracts.md#contract-breach"
+      ],
+      "hash": "894a155c61a90103d291dfb19c9b8704151a4d006ae45c66dff4391c6a184866"
+    },
+    {
+      "hook": "doc-coverage-gap",
+      "kpi": "data.doc.coverage",
+      "threshold": 0.95,
+      "window": "24h",
+      "action": "raise_doc_gap",
+      "owner": "data-quality@trendmarket",
+      "rollback": false,
+      "evidence": [
+        "playbook:docs/runbooks/data_contracts.md#doc-coverage"
+      ],
+      "hash": "f1033f1940777f7a39d44f9818fe38a7197d3cd55ae4109e8a6526df7c0e4551"
+    },
+    {
+      "hook": "web-cwv-rollback",
+      "kpi": "web.cwv.inp_p75",
+      "threshold": "200ms",
+      "window": "24h",
+      "action": "rollback_fe_release",
+      "owner": "FE",
+      "rollback": true,
+      "evidence": [
+        "lighthouse:cwv",
+        "sdk:contract",
+        "playbook:docs/runbooks/fe_experience.md#web-cwv"
+      ],
+      "hash": "c0d333b6c4566970893218feb09937f03cc118d3886a39453e8182c6403d2e12"
+    },
+    {
+      "hook": "api-contract-block",
+      "kpi": "api.contract.breaking_changes",
+      "threshold": 0,
+      "window": "5m",
+      "action": "block_release",
+      "owner": "integration@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "tests:contract",
+        "synthetics:cls",
+        "playbook:docs/runbooks/int_integrations.md#api-breaking"
+      ],
+      "hash": "d02cf5ee4a1abfb8d82cb76fca8050ee1c6dd1c7c3659a4fca44d297637e7ac0"
+    },
+    {
+      "hook": "formal-verification-freeze",
+      "kpi": "formal.verification.failure",
+      "threshold": 1,
+      "window": "5m",
+      "action": "freeze_pipeline",
+      "owner": "sec-priv@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#formal-verification"
+      ],
+      "hash": "9cb072ce7f233edce7e68f302639e54712bcd1dfa21d1dd4960fdfe614eb0a45"
+    },
+    {
+      "hook": "okr-alignment-escalation",
+      "kpi": "okr.risk_alignment_score",
+      "threshold": 0.8,
+      "window": "7d",
+      "action": "escalate_exec_review",
+      "owner": "strategyops@trendmarket",
+      "rollback": false,
+      "evidence": [
+        "playbook:docs/runbooks/plat_observability.md#okr-alignment"
+      ],
+      "hash": "ea84483b6ddce6866d83a9cb767bcd3c44e768d6c09c5a7292b33dfd817624e6"
+    },
+    {
+      "hook": "dp-budget-freeze",
+      "kpi": "privacy.dp_budget_multiplier",
+      "threshold": 1.5,
+      "window": "60m",
+      "action": "freeze_processing",
+      "owner": "sec-priv@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "sbom:latest",
+        "audit:privacy",
+        "playbook:docs/runbooks/sec_privacy.md#dp-budget"
+      ],
+      "hash": "6dc7ce38c44d902c2d5f7b13b7c46bdd776410389b10dcb0761216d718700e47"
+    },
+    {
+      "hook": "dep-vuln-freeze",
+      "kpi": "security.deps.critical_vulns",
+      "threshold": 0,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "sec-priv@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#dep-vuln"
+      ],
+      "hash": "6f9a07cb2739097dd119c9b7b0cafdbac85fbfdb42cf3871cef44904a4496686"
+    },
+    {
+      "hook": "idp-keys-rotation",
+      "kpi": "security.idp.keys_age_days",
+      "threshold": 90,
+      "window": "1d",
+      "action": "rotate_idp_keys",
+      "owner": "sec-priv@trendmarket",
+      "rollback": false,
+      "evidence": [
+        "playbook:docs/runbooks/sec_privacy.md#idp-keys"
+      ],
+      "hash": "dae3d2c51923b9c5e851c29ce16a3839c823a8ce3f86e59768471e690fb691b2"
+    },
+    {
+      "hook": "cache-ttl-block",
+      "kpi": "integration.cache_ttl_violation_pct",
+      "threshold": 0,
+      "window": "10m",
+      "action": "block_release",
+      "owner": "integration@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/int_integrations.md#cache-ttl"
+      ],
+      "hash": "cd7de4f4f302aa8b516c22725dcfd1440540b71d08e58a8ee5b4c33dc928ffde"
+    },
+    {
+      "hook": "cls-payin-cutover",
+      "kpi": "integration.cls_payin_cutoff_delay_ms",
+      "threshold": 30000,
+      "window": "5m",
+      "action": "switch_to_manual_cutoff",
+      "owner": "integration@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/int_integrations.md#cls-payin"
+      ],
+      "hash": "f9657723871f0893c3f37446fe00b338c1d51ced81bb24513a61a97aa5df388c"
+    },
+    {
+      "hook": "tracing-sampling-freeze",
+      "kpi": "tracing.sampling_rate",
+      "threshold": 0.01,
+      "window": "15m",
+      "action": "block_release",
+      "owner": "sre@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "traces:otel",
+        "alerts:platform",
+        "playbook:docs/runbooks/plat_observability.md#tracing-sampling"
+      ],
+      "hash": "ab2efe08b78eeb866305723f0b866597871e0eaa7a3ad346f10755b84d51b1d8"
+    },
+    {
+      "hook": "alert-storm-suppressor",
+      "kpi": "alerts.per_minute",
+      "threshold": 50,
+      "window": "10m",
+      "action": "enable_alert_mitigation",
+      "owner": "sre@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/plat_observability.md#alert-storm"
+      ],
+      "hash": "8b96c5a5e5337cdcbbe4ba1c0c7509fa10e09966f5bf0962a6bbc4d62f88f1a1"
+    },
+    {
+      "hook": "policy-violation-freeze",
+      "kpi": "policy.violation_detected",
+      "threshold": 1,
+      "window": "5m",
+      "action": "freeze_release",
+      "owner": "compliance@trendmarket",
+      "rollback": true,
+      "evidence": [
+        "playbook:docs/runbooks/plat_observability.md#policy-violation"
+      ],
+      "hash": "4e7f0764fede446f682f071040640800fd3eca363f3a3b5b90f960ffe6589c84"
     }
-    // ... demais hooks até totalizar 29, seguindo o mesmo padrão ...
   ]
 }

--- a/ops/reports/repo_audit.json
+++ b/ops/reports/repo_audit.json
@@ -126,5 +126,29 @@
       "/workspace/trendmarket/ops/evidence/evidence.json"
     ],
     "recorded_at": "2025-09-27T20:08:31.205651+00:00"
+  },
+  {
+    "command": "make watchers.dry",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/reports/watchers_dry.json"
+    ],
+    "recorded_at": "2025-09-27T22:22:22.010746+00:00"
+  },
+  {
+    "command": "make hooks.dry",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/reports/hooks_dry.json"
+    ],
+    "recorded_at": "2025-09-27T22:22:23.588251+00:00"
+  },
+  {
+    "command": "make evidence.publish",
+    "status": "success",
+    "artifacts": [
+      "/workspace/trendmarket/ops/evidence/evidence.json"
+    ],
+    "recorded_at": "2025-09-27T22:22:25.288809+00:00"
   }
 ]

--- a/ops/reports/watchers_dry.json
+++ b/ops/reports/watchers_dry.json
@@ -1,179 +1,324 @@
 {
-  "generated_at": "2025-09-27T20:10:12.355162+00:00",
-  "source": "ops/watchers",
-  "total_watchers": 31,
+  "generated_at": "2025-09-27T22:22:21.246841+00:00",
+  "source": "watchers/core.yaml",
+  "total_watchers": 26,
   "watchers": [
     {
-      "id": "cdc_lag_watch",
       "description": "Acompanha lag CDC p95 contra o contrato de dados.",
-      "domains": ["DATA"],
-      "owner": "DATA",
+      "domain": "DATA",
+      "domains": [
+        "DATA"
+      ],
+      "hook_id": "cdc-lag-hot-degrade",
+      "id": "cdc_lag_watch",
       "kpi": "cdc.lag.p95",
-      "hook": "cdc-lag-hot-degrade",
-      "hash": "43c14db3762858f2d30f227b43c8ebf203c775dd1b26a083db2cb0c6fc9f4a7c"
+      "owner": "DATA",
+      "hash": "0dc8811eb1e1894ea6f1c12e5adf9347223377db1b718231d2a35d0295da3203"
     },
     {
-      "id": "data_contract_break_watch",
       "description": "Quebra de contrato de dados A106/A87/A89.",
-      "domains": ["DATA"],
-      "owner": "DATA",
+      "domain": "DATA",
+      "domains": [
+        "DATA"
+      ],
+      "hook_id": "data-contract-breach-guard",
+      "id": "data_contract_break_watch",
       "kpi": "data.contract.break",
-      "hook": "data-contract-breach-guard",
-      "hash": "55ceda7a194528303f81534e76e4a7051201d634b9fdec7bf096aeef4ce812f5"
+      "owner": "DATA",
+      "hash": "0e451f1ed0cd8a2f4ed1e81e484cac7aa94bb9010450122df6c6b39ec5ecf775"
     },
     {
-      "id": "dbt_test_failure_watch",
       "description": "Flag de falhas de testes dbt críticos.",
-      "domains": ["DATA"],
-      "owner": "DATA",
+      "domain": "DATA",
+      "domains": [
+        "DATA"
+      ],
+      "hook_id": "dbt-test-rollback",
+      "id": "dbt_test_failure_watch",
       "kpi": "dbt.tests.failure_rate",
-      "hook": "dbt-test-rollback",
-      "hash": "8ac102d1c08017b50917082f8f4d4f956d1b4fd8c0fec2efe185d3f8db2cad36"
+      "owner": "DATA",
+      "hash": "512d106e1ff2db263cbc11eda962890b7b683e976f559dc07cade7a1a709a404"
     },
     {
-      "id": "doc_coverage_watch",
       "description": "Garante cobertura de documentação mínima das pipelines.",
-      "domains": ["DATA"],
-      "owner": "DATA",
+      "domain": "DATA",
+      "domains": [
+        "DATA"
+      ],
+      "hook_id": "doc-coverage-gap",
+      "id": "doc_coverage_watch",
       "kpi": "data.doc.coverage",
-      "hook": "doc-coverage-gap",
-      "hash": "d7911195b79a05805b136d5944fdf40301e2114483ea8039f3cc1d0cb60fd5b2"
-    },
-    {
-      "id": "schema_registry_drift_watch",
-      "description": "Detecta incompatibilidades no schema registry.",
-      "domains": ["DATA"],
       "owner": "DATA",
+      "hash": "4fc16321f4e4bc063b0b5ba1e19e57c399a82c2e9a96e0eada7059c23b8cecf7"
+    },
+    {
+      "description": "Detecta incompatibilidades no schema registry.",
+      "domain": "DATA",
+      "domains": [
+        "DATA"
+      ],
+      "hook_id": "schema-drift-blocker",
+      "id": "schema_registry_drift_watch",
       "kpi": "schema.drift_detected",
-      "hook": "schema-drift-blocker",
-      "hash": "30d2b90e913bd4d2c897663dce817a4279fd7e31a239670da4f4fdbc8f2e1be0"
+      "owner": "DATA",
+      "hash": "7df43024fac63c8f62e6f9dde45f2e008be400b56b3fa74bfbbc0c625914264c"
     },
     {
-      "id": "metrics_decision_hook_gap_watch",
       "description": "Garante que a latência DEC permaneça dentro dos limites antes de alterar rotas.",
-      "domains": ["DEC"],
-      "owner": "SRE",
+      "domain": "DEC",
+      "domains": [
+        "DEC"
+      ],
+      "hook_id": "dec-latency-degrade",
+      "id": "metrics_decision_hook_gap_watch",
       "kpi": "dec.latency.p95",
-      "hook": "dec-latency-gap",
-      "hash": "a27969ee3b90088b80bba19044e69abb3398d2a0ab384572556024b79e6b695d"
+      "owner": "SRE",
+      "hash": "df96683c39890d93d60a9d06123722898bc89752af504420eb42b1b21307a48c"
     },
     {
-      "id": "model_drift_watch",
       "description": "Detecta drift estatístico relevante para decisões de crédito.",
-      "domains": ["DEC", "ML"],
-      "owner": "ML",
+      "domain": "DEC",
+      "domains": [
+        "DEC",
+        "ML"
+      ],
+      "hook_id": "dec-latency-degrade",
+      "id": "model_drift_watch",
       "kpi": "model.psi",
-      "hook": "model-drift-rollback",
-      "hash": "1efd454ab377ea5a006e9a93447358cba1ee4d85089a6285fe11c0cecb0ee939"
-    },
-    {
-      "id": "slo_budget_breach_watch",
-      "description": "Monitora burn rate do SLO cross-domain.",
-      "domains": ["DEC", "PM", "PLAT"],
-      "owner": "SRE",
-      "kpi": "slo.burn_rate",
-      "hook": "slo-burn-rate-guard",
-      "hash": "0cd4061d37573437a54944d229709785f698e826e6a65a6796f8b8357f60222d"
-    },
-    {
-      "id": "api_breaking_change_watch",
-      "description": "Previne quebras de contrato de APIs públicas/internas.",
-      "domains": ["FE", "INT"],
-      "owner": "INT",
-      "kpi": "api.contract.breaking_changes",
-      "hook": "api-contract-block",
-      "hash": "96912a14632f69164a91fe36b88bc4b662ccc435271d2a97f98d5dc6df28263a"
-    },
-    {
-      "id": "web_cwv_regression_watch",
-      "description": "Observa regressões de Core Web Vitals (INP p75).",
-      "domains": ["FE"],
-      "owner": "FE",
-      "kpi": "web.cwv.inp_p75",
-      "hook": "web-cwv-rollback",
-      "hash": "c4e6a83d0379b66e1b12c6107971f3cd047434e2f16fa1a461b300f7777cc1b2"
-    },
-    {
-      "id": "cache_ttl_misuse_watch",
-      "description": "Flag para TTL incorreto em caches compartilhados.",
-      "domains": ["INT"],
-      "owner": "INT",
-      "kpi": "integration.cache_ttl_violation_pct",
-      "hook": "cache-ttl-block",
-      "hash": "8983b00a2094a028d951dd977dd3eedc1fac9b16ee897a0852da821ba6c0f3d4"
-    },
-    {
-      "id": "cls_payin_cutoff_watch",
-      "description": "Garante que o cutoff CLS payin seja seguido sem atraso.",
-      "domains": ["INT"],
-      "owner": "INT",
-      "kpi": "integration.cls_payin_cutoff_delay_ms",
-      "hook": "cls-payin-cutover",
-      "hash": "e21fd5e3c4b11db666bf3ca9e2139d1bcd18155b892f9a43ae38b8f98344cef2"
-    },
-    {
-      "id": "ab_srm_watch",
-      "description": "Detecta falhas de SRM em experimentos e testes AA.",
-      "domains": ["ML"],
       "owner": "ML",
+      "hash": "1eef2a5f2bca037d8dbd5f943836b34dfbecb82b116421321a76aa5b719b2b42"
+    },
+    {
+      "description": "Monitora burn rate do SLO cross-domain.",
+      "domain": "DEC",
+      "domains": [
+        "DEC",
+        "PM",
+        "PLAT"
+      ],
+      "hook_id": "slo-burn-rate-guard",
+      "id": "slo_budget_breach_watch",
+      "kpi": "slo.burn_rate",
+      "owner": "SRE",
+      "hash": "654f18ce37feada1539b0ec58eb70ff0ff16e5ff80e0206da653fe189744a07b"
+    },
+    {
+      "description": "Previne quebras de contrato de APIs públicas/internas.",
+      "domain": "FE",
+      "domains": [
+        "FE",
+        "INT"
+      ],
+      "hook_id": "api-contract-block",
+      "id": "api_breaking_change_watch",
+      "kpi": "api.contract.breaking_changes",
+      "owner": "INT",
+      "hash": "843bc0690412d9a155bd1da88b6bd1d34f72ae70c67ed49494d034831f8c5911"
+    },
+    {
+      "description": "Observa regressões de Core Web Vitals (INP p75).",
+      "domain": "FE",
+      "domains": [
+        "FE"
+      ],
+      "hook_id": "fe-cwv-regression",
+      "id": "web_cwv_regression_watch",
+      "kpi": "web.cwv.inp_p75",
+      "owner": "FE",
+      "hash": "0ba2ee6d268cee8299b772c276909094cfa6a6b925e2a6329482c4dcb2bbc9d8"
+    },
+    {
+      "description": "Flag para TTL incorreto em caches compartilhados.",
+      "domain": "INT",
+      "domains": [
+        "INT"
+      ],
+      "hook_id": "cache-ttl-block",
+      "id": "cache_ttl_misuse_watch",
+      "kpi": "integration.cache_ttl_violation_pct",
+      "owner": "INT",
+      "hash": "a29a9396679cc710af1d62d56f69fee163476d63611ee3b0bf5d88b081c86860"
+    },
+    {
+      "description": "Garante que o cutoff CLS payin seja seguido sem atraso.",
+      "domain": "INT",
+      "domains": [
+        "INT"
+      ],
+      "hook_id": "cls-payin-cutover",
+      "id": "cls_payin_cutoff_watch",
+      "kpi": "integration.cls_payin_cutoff_delay_ms",
+      "owner": "INT",
+      "hash": "e7ba374a1b1816860de09880dfd42900d539bcf10c35c90953f7c3d9e2d475e8"
+    },
+    {
+      "description": "Detecta falhas de SRM em experimentos e testes AA.",
+      "domain": "ML",
+      "domains": [
+        "ML"
+      ],
+      "hook_id": "experiment-srm-guardrail",
+      "id": "ab_srm_watch",
       "kpi": "experiment.srm_pvalue",
-      "hook": "experiment-srm-guardrail",
-      "hash": "0eea693c860048019b4ca2b342bcb3ccf5e45002638a6c0728f4e7e5ad7eb075"
+      "owner": "ML",
+      "hash": "40c34cb4f5fc4efaf75af08c8f596717fedddfbe72f4b787a1b5f9b6e80d5a40"
     },
     {
-      "id": "image_vuln_regression_watch",
       "description": "Bloqueia regressão de vulnerabilidades críticas em imagens.",
-      "domains": ["ML", "SEC/PRIV"],
-      "owner": "SEC",
+      "domain": "ML",
+      "domains": [
+        "ML",
+        "SEC/PRIV"
+      ],
+      "hook_id": "image-vuln-regression-block",
+      "id": "image_vuln_regression_watch",
       "kpi": "image.critical_vuln_count",
-      "hook": "image-vuln-regression-block",
-      "hash": "449effb729d02a7bf46d41962fb75170f32c29fc901922648c591252b0ff086b"
+      "owner": "SEC",
+      "hash": "293a4790a7e43e8985be136eab9551cd898962a481a069eafc94183e5ca1a662"
     },
     {
-      "id": "runtime_eol_watch",
       "description": "Aponta runtimes em fim de vida para evitar builds inseguras.",
-      "domains": ["ML"],
-      "owner": "PLAT",
+      "domain": "ML",
+      "domains": [
+        "ML"
+      ],
+      "hook_id": "runtime-eol-governance",
+      "id": "runtime_eol_watch",
       "kpi": "runtime.support_gap_days",
-      "hook": "runtime-eol-governance",
-      "hash": "20a35732822c71c22bb4cae2b1274a69dc93cb447d3e4719cd3028d0bbe2d775"
+      "owner": "PLAT",
+      "hash": "097ac976a804480f39645e2094f7d24b52e103519ea0e41ff4328972e1e9e03d"
     },
     {
-      "id": "alert_storm_watch",
       "description": "Detecta tempestades de alertas indicando ruído ou incidentes generalizados.",
-      "domains": ["PLAT"],
-      "owner": "SRE",
+      "domain": "PLAT",
+      "domains": [
+        "PLAT"
+      ],
+      "hook_id": "alert-storm-suppressor",
+      "id": "alert_storm_watch",
       "kpi": "alerts.per_minute",
-      "hook": "alert-storm-suppressor",
-      "hash": "735e625bbe4336b63869d1e1760689db93dafd2861ae91f0eb35c6726ff05568"
-    },
-    {
-      "id": "okr_risk_alignment_watch",
-      "description": "Monitora desalinhamento de riscos com OKRs estratégicos.",
-      "domains": ["PLAT"],
-      "owner": "StrategyOps",
-      "kpi": "okr.risk_alignment_score",
-      "hook": "okr-alignment-escalation",
-      "hash": "6481f6ed1bac91e64632e75f13d7de6fb32b2b37dd28dd250c76d98767a24275"
-    },
-    {
-      "id": "policy_violation_watch",
-      "description": "Garante que políticas operacionais/compliance permaneçam sem violações.",
-      "domains": ["PLAT"],
-      "owner": "Compliance",
-      "kpi": "policy.violation_detected",
-      "hook": "policy-violation-freeze",
-      "hash": "428f7f31ad8ca2a70af349a46d67346e92f1bcba823f80c99c954769876c74a2"
-    },
-    {
-      "id": "tracing_sampling_watch",
-      "description": "Monitora taxa de amostragem do tracing distribuído.",
-      "domains": ["PLAT"],
       "owner": "SRE",
+      "hash": "427bdd3d4096cea9646d40b4c782f74d1a8adffdf03b6877a7e5b7db8e57800d"
+    },
+    {
+      "description": "Monitora desalinhamento de riscos com OKRs estratégicos.",
+      "domain": "PLAT",
+      "domains": [
+        "PLAT"
+      ],
+      "hook_id": "okr-alignment-escalation",
+      "id": "okr_risk_alignment_watch",
+      "kpi": "okr.risk_alignment_score",
+      "owner": "StrategyOps",
+      "hash": "cd0f778ba38ea88b8b376f5b39ec9affe6e5e15649f28493cab47fb43f87a6bd"
+    },
+    {
+      "description": "Garante que políticas operacionais/compliance permaneçam sem violações.",
+      "domain": "PLAT",
+      "domains": [
+        "PLAT"
+      ],
+      "hook_id": "policy-violation-freeze",
+      "id": "policy_violation_watch",
+      "kpi": "policy.violation_detected",
+      "owner": "Compliance",
+      "hash": "9670730d1d52af8176b20429e4957d2da30acffae70c58c615be3ad2c7c18d45"
+    },
+    {
+      "description": "Monitora taxa de amostragem do tracing distribuído.",
+      "domain": "PLAT",
+      "domains": [
+        "PLAT"
+      ],
+      "hook_id": "tracing-sampling-freeze",
+      "id": "tracing_sampling_watch",
       "kpi": "tracing.sampling_rate",
-      "hook": "tracing-sampling-freeze",
-      "hash": "d012e68d02a80a3f7c227e0f0bce09b2378eb449c2440e308fbba6ce7d2d3435"
+      "owner": "SRE",
+      "hash": "290852a0d647d1724f286caec2aa7c3d2fa5d3310e8fb750fb1f838f1bd3baa2"
+    },
+    {
+      "description": "Fiscaliza invariantes KKT e convexidade nos leilões.",
+      "domain": "PM",
+      "domains": [
+        "PM"
+      ],
+      "hook_id": "auction-invariant-pause",
+      "id": "auction_invariant_breach_watch",
+      "kpi": "auction.kkt_violation_pct",
+      "owner": "PM",
+      "hash": "aa6e89c0bd50288e013457b46b8a0847729eb96b581fa1b9b0ba184b13704a32"
+    },
+    {
+      "description": "Compara delta FX com benchmark para evitar arbitragem.",
+      "domain": "PM",
+      "domains": [
+        "PM"
+      ],
+      "hook_id": "fx-delta-benchmark-guard",
+      "id": "fx_delta_benchmark_watch",
+      "kpi": "fx.delta_vs_benchmark_bps",
+      "owner": "PM",
+      "hash": "1fa7cf27227865e006043d0ce78692767d3b948503fcf74d84daa7ecc93cc498"
+    },
+    {
+      "description": "Detecta divergência de preço entre oráculos e referência.",
+      "domain": "PM",
+      "domains": [
+        "PM"
+      ],
+      "hook_id": "pm-oracle-staleness",
+      "id": "oracle_divergence_watch",
+      "kpi": "oracle.divergence_bps",
+      "owner": "PM",
+      "hash": "3e81a13ec7634e94d0eb0906813d7488137c9d702c1719d7a0c1d9570ada7b79"
+    },
+    {
+      "description": "Bloqueia releases com vulnerabilidades críticas em dependências.",
+      "domain": "SEC/PRIV",
+      "domains": [
+        "SEC/PRIV"
+      ],
+      "hook_id": "dep-vuln-freeze",
+      "id": "dep_vuln_watch",
+      "kpi": "security.deps.critical_vulns",
+      "owner": "SEC",
+      "hash": "7d6d684abafee8dc8b2bbf0a40df91dd849fe898433fe237595df4777bfc69ec"
+    },
+    {
+      "description": "Garante que o budget de privacidade diferencial não estoure.",
+      "domain": "SEC/PRIV",
+      "domains": [
+        "SEC/PRIV"
+      ],
+      "hook_id": "dp-budget-freeze",
+      "id": "dp_budget_breach_watch",
+      "kpi": "privacy.dp_budget_multiplier",
+      "owner": "SEC",
+      "hash": "d79b6636d58ce2790bd3a74f3370c4a386ba6cf6edee725139137046fdfe3b7f"
+    },
+    {
+      "description": "Sinaliza falha em gates formais (A108/segurança).",
+      "domain": "SEC/PRIV",
+      "domains": [
+        "SEC/PRIV"
+      ],
+      "hook_id": "formal-verification-freeze",
+      "id": "formal_verification_gate_watch",
+      "kpi": "formal.verification.failure",
+      "owner": "SEC",
+      "hash": "d91a2613e2b71cf0b5d11ef4cc2d0506a600e38bb2f0ee8ac6314b1a5dde7b61"
+    },
+    {
+      "description": "Enforce rotação de chaves/segredos do IdP.",
+      "domain": "SEC/PRIV",
+      "domains": [
+        "SEC/PRIV"
+      ],
+      "hook_id": "idp-keys-rotation",
+      "id": "idp_keys_rotation_watch",
+      "kpi": "security.idp.keys_age_days",
+      "owner": "SEC",
+      "hash": "194244934af32923c6792db2d3533e693b2d18171f20ed70199ab67fc45c9db6"
     }
-    // ... demais watchers até completar 31
   ]
 }


### PR DESCRIPTION
## Summary
- register the cls-payin-cutover hook in the A110 configuration with the CLS payoff runbook reference
- update the okr-alignment hook to include its playbook reference and close the configuration document
- regenerate the hook and watcher evidence artifacts after the configuration change

## Testing
- make -C ops/scripts evidence.publish

------
https://chatgpt.com/codex/tasks/task_e_68d863115cfc8330ac00cbaa00af51bf