### PR TITLE
Add guard rails for AMM fees

### DIFF
--- a/src/amm/errors.rs
+++ b/src/amm/errors.rs
@@ -8,6 +8,7 @@ pub enum AmmError {
     MinReserveBreached,
     Overflow,
     InputTooSmall,
+    InvalidFee,
 }
 
 impl fmt::Display for AmmError {
@@ -19,6 +20,7 @@ impl fmt::Display for AmmError {
             MinReserveBreached => "reserva ficaria abaixo do mínimo",
             Overflow => "overflow/underflow numérico",
             InputTooSmall => "input efetivo após taxa é 0",
+            InvalidFee => "fee_ppm deve ser ≤ 1e6",
         };
         write!(f, "{}", s)
     }

--- a/src/amm/pricing.rs
+++ b/src/amm/pricing.rs
@@ -5,12 +5,14 @@ use super::errors::AmmError;
 use super::guardrails::{
     div_nearest_even_u256, div_nearest_even_u256_to_u128, ensure_nonzero, ensure_reserves,
 };
-use super::swap::{get_amount_in, get_amount_out};
-use super::types::{U256, Ppm, Wad, PPM_SCALE, WAD};
+use super::swap::{ensure_fee_ppm, get_amount_in, get_amount_out};
+use super::types::{Ppm, Wad, PPM_SCALE, U256, WAD};
 use crate::amm::guardrails::u256_to_u128_checked;
 
 #[inline]
-fn ceil_div_u256(n: U256, d: U256) -> U256 { (n + (d - U256::from(1u8))) / d }
+fn ceil_div_u256(n: U256, d: U256) -> U256 {
+    (n + (d - U256::from(1u8))) / d
+}
 
 // --------- Spot price ---------
 /// Preço à vista de 1 X em Y (dy/dx infinitesimal): **p = y/x** (em WAD)
@@ -32,6 +34,7 @@ pub fn spot_price_y_in_x(x: Wad, y: Wad) -> Result<Wad, AmmError> {
 pub fn execution_price_x_to_y(x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm) -> Result<Wad, AmmError> {
     ensure_reserves(x, y)?;
     ensure_nonzero(dx)?;
+    ensure_fee_ppm(fee_ppm)?;
     let out = get_amount_out(x, y, dx, fee_ppm)?;
     let n = U256::from(out) * U256::from(WAD);
     div_nearest_even_u256_to_u128(n, U256::from(dx))
@@ -40,15 +43,24 @@ pub fn execution_price_x_to_y(x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm) -> Result<W
 /// Slippage relativo em **PPM** comparando `p_exec` vs `spot` (sempre ≥0):
 /// slippage_ppm = ((spot - p_exec) / spot) * 1e6
 pub fn slippage_ppm_x_to_y(x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm) -> Result<Ppm, AmmError> {
-    let spot = spot_price_x_in_y(x, y)?;           // WAD
+    ensure_fee_ppm(fee_ppm)?;
+    let spot = spot_price_x_in_y(x, y)?; // WAD
     let exec = execution_price_x_to_y(x, y, dx, fee_ppm)?; // WAD
-    if exec >= spot { return Ok(0); }
+    if exec >= spot {
+        return Ok(0);
+    }
     let num = (U256::from(spot) - U256::from(exec)) * U256::from(PPM_SCALE as u64);
     let den = U256::from(spot);
     let q = div_nearest_even_u256(num, den)?; // U256
     let q128 = u256_to_u128_checked(q)?;
-    let mut ppm = if q128 > u128::from(u32::MAX) { u32::MAX } else { q128 as u32 };
-    if ppm > PPM_SCALE { ppm = PPM_SCALE; }
+    let mut ppm = if q128 > u128::from(u32::MAX) {
+        u32::MAX
+    } else {
+        q128 as u32
+    };
+    if ppm > PPM_SCALE {
+        ppm = PPM_SCALE;
+    }
     Ok(ppm)
 }
 
@@ -56,10 +68,19 @@ pub fn slippage_ppm_x_to_y(x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm) -> Result<Ppm,
 /// Retorna **min_out** aceito pela UI para X→Y considerando `slippage_tolerance_ppm` (0..1e6)
 /// min_out = floor( out * (1 - tol) )
 pub fn min_out_with_tolerance(
-    x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm, slippage_tolerance_ppm: Ppm,
+    x: Wad,
+    y: Wad,
+    dx: Wad,
+    fee_ppm: Ppm,
+    slippage_tolerance_ppm: Ppm,
 ) -> Result<Wad, AmmError> {
+    ensure_fee_ppm(fee_ppm)?;
     let out = get_amount_out(x, y, dx, fee_ppm)?;
-    let tol = if slippage_tolerance_ppm > PPM_SCALE { PPM_SCALE } else { slippage_tolerance_ppm } as u64;
+    let tol = if slippage_tolerance_ppm > PPM_SCALE {
+        PPM_SCALE
+    } else {
+        slippage_tolerance_ppm
+    } as u64;
     let factor = (PPM_SCALE as u64) - tol; // (1 - tol)
     let n = U256::from(out) * U256::from(factor);
     let q = n / U256::from(PPM_SCALE as u64); // floor
@@ -70,10 +91,19 @@ pub fn min_out_with_tolerance(
 /// Retorna **max_in** aceito pela UI para atingir `dy` com tolerância `slippage_tolerance_ppm` (0..1e6)
 /// max_in = ceil( dx * (1 + tol) )
 pub fn max_in_with_tolerance(
-    x: Wad, y: Wad, dy: Wad, fee_ppm: Ppm, slippage_tolerance_ppm: Ppm,
+    x: Wad,
+    y: Wad,
+    dy: Wad,
+    fee_ppm: Ppm,
+    slippage_tolerance_ppm: Ppm,
 ) -> Result<Wad, AmmError> {
+    ensure_fee_ppm(fee_ppm)?;
     let dx = get_amount_in(x, y, dy, fee_ppm)?;
-    let tol = if slippage_tolerance_ppm > PPM_SCALE { PPM_SCALE } else { slippage_tolerance_ppm } as u64;
+    let tol = if slippage_tolerance_ppm > PPM_SCALE {
+        PPM_SCALE
+    } else {
+        slippage_tolerance_ppm
+    } as u64;
     let factor = (PPM_SCALE as u64) + tol; // (1 + tol)
     let n = U256::from(dx) * U256::from(factor);
     let q = ceil_div_u256(n, U256::from(PPM_SCALE as u64)); // ceil
@@ -92,10 +122,30 @@ mod tests {
 
     const FEE0: Ppm = 0;
     const FEE3: Ppm = 3000; // 0,30%
+    const FEE_INVALID: Ppm = PPM_SCALE + 1;
+
+    #[test]
+    fn t_invalid_fee_rejected() {
+        let (x, y) = (1_000_000u128 * WAD, 1_000_000u128 * WAD);
+        let dx = 10_000u128 * WAD;
+        let dy = 9_500u128 * WAD;
+
+        let err_exec = execution_price_x_to_y(x, y, dx, FEE_INVALID).unwrap_err();
+        assert_eq!(err_exec, AmmError::InvalidFee);
+
+        let err_slippage = slippage_ppm_x_to_y(x, y, dx, FEE_INVALID).unwrap_err();
+        assert_eq!(err_slippage, AmmError::InvalidFee);
+
+        let err_min_out = min_out_with_tolerance(x, y, dx, FEE_INVALID, 5_000).unwrap_err();
+        assert_eq!(err_min_out, AmmError::InvalidFee);
+
+        let err_max_in = max_in_with_tolerance(x, y, dy, FEE_INVALID, 5_000).unwrap_err();
+        assert_eq!(err_max_in, AmmError::InvalidFee);
+    }
 
     #[test]
     fn t_spot_prices_basic() {
-        let (x, y) = (1_000_000u128*WAD, 2_000_000u128*WAD);
+        let (x, y) = (1_000_000u128 * WAD, 2_000_000u128 * WAD);
         let p_xy = spot_price_x_in_y(x, y).unwrap(); // 2.0
         let p_yx = spot_price_y_in_x(x, y).unwrap(); // 0.5
         assert_eq!(p_xy, 2 * WAD);
@@ -104,17 +154,25 @@ mod tests {
 
     #[test]
     fn t_slippage_no_fee_vs_fee() {
-        let (x, y, dx) = (1_000_000u128*WAD, 1_000_000u128*WAD, 10_000u128*WAD);
+        let (x, y, dx) = (1_000_000u128 * WAD, 1_000_000u128 * WAD, 10_000u128 * WAD);
         let s0 = slippage_ppm_x_to_y(x, y, dx, FEE0).unwrap();
         let s3 = slippage_ppm_x_to_y(x, y, dx, FEE3).unwrap();
         // Janela bem apertada em torno de ~1.00% e ~1.30% para acomodar nearest-even
-        assert!((9_800..=10_200).contains(&s0), "s0={}ppm (esperado ~10_000ppm)", s0);
-        assert!((12_800..=13_200).contains(&s3), "s3={}ppm (esperado ~13_000ppm)", s3);
+        assert!(
+            (9_800..=10_200).contains(&s0),
+            "s0={}ppm (esperado ~10_000ppm)",
+            s0
+        );
+        assert!(
+            (12_800..=13_200).contains(&s3),
+            "s3={}ppm (esperado ~13_000ppm)",
+            s3
+        );
     }
 
     #[test]
     fn t_min_out_with_tolerance() {
-        let (x, y, dx) = (1_000_000u128*WAD, 1_000_000u128*WAD, 10_000u128*WAD);
+        let (x, y, dx) = (1_000_000u128 * WAD, 1_000_000u128 * WAD, 10_000u128 * WAD);
         let min_out = min_out_with_tolerance(x, y, dx, FEE3, 5_000).unwrap();
 
         // Esperado = floor( out * (1 - tol) ), usando o out real
@@ -127,7 +185,7 @@ mod tests {
 
     #[test]
     fn t_max_in_with_tolerance() {
-        let (x, y, dy) = (1_000_000u128*WAD, 1_000_000u128*WAD, 9_870u128*WAD);
+        let (x, y, dy) = (1_000_000u128 * WAD, 1_000_000u128 * WAD, 9_870u128 * WAD);
         let max_in = max_in_with_tolerance(x, y, dy, FEE3, 5_000).unwrap();
 
         // Esperado = ceil( dx_core * (1 + tol) ), usando o dx_core real
@@ -153,7 +211,7 @@ mod tests {
 
     #[test]
     fn t_exec_price_matches_ratio_out_over_dx() {
-        let (x, y, dx) = (1_000_000u128*WAD, 1_000_000u128*WAD, 10_000u128*WAD);
+        let (x, y, dx) = (1_000_000u128 * WAD, 1_000_000u128 * WAD, 10_000u128 * WAD);
         let out = get_amount_out(x, y, dx, FEE0).unwrap();
         let p_exec = execution_price_x_to_y(x, y, dx, FEE0).unwrap();
         let p_exec_check = (U256::from(out) * U256::from(WAD)) / U256::from(dx);

--- a/src/amm/swap.rs
+++ b/src/amm/swap.rs
@@ -4,13 +4,18 @@
 
 use super::errors::AmmError;
 use super::guardrails::{
-    checked_add,
-    div_nearest_even_u256_to_u128,
-    ensure_nonzero,
-    ensure_reserves,
+    checked_add, div_nearest_even_u256_to_u128, ensure_nonzero, ensure_reserves,
     u256_to_u128_checked,
 };
-use super::types::{U256, Ppm, Wad, PPM_SCALE, MIN_RESERVE};
+use super::types::{Ppm, Wad, MIN_RESERVE, PPM_SCALE, U256};
+
+#[inline]
+pub(crate) fn ensure_fee_ppm(fee_ppm: Ppm) -> Result<(), AmmError> {
+    if fee_ppm > PPM_SCALE {
+        return Err(AmmError::InvalidFee);
+    }
+    Ok(())
+}
 
 #[inline]
 fn ceil_div_u256(n: U256, d: U256) -> U256 {
@@ -20,7 +25,9 @@ fn ceil_div_u256(n: U256, d: U256) -> U256 {
 
 #[inline]
 fn fee_on_input_ceil(dx: Wad, fee_ppm: Ppm) -> Result<Wad, AmmError> {
-    if fee_ppm == 0 { return Ok(0); }
+    if fee_ppm == 0 {
+        return Ok(0);
+    }
     let n = U256::from(dx) * U256::from(fee_ppm as u64);
     let d = U256::from(PPM_SCALE as u64);
     let fee_u256 = ceil_div_u256(n, d);
@@ -35,11 +42,14 @@ fn fee_on_input_ceil(dx: Wad, fee_ppm: Ppm) -> Result<Wad, AmmError> {
 pub fn get_amount_out(x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm) -> Result<Wad, AmmError> {
     ensure_reserves(x, y)?;
     ensure_nonzero(dx)?;
+    ensure_fee_ppm(fee_ppm)?;
 
     // taxa sobre o input
     let dx_fee = fee_on_input_ceil(dx, fee_ppm)?;
     let dx_net = dx.checked_sub(dx_fee).ok_or(AmmError::Overflow)?;
-    if dx_net == 0 { return Err(AmmError::InputTooSmall); }
+    if dx_net == 0 {
+        return Err(AmmError::InputTooSmall);
+    }
 
     // x' = x + dx_net (checado)
     let x1 = checked_add(x, dx_net)?;
@@ -53,7 +63,9 @@ pub fn get_amount_out(x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm) -> Result<Wad, AmmE
 
     // y' >= min_reserve
     let y1 = y.checked_sub(out).ok_or(AmmError::Overflow)?;
-    if y1 < MIN_RESERVE { return Err(AmmError::MinReserveBreached); }
+    if y1 < MIN_RESERVE {
+        return Err(AmmError::MinReserveBreached);
+    }
 
     Ok(out)
 }
@@ -69,6 +81,7 @@ pub fn get_amount_out(x: Wad, y: Wad, dx: Wad, fee_ppm: Ppm) -> Result<Wad, AmmE
 pub fn get_amount_in(x: Wad, y: Wad, dy: Wad, fee_ppm: Ppm) -> Result<Wad, AmmError> {
     ensure_reserves(x, y)?;
     ensure_nonzero(dy)?;
+    ensure_fee_ppm(fee_ppm)?;
 
     // Não pode esvaziar o pool além do mínimo
     if dy > y.checked_sub(MIN_RESERVE).ok_or(AmmError::Overflow)? {
@@ -82,13 +95,19 @@ pub fn get_amount_in(x: Wad, y: Wad, dy: Wad, fee_ppm: Ppm) -> Result<Wad, AmmEr
     let dx_net = u256_to_u128_checked(ceil_div_u256(num, den))?;
 
     // dx_gross = ceil( dx_net * 1e6 / (1e6 - fee) )
-    let denom_ppm = (PPM_SCALE as u64).checked_sub(fee_ppm as u64).ok_or(AmmError::InputTooSmall)?;
-    if denom_ppm == 0 { return Err(AmmError::InputTooSmall); }
+    let denom_ppm = (PPM_SCALE as u64)
+        .checked_sub(fee_ppm as u64)
+        .ok_or(AmmError::InputTooSmall)?;
+    if denom_ppm == 0 {
+        return Err(AmmError::InputTooSmall);
+    }
     let mut hi = u256_to_u128_checked(ceil_div_u256(
         U256::from(dx_net) * U256::from(PPM_SCALE as u64),
         U256::from(denom_ppm),
     ))?;
-    if hi == 0 { hi = 1; }
+    if hi == 0 {
+        hi = 1;
+    }
 
     // garante que `hi` satisfaz (expande se necessário)
     let mut last_safe_hi: Wad = 0;
@@ -145,7 +164,7 @@ pub fn get_amount_in(x: Wad, y: Wad, dy: Wad, fee_ppm: Ppm) -> Result<Wad, AmmEr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::amm::types::{MIN_RESERVE, U256, Ppm, WAD, PPM_SCALE};
+    use crate::amm::types::{Ppm, MIN_RESERVE, PPM_SCALE, U256, WAD};
 
     fn legacy_get_amount_in_with_hi(
         x: Wad,
@@ -157,11 +176,7 @@ mod tests {
         crate::amm::guardrails::ensure_reserves(x, y)?;
         crate::amm::guardrails::ensure_nonzero(dy)?;
 
-        if dy
-            >= y
-                .checked_sub(MIN_RESERVE)
-                .ok_or(AmmError::Overflow)?
-        {
+        if dy >= y.checked_sub(MIN_RESERVE).ok_or(AmmError::Overflow)? {
             return Err(AmmError::MinReserveBreached);
         }
 
@@ -195,6 +210,17 @@ mod tests {
 
     const FEE0: Ppm = 0;
     const FEE3: Ppm = 3000; // 0,30%
+    const FEE_INVALID: Ppm = PPM_SCALE + 1;
+
+    #[test]
+    fn t_fee_above_scale_rejected() {
+        let (x, y) = (1_000_000u128 * WAD, 1_000_000u128 * WAD);
+        let err_out = get_amount_out(x, y, 10 * WAD, FEE_INVALID).unwrap_err();
+        assert_eq!(err_out, AmmError::InvalidFee);
+
+        let err_in = get_amount_in(x, y, 10 * WAD, FEE_INVALID).unwrap_err();
+        assert_eq!(err_in, AmmError::InvalidFee);
+    }
 
     #[test]
     fn t_out_symmetric_no_fee() {
@@ -204,7 +230,8 @@ mod tests {
         // esperado via y* arredondado igual ao core
         let x1 = x + dx;
         let k = U256::from(x) * U256::from(y);
-        let y_star = crate::amm::guardrails::div_nearest_even_u256_to_u128(k, U256::from(x1)).unwrap();
+        let y_star =
+            crate::amm::guardrails::div_nearest_even_u256_to_u128(k, U256::from(x1)).unwrap();
         assert_eq!(out, y - y_star);
 
         // y' permanece >= mínimo
@@ -220,7 +247,8 @@ mod tests {
         let dx_fee = super::fee_on_input_ceil(dx, FEE3).unwrap();
         let x1 = x + (dx - dx_fee);
         let k = U256::from(x) * U256::from(y);
-        let y_star = crate::amm::guardrails::div_nearest_even_u256_to_u128(k, U256::from(x1)).unwrap();
+        let y_star =
+            crate::amm::guardrails::div_nearest_even_u256_to_u128(k, U256::from(x1)).unwrap();
         let expected = y - y_star;
         assert_eq!(out, expected);
     }
@@ -245,7 +273,8 @@ mod tests {
 
         let x1 = x + dx;
         let k = U256::from(x) * U256::from(y);
-        let y_star = crate::amm::guardrails::div_nearest_even_u256_to_u128(k, U256::from(x1)).unwrap();
+        let y_star =
+            crate::amm::guardrails::div_nearest_even_u256_to_u128(k, U256::from(x1)).unwrap();
         let expected = y - y_star;
         assert_eq!(out, expected);
     }
@@ -302,12 +331,12 @@ mod tests {
     }
 
     #[test]
-    fn t_fee_overflow_propagates() {
+    fn t_fee_overflow_guarded() {
         let x = MIN_RESERVE * 2;
         let y = MIN_RESERVE * 2;
         let dx = u128::MAX;
         let err = get_amount_out(x, y, dx, u32::MAX).unwrap_err();
-        assert_eq!(err, AmmError::Overflow);
+        assert_eq!(err, AmmError::InvalidFee);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an `InvalidFee` error and helper to enforce `fee_ppm` never exceeds `PPM_SCALE`
- call the guard from AMM swap and pricing paths and add unit coverage for invalid fees

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d863265b408330a83fa779f861fcf0