### PR TITLE
Add AMM error catalog and reporting index

### DIFF
--- a/ops/errors/README.md
+++ b/ops/errors/README.md
@@ -1,0 +1,21 @@
+# Catálogo de erros do AMM
+
+Este diretório materializa o mapeamento oficial entre `AmmError` (Rust) e os códigos operacionais do domínio AMM. O catálogo serve tanto para integrações (tratativa de erros, dashboards, alertas) quanto para governança (auditoria, versionamento e SLOs de resposta).
+
+## Como introduzir um novo `AmmError`
+
+1. **Defina o erro na aplicação**: adicione a nova variante em [`src/amm/errors.rs`](../../src/amm/errors.rs) com a mensagem padrão desejada no `Display`.
+2. **Atribua o próximo código**: no arquivo [`catalog_amm.yaml`](catalog_amm.yaml) acrescente uma nova entrada usando o prefixo `CE-AMM` e o próximo número sequencial livre (`CE-AMM-0007`, `CE-AMM-0008`, ...). Preserve `variant`, `code`, `default_message` e `http_status`.
+3. **Atualize os testes de cobertura**: inclua a nova variante na lista `expected_catalog()` do teste [`tests/amm_error_catalog.rs`](../../tests/amm_error_catalog.rs) para garantir que o catálogo continue completo.
+4. **Regenere o índice JSON** (para dashboards): execute o script [`ops/scripts/generate_amm_error_index.py`](../scripts/generate_amm_error_index.py) a partir da raiz do repositório. Ele consome o YAML e reescreve [`ops/reports/amm_error_index.json`](../reports/amm_error_index.json).
+5. **Revise e commite**: garanta que `catalog_amm.yaml`, o teste e o `amm_error_index.json` estejam sincronizados antes de abrir PR.
+
+## Índice JSON para dashboards
+
+O arquivo [`../reports/amm_error_index.json`](../reports/amm_error_index.json) resume `{variant, code, default_message}` e é usado por painéis de observabilidade. Para atualizá-lo:
+
+```bash
+./ops/scripts/generate_amm_error_index.py
+```
+
+O script não depende de bibliotecas externas e reconstrói o JSON com base no catálogo versionado. Incorpore o resultado no mesmo commit do ajuste no YAML para manter os artefatos alinhados.

--- a/ops/errors/catalog_amm.yaml
+++ b/ops/errors/catalog_amm.yaml
@@ -1,0 +1,29 @@
+meta:
+  domain: "credit-engine.amm"
+  prefix: "CE-AMM"
+  version: "1.0.0"
+errors:
+  - variant: ZeroAmount
+    code: "CE-AMM-0001"
+    default_message: "amount deve ser > 0"
+    http_status: 400
+  - variant: ZeroReserve
+    code: "CE-AMM-0002"
+    default_message: "reserve deve ser > 0"
+    http_status: 400
+  - variant: MinReserveBreached
+    code: "CE-AMM-0003"
+    default_message: "reserva ficaria abaixo do mínimo"
+    http_status: 409
+  - variant: Overflow
+    code: "CE-AMM-0004"
+    default_message: "overflow/underflow numérico"
+    http_status: 500
+  - variant: InputTooSmall
+    code: "CE-AMM-0005"
+    default_message: "input efetivo após taxa é 0"
+    http_status: 422
+  - variant: InvalidFee
+    code: "CE-AMM-0006"
+    default_message: "fee_ppm deve ser ≤ 1e6"
+    http_status: 400

--- a/ops/reports/amm_error_index.json
+++ b/ops/reports/amm_error_index.json
@@ -1,0 +1,32 @@
+[
+  {
+    "variant": "ZeroAmount",
+    "code": "CE-AMM-0001",
+    "default_message": "amount deve ser > 0"
+  },
+  {
+    "variant": "ZeroReserve",
+    "code": "CE-AMM-0002",
+    "default_message": "reserve deve ser > 0"
+  },
+  {
+    "variant": "MinReserveBreached",
+    "code": "CE-AMM-0003",
+    "default_message": "reserva ficaria abaixo do mínimo"
+  },
+  {
+    "variant": "Overflow",
+    "code": "CE-AMM-0004",
+    "default_message": "overflow/underflow numérico"
+  },
+  {
+    "variant": "InputTooSmall",
+    "code": "CE-AMM-0005",
+    "default_message": "input efetivo após taxa é 0"
+  },
+  {
+    "variant": "InvalidFee",
+    "code": "CE-AMM-0006",
+    "default_message": "fee_ppm deve ser ≤ 1e6"
+  }
+]

--- a/ops/scripts/generate_amm_error_index.py
+++ b/ops/scripts/generate_amm_error_index.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Build the JSON index of AMM error codes from the YAML catalog."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "errors" / "catalog_amm.yaml"
+OUTPUT = ROOT / "reports" / "amm_error_index.json"
+
+
+def _strip_quotes(value: str) -> str:
+    value = value.strip()
+    if value.startswith("\"") and value.endswith("\""):
+        return value[1:-1]
+    return value
+
+
+def extract_entries(text: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_errors = False
+    for raw_line in text.splitlines():
+        if not raw_line.strip():
+            continue
+        if raw_line.startswith("errors:"):
+            in_errors = True
+            continue
+        if not in_errors:
+            continue
+        if raw_line.startswith("  - "):
+            if current:
+                entries.append(current)
+            current = {}
+            line = raw_line.strip()
+            key, value = line[len("- "):].split(":", 1)
+            current[key.strip()] = _strip_quotes(value)
+            continue
+        if current is None:
+            continue
+        line = raw_line.strip()
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        current[key.strip()] = _strip_quotes(value)
+    if current:
+        entries.append(current)
+    return entries
+
+
+def main() -> None:
+    catalog_text = CATALOG.read_text(encoding="utf-8")
+    entries = extract_entries(catalog_text)
+    index = [
+        {
+            "variant": entry["variant"],
+            "code": entry["code"],
+            "default_message": entry["default_message"],
+        }
+        for entry in entries
+    ]
+    OUTPUT.write_text(
+        json.dumps(index, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/amm_error_catalog.rs
+++ b/tests/amm_error_catalog.rs
@@ -1,0 +1,83 @@
+use credit_engine_core::amm::errors::AmmError;
+use std::fs;
+
+fn expected_catalog() -> Vec<(AmmError, &'static str, &'static str)> {
+    vec![
+        (
+            AmmError::ZeroAmount,
+            "CE-AMM-0001",
+            "default_message: \"amount deve ser > 0\"",
+        ),
+        (
+            AmmError::ZeroReserve,
+            "CE-AMM-0002",
+            "default_message: \"reserve deve ser > 0\"",
+        ),
+        (
+            AmmError::MinReserveBreached,
+            "CE-AMM-0003",
+            "default_message: \"reserva ficaria abaixo do mínimo\"",
+        ),
+        (
+            AmmError::Overflow,
+            "CE-AMM-0004",
+            "default_message: \"overflow/underflow numérico\"",
+        ),
+        (
+            AmmError::InputTooSmall,
+            "CE-AMM-0005",
+            "default_message: \"input efetivo após taxa é 0\"",
+        ),
+        (
+            AmmError::InvalidFee,
+            "CE-AMM-0006",
+            "default_message: \"fee_ppm deve ser ≤ 1e6\"",
+        ),
+    ]
+}
+
+#[test]
+fn catalog_covers_all_amm_errors() {
+    let catalog = fs::read_to_string("ops/errors/catalog_amm.yaml").expect("catalog readable");
+
+    for (variant, code, message_line) in expected_catalog() {
+        let variant_name = format!("variant: {:?}", variant);
+        assert!(
+            catalog.contains(&variant_name),
+            "missing variant mapping for {}",
+            variant_name
+        );
+        let code_line = format!("code: \"{}\"", code);
+        assert!(
+            catalog.contains(&code_line),
+            "missing code mapping for {}",
+            variant_name
+        );
+        assert!(
+            catalog.contains(message_line),
+            "missing default message for {}",
+            variant_name
+        );
+    }
+
+    let declared = catalog.matches("variant:").count();
+    let expected = expected_catalog().len();
+    assert_eq!(
+        declared, expected,
+        "catalog has {} entries but {} variants are expected",
+        declared, expected
+    );
+}
+
+#[test]
+fn http_status_are_present() {
+    let catalog = fs::read_to_string("ops/errors/catalog_amm.yaml").expect("catalog readable");
+    for status in [400, 409, 500, 422] {
+        let needle = format!("http_status: {}", status);
+        assert!(
+            catalog.contains(&needle),
+            "expected to find {} in catalog",
+            needle
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a YAML catalog for `AmmError` variants with CE-AMM codes and HTTP status metadata
- document how to extend the catalog and generate the derived JSON index for dashboards
- add a generator script and tests that guard the mapping between the enum and the catalog

## Testing
- cargo test --test amm_error_catalog

------
https://chatgpt.com/codex/tasks/task_e_68d890d67fc8833085e513d6e1288cfb