### PR TITLE
Support timeout command variants for gate A110

### DIFF
--- a/ops/scripts/gate_a110.sh
+++ b/ops/scripts/gate_a110.sh
@@ -239,11 +239,20 @@ print("[A110] Gate check passed: watchers, hooks e runbooks consistentes.")
 PY
 
 if [[ -n $timeout_secs ]]; then
-  if ! command -v timeout >/dev/null 2>&1; then
-    echo "[A110][ERROR] --timeout requested but 'timeout' command is not available" >&2
+  timeout_cmd=""
+  for candidate in timeout gtimeout; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      timeout_cmd="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z $timeout_cmd ]]; then
+    echo "[A110][ERROR] --timeout requested but neither 'timeout' nor 'gtimeout' command is available" >&2
     exit 1
   fi
-  timeout "$timeout_secs" python "$script_path"
+
+  "$timeout_cmd" "$timeout_secs" python "$script_path"
 else
   python "$script_path"
 fi

--- a/ops/scripts/tests/test_gate_a110.py
+++ b/ops/scripts/tests/test_gate_a110.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import shutil
 import subprocess
@@ -10,13 +11,14 @@ SCRIPT_PATH = REPO_ROOT / "ops" / "scripts" / "gate_a110.sh"
 HOOKS_PATH = REPO_ROOT / "ops" / "hooks" / "a110.yml"
 
 
-def _run_gate() -> subprocess.CompletedProcess[str]:
+def _run_gate(*extra_args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", str(SCRIPT_PATH), "--require-green"],
+        ["bash", str(SCRIPT_PATH), "--require-green", *extra_args],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
 
 
@@ -50,3 +52,32 @@ def test_gate_fails_when_hooks_manifest_malformed(_restore_hooks):
     combined_output = "\n".join(part for part in (result.stdout, result.stderr) if part)
     assert result.returncode != 0, combined_output
     assert "failed to parse" in combined_output
+
+
+def test_gate_uses_timeout_when_requested(tmp_path):
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+
+    log_path = tmp_path / "timeout.log"
+    fake_timeout = fake_bin / "timeout"
+    fake_timeout.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+log_path="${GATE_A110_TIMEOUT_LOG:?missing GATE_A110_TIMEOUT_LOG}"
+printf '%s\n' "$@" >"$log_path"
+shift
+exec "$@"
+""",
+        encoding="utf-8",
+    )
+    fake_timeout.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["GATE_A110_TIMEOUT_LOG"] = str(log_path)
+
+    result = _run_gate("--timeout", "5", env=env)
+
+    assert log_path.exists(), "timeout wrapper did not execute"
+    logged_args = log_path.read_text(encoding="utf-8").splitlines()
+    assert logged_args[:2] == ["5", "python"]


### PR DESCRIPTION
## Summary
- detect either `timeout` or `gtimeout` before running the gate A110 python validator when a timeout is requested
- add a unit test that stubs the timeout executable to ensure the gate script delegates through it

## Testing
- pytest ops/scripts/tests/test_gate_a110.py

------
https://chatgpt.com/codex/tasks/task_e_68d8631bb19483309049c5131a08ccbe