### PR TITLE
Add YAML-aware evidence parser with tests

### DIFF
--- a/ops/scripts/evidence_publish.py
+++ b/ops/scripts/evidence_publish.py
@@ -5,20 +5,53 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import pathlib
 import sys
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 
-def _load_json(path: pathlib.Path) -> Dict[str, Any]:
+def _load_yaml_parser() -> Callable[[str], Any] | None:
+    spec = importlib.util.find_spec("yaml")
+    if spec is None:
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module.safe_load  # type: ignore[return-value]
+
+
+_YAML_PARSER = _load_yaml_parser()
+
+
+def _parse_content(text: str) -> Any:
+    yaml_error: Exception | None = None
+    if _YAML_PARSER is not None:
+        try:
+            return _YAML_PARSER(text)
+        except Exception as exc:  # pragma: no cover - safe fallback
+            yaml_error = exc
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        if yaml_error is not None:
+            raise RuntimeError(
+                f"Unable to parse artefact as YAML ({yaml_error}) or JSON"
+            ) from exc
+        raise RuntimeError(f"Invalid JSON: {exc}") from exc
+
+
+def _load_document(path: pathlib.Path) -> Dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(f"Required artefact not found: {path}")
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"Invalid JSON at {path}: {exc}") from exc
+    payload = _parse_content(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Artefact at {path} must be a mapping")
+    return payload
 
 
 def _digest(content: Dict[str, Any]) -> str:
@@ -27,8 +60,8 @@ def _digest(content: Dict[str, Any]) -> str:
 
 
 def aggregate(watchers_path: pathlib.Path, hooks_path: pathlib.Path) -> Dict[str, Any]:
-    watchers = _load_json(watchers_path)
-    hooks = _load_json(hooks_path)
+    watchers = _load_document(watchers_path)
+    hooks = _load_document(hooks_path)
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "watchers_artifact": str(watchers_path),

--- a/ops/scripts/tests/test_evidence_publish.py
+++ b/ops/scripts/tests/test_evidence_publish.py
@@ -1,0 +1,89 @@
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "evidence_publish.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("evidence_publish", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load evidence_publish module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+evidence_publish = _load_module()
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, object]) -> pathlib.Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_aggregate_supports_json_inputs(tmp_path):
+    watchers_path = _write_json(
+        tmp_path / "watchers.json",
+        {
+            "total_watchers": 1,
+            "watchers": [{"id": "model_drift_watch"}],
+        },
+    )
+    hooks_path = _write_json(
+        tmp_path / "hooks.json",
+        {
+            "total_hooks": 1,
+            "hooks": [{"id": "dec-latency-degrade"}],
+        },
+    )
+
+    bundle = evidence_publish.aggregate(watchers_path, hooks_path)
+
+    assert bundle["watchers_count"] == 1
+    assert bundle["hooks_count"] == 1
+    assert bundle["evidence"]["watchers"][0]["id"] == "model_drift_watch"
+    assert bundle["evidence"]["hooks"][0]["id"] == "dec-latency-degrade"
+
+
+def test_aggregate_supports_yaml_inputs(tmp_path):
+    pytest.importorskip("yaml")
+
+    watchers_path = tmp_path / "watchers.yaml"
+    watchers_path.write_text(
+        """
+        total_watchers: 2
+        watchers:
+          - id: metrics_decision_hook_gap_watch
+          - id: slo_budget_breach_watch
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    hooks_path = tmp_path / "hooks.yaml"
+    hooks_path.write_text(
+        """
+        total_hooks: 2
+        hooks:
+          - id: dec-latency-degrade
+          - id: slo-burn-rate-guard
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    bundle = evidence_publish.aggregate(watchers_path, hooks_path)
+
+    assert bundle["watchers_count"] == 2
+    assert bundle["hooks_count"] == 2
+    watcher_ids = {entry["id"] for entry in bundle["evidence"]["watchers"]}
+    hook_ids = {entry["id"] for entry in bundle["evidence"]["hooks"]}
+    assert watcher_ids == {
+        "metrics_decision_hook_gap_watch",
+        "slo_budget_breach_watch",
+    }
+    assert hook_ids == {
+        "dec-latency-degrade",
+        "slo-burn-rate-guard",
+    }


### PR DESCRIPTION
## Summary
- update `ops/scripts/evidence_publish.py` to load artefacts with a YAML-safe parser that falls back to JSON
- add unit tests covering aggregation from JSON and YAML inputs

## Testing
- pytest ops/scripts/tests/test_evidence_publish.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d8631ada8883309b0df0123d13e23c