### PR TITLE
Add support for OTLP signal-specific endpoints and timeouts

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -13,8 +13,8 @@ use opentelemetry_sdk::{
     resource::Resource,
     trace::SdkTracerProvider,
 };
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 use tracing::Level;
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 
 pub struct Telemetry {
     pub tracer_provider: SdkTracerProvider,
@@ -34,6 +34,17 @@ impl Telemetry {
 pub fn init(service_name: &str) -> Result<Telemetry> {
     let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
         .unwrap_or_else(|_| "http://localhost:4318".to_string());
+    let traces_endpoint =
+        std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT").unwrap_or_else(|_| endpoint.clone());
+    let metrics_endpoint =
+        std::env::var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT").unwrap_or_else(|_| endpoint.clone());
+
+    let default_timeout =
+        env_timeout("OTEL_EXPORTER_OTLP_TIMEOUT").unwrap_or_else(|| Duration::from_secs(10));
+    let traces_timeout =
+        env_timeout("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT").unwrap_or(default_timeout);
+    let metrics_timeout =
+        env_timeout("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT").unwrap_or(default_timeout);
 
     let commit = std::env::var("CE_COMMIT_SHA").unwrap_or_else(|_| "unknown".into());
 
@@ -48,7 +59,8 @@ pub fn init(service_name: &str) -> Result<Telemetry> {
     // ---- Traces (OTLP/HTTP) ----
     let span_exporter = SpanExporter::builder()
         .with_http()
-        .with_endpoint(&endpoint)
+        .with_endpoint(&traces_endpoint)
+        .with_timeout(traces_timeout)
         .build()?;
 
     let tracer_provider = SdkTracerProvider::builder()
@@ -61,7 +73,8 @@ pub fn init(service_name: &str) -> Result<Telemetry> {
     // ---- Métricas (OTLP/HTTP) ----
     let metric_exporter = MetricExporter::builder()
         .with_http()
-        .with_endpoint(&endpoint)
+        .with_endpoint(&metrics_endpoint)
+        .with_timeout(metrics_timeout)
         .build()?;
 
     let reader = PeriodicReader::builder(metric_exporter)
@@ -99,7 +112,24 @@ pub fn init(service_name: &str) -> Result<Telemetry> {
         .with_description("Relative invariant error |Δk/k| per operation")
         .build();
 
-    Ok(Telemetry { tracer_provider, meter_provider, meter, swap_latency_ms, invariant_error_rel })
+    Ok(Telemetry {
+        tracer_provider,
+        meter_provider,
+        meter,
+        swap_latency_ms,
+        invariant_error_rel,
+    })
+}
+
+fn env_timeout(var: &str) -> Option<Duration> {
+    std::env::var(var).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            trimmed.parse::<u64>().ok().map(Duration::from_millis)
+        }
+    })
 }
 
 /// Cria um `Span` INFO com nome **estático** (exigência do tracing) e
@@ -116,4 +146,3 @@ pub fn make_info_span(name: &str, op_id: u32, component: &str) -> tracing::Span 
         component = component
     )
 }
-


### PR DESCRIPTION
## Summary
- allow telemetry init to honor OTLP trace and metric specific endpoints with sensible fallbacks
- parse OTLP timeout environment variables and wire them into both span and metric exporters

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d8631dd1288330adcf5f02417f29bb