### PR TITLE
Handle JSON parse failures in k6 smoke test

### DIFF
--- a/ops/tests/k6_smoke_test.js
+++ b/ops/tests/k6_smoke_test.js
@@ -34,6 +34,15 @@ function assertDefaultQuotePath(base, endpoint) {
 assertDefaultQuotePath(baseUrl, quoteEndpoint);
 const latency = new Trend('decision_latency', true);
 
+function safeJson(response, path) {
+  try {
+    return response.json(path);
+  } catch (error) {
+    console.error(`Failed to parse response JSON for path "${path}": ${error}`);
+    return undefined;
+  }
+}
+
 function buildQuotePayload() {
   return {
     app_id: 'smoke-app-001',
@@ -67,7 +76,7 @@ function requestQuote() {
 
   const ok = check(response, {
     'status is 2xx': (r) => r.status >= 200 && r.status < 300,
-    'has price payload': (r) => !!r.json('price.apr'),
+    'has price payload': (r) => Boolean(safeJson(r, 'price.apr')),
     'latency under p95 budget': (r) => r.timings.duration <= Number(__ENV.K6_LATENCY_BUDGET_MS || 800),
   });
 


### PR DESCRIPTION
## Summary
- add a safeJson helper to wrap k6 response parsing and log parse errors
- update the smoke test check to use the helper so JSON parse failures return false instead of throwing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8631d4278833092fedd672503c25f