### PR TITLE
Make AMM error packaging reproducible without committed binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 **/*.DS_Store
 *.log
+out/**/*.zip
 /.idea
 /.vscode

--- a/PR_COMMENT.md
+++ b/PR_COMMENT.md
@@ -1,7 +1,8 @@
 ## Resumo
-- provisionada a topologia mínima dos diretórios de domínio (BE, FE, DATA, ML, SPECS, INFRA, OPS TESTS) com governança de owners/watchers
-- adicionados Makefiles, scripts de bootstrap e lockfiles por domínio para lint/test/build/evidence
-- inventário operacional atualizado (`ops/reports/inventory.json`) com owners, watchers e artefatos versionados
+- Hardened `AmmError` into a stable contract with error codes, user messages, HTTP hints and descriptors, plus structured logging usage.
+- Published the human catalog (`ops/errors/catalog_amm.yaml`), maintainer guide, QA index, and new contract regression test.
+- Replaced tracked ZIP payloads with a reproducible packaging script so artifacts stay reproducible without blocking PR creation.
 
 ## Testes
-- não executados (estrutura inicial, sem código executável)
+- `cargo test`
+- `rustfmt --edition 2021 --check src/amm/errors.rs src/bin/obs_demo.rs tests/amm_error_contract.rs`

--- a/_jira_out/amm_error_contract.txt
+++ b/_jira_out/amm_error_contract.txt
@@ -1,0 +1,8 @@
+Branch: work
+Tag: amm-error-contract-v1 (annotated)
+Short HEAD: resolve tag `amm-error-contract-v1` after merge
+PR: <pending>
+Artifacts ZIP: (generate via `ops/scripts/package_amm_error_contract.sh`) out/artifacts/amm_error_contract_artifacts.zip
+Patches ZIP: (generate via `ops/scripts/package_amm_error_contract.sh`) out/patches/amm_error_contract_patches.zip
+
+Recap: Hardened the AMM error surface with stable CE-AMM codes/messages, logged adoption, a full catalog + maintainer guide, a QA index, regression tests, and archived formatter/test evidence so UI/integrators can rely on the contract.

--- a/ops/errors/README.md
+++ b/ops/errors/README.md
@@ -1,0 +1,45 @@
+# AMM Error Contract Guide
+
+This guide documents how to evolve the AMM error contract safely. The contract is
+consumed by UI, API, and observability surfaces and **must remain stable**.
+
+## Adding a new error variant
+
+1. **Declare the variant** in `src/amm/errors.rs` and keep the enum payload-free.
+2. **Assign contract metadata**:
+   - Extend the `AmmError::ALL_VARIANTS` array with the new variant.
+   - Provide mappings in `error_code()`, `user_message()`, `http_status()`, and `variant_name()`.
+   - Codes must follow `CE-AMM-XXXX`, be unique, and never be reused.
+   - Messages are short, neutral English sentences ending with a period.
+3. **Update the catalog** in `ops/errors/catalog_amm.yaml` with the same metadata.
+4. **Refresh the QA index** in `ops/reports/amm_error_index.json` (sorted by code).
+5. **Extend the tests**:
+   - Update assertions in `tests/amm_error_contract.rs` if new validation is required.
+   - Ensure `variant_count::<AmmError>()` matches the number of variants.
+6. **Document evidence**: run `ops/scripts/package_amm_error_contract.sh` to
+   regenerate the artifacts bundle so the formatter, linter, and test logs
+   capture the new variant.
+
+## Validating changes locally
+
+```bash
+cargo fmt
+cargo clippy --all-targets --all-features
+cargo test
+```
+
+Keep the logs for these commands; they are bundled in the artifacts ZIP.
+
+## Releasing the change
+
+1. Execute `ops/scripts/package_amm_error_contract.sh` (optionally passing the
+   merge base) to refresh logs, artifacts, and patch outputs under `out/`.
+2. The script writes the Git diff to `out/patches/amm_error_contract.patch` and
+   produces ZIP archives (ignored by Git) for hand-off when required.
+3. Tag the commit with an **annotated** tag (`git tag -a`).
+4. Update the Jira comment template in `_jira_out/amm_error_contract.txt`.
+
+Each release should be auditable: the catalog, QA index, tests, and logs must be
+present so Support, Ops, and integrators can rely on the error surface. The
+packaging script keeps the reproducible ZIPs outside version control so they do
+not block PR creation while remaining one command away for distribution.

--- a/ops/errors/catalog_amm.yaml
+++ b/ops/errors/catalog_amm.yaml
@@ -1,0 +1,29 @@
+meta:
+  domain: AMM
+  prefix: CE-AMM
+  version: 1
+errors:
+  - variant: ZeroAmount
+    code: CE-AMM-0001
+    default_message: "Input amount must be greater than zero."
+    http_status: 400
+  - variant: ZeroReserve
+    code: CE-AMM-0002
+    default_message: "Reserves must stay above zero."
+    http_status: 400
+  - variant: MinReserveBreached
+    code: CE-AMM-0003
+    default_message: "Operation would breach the minimum reserve."
+    http_status: 409
+  - variant: Overflow
+    code: CE-AMM-0004
+    default_message: "Numerical overflow or underflow detected."
+    http_status: 500
+  - variant: InputTooSmall
+    code: CE-AMM-0005
+    default_message: "Effective input amount is too small."
+    http_status: 400
+  - variant: InvalidFee
+    code: CE-AMM-0006
+    default_message: "Fee ppm must be at most 1,000,000."
+    http_status: 400

--- a/ops/reports/amm_error_index.json
+++ b/ops/reports/amm_error_index.json
@@ -1,0 +1,46 @@
+{
+  "meta": {
+    "generated_at": "2025-09-28T01:17:29.202927+00:00",
+    "domain": "AMM",
+    "prefix": "CE-AMM",
+    "version": 1
+  },
+  "errors": [
+    {
+      "variant": "ZeroAmount",
+      "code": "CE-AMM-0001",
+      "message": "Input amount must be greater than zero.",
+      "http_status": 400
+    },
+    {
+      "variant": "ZeroReserve",
+      "code": "CE-AMM-0002",
+      "message": "Reserves must stay above zero.",
+      "http_status": 400
+    },
+    {
+      "variant": "MinReserveBreached",
+      "code": "CE-AMM-0003",
+      "message": "Operation would breach the minimum reserve.",
+      "http_status": 409
+    },
+    {
+      "variant": "Overflow",
+      "code": "CE-AMM-0004",
+      "message": "Numerical overflow or underflow detected.",
+      "http_status": 500
+    },
+    {
+      "variant": "InputTooSmall",
+      "code": "CE-AMM-0005",
+      "message": "Effective input amount is too small.",
+      "http_status": 400
+    },
+    {
+      "variant": "InvalidFee",
+      "code": "CE-AMM-0006",
+      "message": "Fee ppm must be at most 1,000,000.",
+      "http_status": 400
+    }
+  ]
+}

--- a/ops/scripts/package_amm_error_contract.sh
+++ b/ops/scripts/package_amm_error_contract.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+LOG_DIR="$ROOT_DIR/out/logs"
+ARTIFACTS_DIR="$ROOT_DIR/out/artifacts"
+PATCHES_DIR="$ROOT_DIR/out/patches"
+
+mkdir -p "$LOG_DIR" "$ARTIFACTS_DIR" "$PATCHES_DIR"
+
+if ! command -v zip >/dev/null 2>&1; then
+  echo "zip command not found; please install it to package the artifacts." >&2
+  exit 1
+fi
+
+BASE_REF="${1:-}"
+if [[ -z "$BASE_REF" ]]; then
+  if git show-ref --verify --quiet refs/heads/main; then
+    BASE_REF=$(git merge-base main HEAD)
+  elif upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null); then
+    BASE_REF=$(git merge-base "$upstream" HEAD)
+  fi
+fi
+
+if [[ -z "$BASE_REF" ]]; then
+  echo "Unable to resolve merge-base for patches. Provide it explicitly as the first argument." >&2
+  exit 1
+fi
+
+echo "Using merge base: $BASE_REF"
+
+TEST_LOG="$LOG_DIR/cargo_test.log"
+FMT_LOG="$LOG_DIR/rustfmt.log"
+
+echo "Running cargo test (logs -> $TEST_LOG)"
+cargo test --all-targets --all-features >"$TEST_LOG" 2>&1
+
+echo "Running rustfmt check (logs -> $FMT_LOG)"
+rustfmt --edition 2021 --check \
+  src/amm/errors.rs \
+  src/bin/obs_demo.rs \
+  tests/amm_error_contract.rs >"$FMT_LOG" 2>&1
+
+ARTIFACT_ZIP="$ARTIFACTS_DIR/amm_error_contract_artifacts.zip"
+PATCH_FILE="$PATCHES_DIR/amm_error_contract.patch"
+PATCH_ZIP="$PATCHES_DIR/amm_error_contract_patches.zip"
+
+rm -f "$ARTIFACT_ZIP" "$PATCH_ZIP"
+
+ZIP_LOG="$ARTIFACTS_DIR/zip_artifacts.log"
+PATCH_ZIP_LOG="$PATCHES_DIR/zip_patches.log"
+
+echo "Packaging artifacts -> $ARTIFACT_ZIP"
+TMP_ARTIFACT_LOG=$(mktemp)
+zip -r "$ARTIFACT_ZIP" \
+  ops/errors/catalog_amm.yaml \
+  ops/errors/README.md \
+  ops/reports/amm_error_index.json \
+  tests/amm_error_contract.rs \
+  out/logs/ >"$TMP_ARTIFACT_LOG"
+mv "$TMP_ARTIFACT_LOG" "$ZIP_LOG"
+
+echo "Writing diff to $PATCH_FILE (base: $BASE_REF)"
+TMP_PATCH=$(mktemp)
+git diff "$BASE_REF" >"$TMP_PATCH"
+mv "$TMP_PATCH" "$PATCH_FILE"
+
+echo "Packaging patches -> $PATCH_ZIP"
+TMP_PATCH_LOG=$(mktemp)
+zip -j "$PATCH_ZIP" "$PATCH_FILE" >"$TMP_PATCH_LOG"
+mv "$TMP_PATCH_LOG" "$PATCH_ZIP_LOG"
+
+echo "Artifacts ready under out/. Files tracked by git exclude the generated ZIP archives."

--- a/out/artifacts/zip_artifacts.log
+++ b/out/artifacts/zip_artifacts.log
@@ -1,0 +1,7 @@
+  adding: ops/errors/catalog_amm.yaml (deflated 61%)
+  adding: ops/errors/README.md (deflated 49%)
+  adding: ops/reports/amm_error_index.json (deflated 65%)
+  adding: tests/amm_error_contract.rs (deflated 64%)
+  adding: out/logs/ (stored 0%)
+  adding: out/logs/cargo_test.log (deflated 72%)
+  adding: out/logs/rustfmt.log (stored 0%)

--- a/out/logs/cargo_test.log
+++ b/out/logs/cargo_test.log
@@ -1,0 +1,263 @@
+   Compiling proc-macro2 v1.0.101
+   Compiling unicode-ident v1.0.19
+   Compiling libc v0.2.175
+   Compiling pin-project-lite v0.2.16
+   Compiling cfg-if v1.0.3
+   Compiling futures-core v0.3.31
+   Compiling itoa v1.0.15
+   Compiling once_cell v1.21.3
+   Compiling stable_deref_trait v1.2.0
+   Compiling serde_core v1.0.222
+   Compiling memchr v2.7.5
+   Compiling futures-sink v0.3.31
+   Compiling quote v1.0.40
+   Compiling socket2 v0.6.0
+   Compiling mio v1.0.4
+   Compiling syn v2.0.106
+   Compiling fnv v1.0.7
+   Compiling getrandom v0.3.3
+   Compiling tracing-core v0.1.34
+   Compiling pin-utils v0.1.0
+   Compiling bytes v1.10.1
+   Compiling slab v0.4.11
+   Compiling futures-io v0.3.31
+   Compiling smallvec v1.15.1
+   Compiling percent-encoding v2.3.2
+   Compiling futures-task v0.3.31
+   Compiling http v1.3.1
+   Compiling ryu v1.0.20
+   Compiling zerocopy v0.8.27
+   Compiling serde v1.0.222
+   Compiling litemap v0.8.0
+   Compiling writeable v0.6.1
+   Compiling http-body v1.0.1
+   Compiling icu_properties_data v2.0.1
+   Compiling icu_normalizer_data v2.0.0
+   Compiling rand_core v0.9.3
+   Compiling futures-channel v0.3.31
+   Compiling either v1.15.0
+   Compiling tower-service v0.3.3
+   Compiling bitflags v2.9.4
+   Compiling serde_json v1.0.145
+   Compiling thiserror v2.0.16
+   Compiling synstructure v0.13.2
+   Compiling itertools v0.10.5
+   Compiling httparse v1.10.1
+   Compiling ppv-lite86 v0.2.21
+   Compiling anyhow v1.0.99
+   Compiling regex-syntax v0.8.6
+   Compiling zerofrom-derive v0.1.6
+   Compiling yoke-derive v0.8.0
+   Compiling zerovec-derive v0.11.1
+   Compiling displaydoc v0.2.5
+   Compiling tokio-macros v2.5.0
+   Compiling zerofrom v0.1.6
+   Compiling yoke v0.8.0
+   Compiling zerovec v0.11.4
+   Compiling futures-macro v0.3.31
+   Compiling tokio v1.47.1
+   Compiling tracing-attributes v0.1.30
+   Compiling tinystr v0.8.1
+   Compiling icu_locale_core v2.0.0
+   Compiling futures-util v0.3.31
+   Compiling potential_utf v0.1.3
+   Compiling zerotrie v0.2.2
+   Compiling tracing v0.1.41
+   Compiling serde_derive v1.0.222
+   Compiling icu_provider v2.0.0
+   Compiling icu_collections v2.0.0
+   Compiling thiserror-impl v2.0.16
+   Compiling tower-layer v0.3.3
+   Compiling icu_properties v2.0.1
+   Compiling icu_normalizer v2.0.0
+   Compiling rand_chacha v0.9.0
+   Compiling base64 v0.22.1
+   Compiling try-lock v0.2.5
+   Compiling log v0.4.28
+   Compiling want v0.3.1
+   Compiling idna_adapter v1.2.1
+   Compiling rand v0.9.2
+   Compiling opentelemetry v0.29.1
+   Compiling tokio-stream v0.1.17
+   Compiling regex-automata v0.4.10
+   Compiling http-body-util v0.1.3
+   Compiling form_urlencoded v1.2.2
+   Compiling sync_wrapper v1.0.2
+   Compiling utf8_iter v1.0.4
+   Compiling atomic-waker v1.1.2
+   Compiling hyper v1.7.0
+   Compiling idna v1.1.0
+   Compiling tower v0.5.2
+   Compiling prost-derive v0.13.5
+   Compiling futures-executor v0.3.31
+   Compiling async-trait v0.1.89
+   Compiling pin-project-internal v1.1.10
+   Compiling iri-string v0.7.8
+   Compiling ipnet v2.11.0
+   Compiling lazy_static v1.5.0
+   Compiling glob v0.3.3
+   Compiling opentelemetry_sdk v0.29.0
+   Compiling hyper-util v0.1.17
+   Compiling tower-http v0.6.6
+   Compiling prost v0.13.5
+   Compiling pin-project v1.1.10
+   Compiling url v2.5.7
+   Compiling serde_urlencoded v0.7.1
+   Compiling autocfg v1.5.0
+   Compiling rustix v1.1.2
+   Compiling crunchy v0.2.4
+   Compiling num-traits v0.2.19
+   Compiling reqwest v0.12.23
+   Compiling tonic v0.12.3
+   Compiling sharded-slab v0.1.7
+   Compiling matchers v0.2.0
+   Compiling tracing-log v0.2.0
+   Compiling thread_local v1.1.9
+   Compiling nu-ansi-term v0.50.1
+   Compiling linux-raw-sys v0.11.0
+   Compiling tracing-subscriber v0.3.20
+   Compiling opentelemetry-http v0.29.0
+   Compiling opentelemetry-proto v0.29.0
+   Compiling half v2.6.0
+   Compiling clap_lex v0.7.5
+   Compiling byteorder v1.5.0
+   Compiling hex v0.4.3
+   Compiling ciborium-io v0.2.2
+   Compiling fastrand v2.3.0
+   Compiling static_assertions v1.1.0
+   Compiling anstyle v1.0.11
+   Compiling uint v0.9.5
+   Compiling tempfile v3.22.0
+   Compiling clap_builder v4.5.47
+   Compiling ciborium-ll v0.2.2
+   Compiling opentelemetry-otlp v0.29.0
+   Compiling tracing-opentelemetry v0.30.0
+   Compiling wait-timeout v0.2.1
+   Compiling same-file v1.0.6
+   Compiling quick-error v1.2.3
+   Compiling bit-vec v0.8.0
+   Compiling cast v0.3.0
+   Compiling walkdir v2.5.0
+   Compiling criterion-plot v0.5.0
+   Compiling bit-set v0.8.0
+   Compiling clap v4.5.47
+   Compiling rusty-fork v0.3.0
+   Compiling ciborium v0.2.2
+   Compiling regex v1.11.2
+   Compiling tinytemplate v1.2.1
+   Compiling rand_xorshift v0.4.0
+   Compiling is-terminal v0.4.16
+   Compiling anes v0.1.6
+   Compiling oorandom v11.1.5
+   Compiling unarray v0.1.4
+   Compiling credit-engine-core v0.1.0 (/workspace/trendmarket)
+   Compiling proptest v1.7.0
+   Compiling criterion v0.5.1
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 38s
+     Running unittests src/lib.rs (target/debug/deps/credit_engine_core-1479e44b344d23ac)
+
+running 43 tests
+test amm::guardrails::tests::t_checked_add_sub_over_under_flow ... ok
+test amm::guardrails::tests::t_ensure_nonzero ... ok
+test amm::guardrails::tests::t_ensure_reserves ... ok
+test amm::guardrails::tests::t_u256_div_nearest_even_rounding ... ok
+test amm::guardrails::tests::t_u256_div_nearest_even_extreme_values ... ok
+test amm::liquidity::tests::t_add_liquidity_min_by_y ... ok
+test amm::liquidity::tests::t_add_liquidity_proportional_sym ... ok
+test amm::liquidity::tests::t_add_liquidity_too_small ... ok
+test amm::liquidity::tests::t_initial_mint_min_reserve_guard ... ok
+test amm::liquidity::tests::t_initial_mint_near_u256_limit ... ok
+test amm::liquidity::tests::t_initial_mint_symmetrical ... ok
+test amm::liquidity::tests::t_initial_mint_u128_max_square ... ok
+test amm::liquidity::tests::t_remove_liquidity_10_percent ... ok
+test amm::liquidity::tests::t_remove_liquidity_burn_too_big ... ok
+test amm::liquidity::tests::t_isqrt_u256_handles_max_range ... ok
+test amm::liquidity::tests::t_remove_liquidity_min_reserve_guard ... ok
+test amm::liquidity::tests::t_remove_liquidity_zero_burn ... ok
+test amm::pricing::tests::t_exec_price_matches_ratio_out_over_dx ... ok
+test amm::pricing::tests::t_invalid_fee_rejected ... ok
+test amm::pricing::tests::t_max_in_with_tolerance_overflow ... ok
+test amm::pricing::tests::t_min_out_with_tolerance ... ok
+test amm::pricing::tests::t_safety_invalid_inputs ... ok
+test amm::pricing::tests::t_slippage_tolerance_scaling_overflow ... ok
+test amm::pricing::tests::t_slippage_no_fee_vs_fee ... ok
+test amm::pricing::tests::t_spot_prices_basic ... ok
+test amm::swap::tests::t_dx_net_overflow_errors ... ok
+test amm::swap::tests::t_dx_net_zero_due_fee_rejected ... ok
+test amm::swap::tests::t_dx_tiny_due_rounding_rejected ... ok
+test amm::swap::tests::t_dx_zero_rejected ... ok
+test amm::swap::tests::t_dy_too_large_rejected ... ok
+test amm::swap::tests::t_dy_equal_min_reserve_allowed ... ok
+test amm::swap::tests::t_fee_above_scale_rejected ... ok
+test amm::swap::tests::t_fee_overflow_guarded ... ok
+test amm::pricing::tests::t_max_in_with_tolerance ... ok
+test amm::swap::tests::t_hi_overflow_errors ... ok
+test amm::swap::tests::t_out_asymmetric_no_fee ... ok
+test amm::swap::tests::t_out_symmetric_no_fee ... ok
+test amm::swap::tests::t_out_symmetric_with_fee ... ok
+test amm::swap::tests::t_small_values_min_reserve_guard ... ok
+test amm::swap::tests::t_zero_reserve_rejected ... ok
+test amm::swap::tests::t_in_for_target_out_with_fee_minimal ... ok
+test amm::swap::tests::t_tight_pool_min_reserve_regression ... ok
+[2m2025-09-28T01:56:19.958187Z[0m [31mERROR[0m  [3mname[0m[2m=[0m"BatchSpanProcessor.ExportError" [3merror[0m[2m=[0m"Operation failed: reqwest::Error { kind: Request, url: \"http://localhost:4318/\", source: hyper_util::client::legacy::Error(Connect, ConnectError(\"tcp connect error\", 127.0.0.1:4318, Os { code: 111, kind: ConnectionRefused, message: \"Connection refused\" })) }"
+test telemetry::tests::trace_context_propagator_injects_and_extracts_after_init ... ok
+
+test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+
+     Running unittests src/bin/obs_demo.rs (target/debug/deps/obs_demo-8405b4111421259a)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/amm_error_contract.rs (target/debug/deps/amm_error_contract-9f3b0660a252654a)
+
+running 1 test
+test amm_error_contract_is_exhaustive_and_well_formed ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/fuzz_invariants.rs (target/debug/deps/fuzz_invariants-2eac2f5243c32d2e)
+
+running 1 test
+test invariants_hold ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.33s
+
+     Running tests/golden_cpmm.rs (target/debug/deps/golden_cpmm-bf365f5c1bc91b4b)
+
+running 1 test
+test golden_cpmm_all ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/rounding.rs (target/debug/deps/rounding-8cb7047059f6c7d1)
+
+running 6 tests
+test r1_amount_out_is_floor_of_continuous_value ... ok
+test r3_fee_is_ceil_no_undercollection ... ok
+test r2_amount_in_is_ceil_minimality ... ok
+test r5_burn_amounts_are_floor_of_proportion ... ok
+test r6_intermediate_rounding_is_nearest_even_on_tie ... ok
+test r4_mint_is_floor_of_sqrt_xy ... ok
+
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running benches/bench_liquidity.rs (target/debug/deps/bench_liquidity-8ebfad51017a24ea)
+Testing liquidity/remove_liquidity_partial
+Success
+
+     Running benches/bench_swap.rs (target/debug/deps/bench_swap-0a398b7b0f9d3add)
+Testing swap/sym_small_f0
+Success
+Testing swap/sym_large_f0
+Success
+Testing swap/asym_xgg_f0
+Success
+Testing swap/asym_ygg_f0
+Success
+Testing swap/sym_small_fee_f300
+Success
+Testing swap/asym_xgg_fee_f300
+Success
+

--- a/out/patches/amm_error_contract.patch
+++ b/out/patches/amm_error_contract.patch
@@ -1,0 +1,1315 @@
+diff --git a/.gitignore b/.gitignore
+index 8209b89..2e234e3 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,5 +1,6 @@
+ /target
+ **/*.DS_Store
+ *.log
++out/**/*.zip
+ /.idea
+ /.vscode
+diff --git a/PR_COMMENT.md b/PR_COMMENT.md
+index 0b73380..2550690 100644
+--- a/PR_COMMENT.md
++++ b/PR_COMMENT.md
+@@ -1,7 +1,8 @@
+ ## Resumo
+-- provisionada a topologia mínima dos diretórios de domínio (BE, FE, DATA, ML, SPECS, INFRA, OPS TESTS) com governança de owners/watchers
+-- adicionados Makefiles, scripts de bootstrap e lockfiles por domínio para lint/test/build/evidence
+-- inventário operacional atualizado (`ops/reports/inventory.json`) com owners, watchers e artefatos versionados
++- Hardened `AmmError` into a stable contract with error codes, user messages, HTTP hints and descriptors, plus structured logging usage.
++- Published the human catalog (`ops/errors/catalog_amm.yaml`), maintainer guide, QA index, and new contract regression test.
++- Replaced tracked ZIP payloads with a reproducible packaging script so artifacts stay reproducible without blocking PR creation.
+ 
+ ## Testes
+-- não executados (estrutura inicial, sem código executável)
++- `cargo test`
++- `rustfmt --edition 2021 --check src/amm/errors.rs src/bin/obs_demo.rs tests/amm_error_contract.rs`
+diff --git a/_jira_out/amm_error_contract.txt b/_jira_out/amm_error_contract.txt
+new file mode 100644
+index 0000000..f33de4d
+--- /dev/null
++++ b/_jira_out/amm_error_contract.txt
+@@ -0,0 +1,8 @@
++Branch: work
++Tag: amm-error-contract-v1 (annotated)
++Short HEAD: resolve tag `amm-error-contract-v1` after merge
++PR: <pending>
++Artifacts ZIP: (generate via `ops/scripts/package_amm_error_contract.sh`) out/artifacts/amm_error_contract_artifacts.zip
++Patches ZIP: (generate via `ops/scripts/package_amm_error_contract.sh`) out/patches/amm_error_contract_patches.zip
++
++Recap: Hardened the AMM error surface with stable CE-AMM codes/messages, logged adoption, a full catalog + maintainer guide, a QA index, regression tests, and archived formatter/test evidence so UI/integrators can rely on the contract.
+diff --git a/ops/errors/README.md b/ops/errors/README.md
+new file mode 100644
+index 0000000..57dcf75
+--- /dev/null
++++ b/ops/errors/README.md
+@@ -0,0 +1,45 @@
++# AMM Error Contract Guide
++
++This guide documents how to evolve the AMM error contract safely. The contract is
++consumed by UI, API, and observability surfaces and **must remain stable**.
++
++## Adding a new error variant
++
++1. **Declare the variant** in `src/amm/errors.rs` and keep the enum payload-free.
++2. **Assign contract metadata**:
++   - Extend the `AmmError::ALL_VARIANTS` array with the new variant.
++   - Provide mappings in `error_code()`, `user_message()`, `http_status()`, and `variant_name()`.
++   - Codes must follow `CE-AMM-XXXX`, be unique, and never be reused.
++   - Messages are short, neutral English sentences ending with a period.
++3. **Update the catalog** in `ops/errors/catalog_amm.yaml` with the same metadata.
++4. **Refresh the QA index** in `ops/reports/amm_error_index.json` (sorted by code).
++5. **Extend the tests**:
++   - Update assertions in `tests/amm_error_contract.rs` if new validation is required.
++   - Ensure `variant_count::<AmmError>()` matches the number of variants.
++6. **Document evidence**: run `ops/scripts/package_amm_error_contract.sh` to
++   regenerate the artifacts bundle so the formatter, linter, and test logs
++   capture the new variant.
++
++## Validating changes locally
++
++```bash
++cargo fmt
++cargo clippy --all-targets --all-features
++cargo test
++```
++
++Keep the logs for these commands; they are bundled in the artifacts ZIP.
++
++## Releasing the change
++
++1. Execute `ops/scripts/package_amm_error_contract.sh` (optionally passing the
++   merge base) to refresh logs, artifacts, and patch outputs under `out/`.
++2. The script writes the Git diff to `out/patches/amm_error_contract.patch` and
++   produces ZIP archives (ignored by Git) for hand-off when required.
++3. Tag the commit with an **annotated** tag (`git tag -a`).
++4. Update the Jira comment template in `_jira_out/amm_error_contract.txt`.
++
++Each release should be auditable: the catalog, QA index, tests, and logs must be
++present so Support, Ops, and integrators can rely on the error surface. The
++packaging script keeps the reproducible ZIPs outside version control so they do
++not block PR creation while remaining one command away for distribution.
+diff --git a/ops/errors/catalog_amm.yaml b/ops/errors/catalog_amm.yaml
+new file mode 100644
+index 0000000..f5eeaf0
+--- /dev/null
++++ b/ops/errors/catalog_amm.yaml
+@@ -0,0 +1,29 @@
++meta:
++  domain: AMM
++  prefix: CE-AMM
++  version: 1
++errors:
++  - variant: ZeroAmount
++    code: CE-AMM-0001
++    default_message: "Input amount must be greater than zero."
++    http_status: 400
++  - variant: ZeroReserve
++    code: CE-AMM-0002
++    default_message: "Reserves must stay above zero."
++    http_status: 400
++  - variant: MinReserveBreached
++    code: CE-AMM-0003
++    default_message: "Operation would breach the minimum reserve."
++    http_status: 409
++  - variant: Overflow
++    code: CE-AMM-0004
++    default_message: "Numerical overflow or underflow detected."
++    http_status: 500
++  - variant: InputTooSmall
++    code: CE-AMM-0005
++    default_message: "Effective input amount is too small."
++    http_status: 400
++  - variant: InvalidFee
++    code: CE-AMM-0006
++    default_message: "Fee ppm must be at most 1,000,000."
++    http_status: 400
+diff --git a/ops/reports/amm_error_index.json b/ops/reports/amm_error_index.json
+new file mode 100644
+index 0000000..85e6876
+--- /dev/null
++++ b/ops/reports/amm_error_index.json
+@@ -0,0 +1,46 @@
++{
++  "meta": {
++    "generated_at": "2025-09-28T01:17:29.202927+00:00",
++    "domain": "AMM",
++    "prefix": "CE-AMM",
++    "version": 1
++  },
++  "errors": [
++    {
++      "variant": "ZeroAmount",
++      "code": "CE-AMM-0001",
++      "message": "Input amount must be greater than zero.",
++      "http_status": 400
++    },
++    {
++      "variant": "ZeroReserve",
++      "code": "CE-AMM-0002",
++      "message": "Reserves must stay above zero.",
++      "http_status": 400
++    },
++    {
++      "variant": "MinReserveBreached",
++      "code": "CE-AMM-0003",
++      "message": "Operation would breach the minimum reserve.",
++      "http_status": 409
++    },
++    {
++      "variant": "Overflow",
++      "code": "CE-AMM-0004",
++      "message": "Numerical overflow or underflow detected.",
++      "http_status": 500
++    },
++    {
++      "variant": "InputTooSmall",
++      "code": "CE-AMM-0005",
++      "message": "Effective input amount is too small.",
++      "http_status": 400
++    },
++    {
++      "variant": "InvalidFee",
++      "code": "CE-AMM-0006",
++      "message": "Fee ppm must be at most 1,000,000.",
++      "http_status": 400
++    }
++  ]
++}
+diff --git a/out/artifacts/zip_artifacts.log b/out/artifacts/zip_artifacts.log
+new file mode 100644
+index 0000000..693c2cc
+--- /dev/null
++++ b/out/artifacts/zip_artifacts.log
+@@ -0,0 +1,7 @@
++  adding: ops/errors/catalog_amm.yaml (deflated 61%)
++  adding: ops/errors/README.md (deflated 49%)
++  adding: ops/reports/amm_error_index.json (deflated 65%)
++  adding: tests/amm_error_contract.rs (deflated 64%)
++  adding: out/logs/ (stored 0%)
++  adding: out/logs/cargo_test.log (deflated 72%)
++  adding: out/logs/rustfmt.log (stored 0%)
+diff --git a/out/logs/cargo_test.log b/out/logs/cargo_test.log
+new file mode 100644
+index 0000000..cab372a
+--- /dev/null
++++ b/out/logs/cargo_test.log
+@@ -0,0 +1,263 @@
++   Compiling proc-macro2 v1.0.101
++   Compiling unicode-ident v1.0.19
++   Compiling libc v0.2.175
++   Compiling pin-project-lite v0.2.16
++   Compiling cfg-if v1.0.3
++   Compiling futures-core v0.3.31
++   Compiling itoa v1.0.15
++   Compiling once_cell v1.21.3
++   Compiling stable_deref_trait v1.2.0
++   Compiling serde_core v1.0.222
++   Compiling memchr v2.7.5
++   Compiling futures-sink v0.3.31
++   Compiling quote v1.0.40
++   Compiling socket2 v0.6.0
++   Compiling mio v1.0.4
++   Compiling syn v2.0.106
++   Compiling fnv v1.0.7
++   Compiling getrandom v0.3.3
++   Compiling tracing-core v0.1.34
++   Compiling pin-utils v0.1.0
++   Compiling bytes v1.10.1
++   Compiling slab v0.4.11
++   Compiling futures-io v0.3.31
++   Compiling smallvec v1.15.1
++   Compiling percent-encoding v2.3.2
++   Compiling futures-task v0.3.31
++   Compiling http v1.3.1
++   Compiling ryu v1.0.20
++   Compiling zerocopy v0.8.27
++   Compiling serde v1.0.222
++   Compiling litemap v0.8.0
++   Compiling writeable v0.6.1
++   Compiling http-body v1.0.1
++   Compiling icu_properties_data v2.0.1
++   Compiling icu_normalizer_data v2.0.0
++   Compiling rand_core v0.9.3
++   Compiling futures-channel v0.3.31
++   Compiling either v1.15.0
++   Compiling tower-service v0.3.3
++   Compiling bitflags v2.9.4
++   Compiling serde_json v1.0.145
++   Compiling thiserror v2.0.16
++   Compiling synstructure v0.13.2
++   Compiling itertools v0.10.5
++   Compiling httparse v1.10.1
++   Compiling ppv-lite86 v0.2.21
++   Compiling anyhow v1.0.99
++   Compiling regex-syntax v0.8.6
++   Compiling zerofrom-derive v0.1.6
++   Compiling yoke-derive v0.8.0
++   Compiling zerovec-derive v0.11.1
++   Compiling displaydoc v0.2.5
++   Compiling tokio-macros v2.5.0
++   Compiling zerofrom v0.1.6
++   Compiling yoke v0.8.0
++   Compiling zerovec v0.11.4
++   Compiling futures-macro v0.3.31
++   Compiling tokio v1.47.1
++   Compiling tracing-attributes v0.1.30
++   Compiling tinystr v0.8.1
++   Compiling icu_locale_core v2.0.0
++   Compiling futures-util v0.3.31
++   Compiling potential_utf v0.1.3
++   Compiling zerotrie v0.2.2
++   Compiling tracing v0.1.41
++   Compiling serde_derive v1.0.222
++   Compiling icu_provider v2.0.0
++   Compiling icu_collections v2.0.0
++   Compiling thiserror-impl v2.0.16
++   Compiling tower-layer v0.3.3
++   Compiling icu_properties v2.0.1
++   Compiling icu_normalizer v2.0.0
++   Compiling rand_chacha v0.9.0
++   Compiling base64 v0.22.1
++   Compiling try-lock v0.2.5
++   Compiling log v0.4.28
++   Compiling want v0.3.1
++   Compiling idna_adapter v1.2.1
++   Compiling rand v0.9.2
++   Compiling opentelemetry v0.29.1
++   Compiling tokio-stream v0.1.17
++   Compiling regex-automata v0.4.10
++   Compiling http-body-util v0.1.3
++   Compiling form_urlencoded v1.2.2
++   Compiling sync_wrapper v1.0.2
++   Compiling utf8_iter v1.0.4
++   Compiling atomic-waker v1.1.2
++   Compiling hyper v1.7.0
++   Compiling idna v1.1.0
++   Compiling tower v0.5.2
++   Compiling prost-derive v0.13.5
++   Compiling futures-executor v0.3.31
++   Compiling async-trait v0.1.89
++   Compiling pin-project-internal v1.1.10
++   Compiling iri-string v0.7.8
++   Compiling ipnet v2.11.0
++   Compiling lazy_static v1.5.0
++   Compiling glob v0.3.3
++   Compiling opentelemetry_sdk v0.29.0
++   Compiling hyper-util v0.1.17
++   Compiling tower-http v0.6.6
++   Compiling prost v0.13.5
++   Compiling pin-project v1.1.10
++   Compiling url v2.5.7
++   Compiling serde_urlencoded v0.7.1
++   Compiling autocfg v1.5.0
++   Compiling rustix v1.1.2
++   Compiling crunchy v0.2.4
++   Compiling num-traits v0.2.19
++   Compiling reqwest v0.12.23
++   Compiling tonic v0.12.3
++   Compiling sharded-slab v0.1.7
++   Compiling matchers v0.2.0
++   Compiling tracing-log v0.2.0
++   Compiling thread_local v1.1.9
++   Compiling nu-ansi-term v0.50.1
++   Compiling linux-raw-sys v0.11.0
++   Compiling tracing-subscriber v0.3.20
++   Compiling opentelemetry-http v0.29.0
++   Compiling opentelemetry-proto v0.29.0
++   Compiling half v2.6.0
++   Compiling clap_lex v0.7.5
++   Compiling byteorder v1.5.0
++   Compiling hex v0.4.3
++   Compiling ciborium-io v0.2.2
++   Compiling fastrand v2.3.0
++   Compiling static_assertions v1.1.0
++   Compiling anstyle v1.0.11
++   Compiling uint v0.9.5
++   Compiling tempfile v3.22.0
++   Compiling clap_builder v4.5.47
++   Compiling ciborium-ll v0.2.2
++   Compiling opentelemetry-otlp v0.29.0
++   Compiling tracing-opentelemetry v0.30.0
++   Compiling wait-timeout v0.2.1
++   Compiling same-file v1.0.6
++   Compiling quick-error v1.2.3
++   Compiling bit-vec v0.8.0
++   Compiling cast v0.3.0
++   Compiling walkdir v2.5.0
++   Compiling criterion-plot v0.5.0
++   Compiling bit-set v0.8.0
++   Compiling clap v4.5.47
++   Compiling rusty-fork v0.3.0
++   Compiling ciborium v0.2.2
++   Compiling regex v1.11.2
++   Compiling tinytemplate v1.2.1
++   Compiling rand_xorshift v0.4.0
++   Compiling is-terminal v0.4.16
++   Compiling anes v0.1.6
++   Compiling oorandom v11.1.5
++   Compiling unarray v0.1.4
++   Compiling credit-engine-core v0.1.0 (/workspace/trendmarket)
++   Compiling proptest v1.7.0
++   Compiling criterion v0.5.1
++    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 38s
++     Running unittests src/lib.rs (target/debug/deps/credit_engine_core-1479e44b344d23ac)
++
++running 43 tests
++test amm::guardrails::tests::t_checked_add_sub_over_under_flow ... ok
++test amm::guardrails::tests::t_ensure_nonzero ... ok
++test amm::guardrails::tests::t_ensure_reserves ... ok
++test amm::guardrails::tests::t_u256_div_nearest_even_rounding ... ok
++test amm::guardrails::tests::t_u256_div_nearest_even_extreme_values ... ok
++test amm::liquidity::tests::t_add_liquidity_min_by_y ... ok
++test amm::liquidity::tests::t_add_liquidity_proportional_sym ... ok
++test amm::liquidity::tests::t_add_liquidity_too_small ... ok
++test amm::liquidity::tests::t_initial_mint_min_reserve_guard ... ok
++test amm::liquidity::tests::t_initial_mint_near_u256_limit ... ok
++test amm::liquidity::tests::t_initial_mint_symmetrical ... ok
++test amm::liquidity::tests::t_initial_mint_u128_max_square ... ok
++test amm::liquidity::tests::t_remove_liquidity_10_percent ... ok
++test amm::liquidity::tests::t_remove_liquidity_burn_too_big ... ok
++test amm::liquidity::tests::t_isqrt_u256_handles_max_range ... ok
++test amm::liquidity::tests::t_remove_liquidity_min_reserve_guard ... ok
++test amm::liquidity::tests::t_remove_liquidity_zero_burn ... ok
++test amm::pricing::tests::t_exec_price_matches_ratio_out_over_dx ... ok
++test amm::pricing::tests::t_invalid_fee_rejected ... ok
++test amm::pricing::tests::t_max_in_with_tolerance_overflow ... ok
++test amm::pricing::tests::t_min_out_with_tolerance ... ok
++test amm::pricing::tests::t_safety_invalid_inputs ... ok
++test amm::pricing::tests::t_slippage_tolerance_scaling_overflow ... ok
++test amm::pricing::tests::t_slippage_no_fee_vs_fee ... ok
++test amm::pricing::tests::t_spot_prices_basic ... ok
++test amm::swap::tests::t_dx_net_overflow_errors ... ok
++test amm::swap::tests::t_dx_net_zero_due_fee_rejected ... ok
++test amm::swap::tests::t_dx_tiny_due_rounding_rejected ... ok
++test amm::swap::tests::t_dx_zero_rejected ... ok
++test amm::swap::tests::t_dy_too_large_rejected ... ok
++test amm::swap::tests::t_dy_equal_min_reserve_allowed ... ok
++test amm::swap::tests::t_fee_above_scale_rejected ... ok
++test amm::swap::tests::t_fee_overflow_guarded ... ok
++test amm::pricing::tests::t_max_in_with_tolerance ... ok
++test amm::swap::tests::t_hi_overflow_errors ... ok
++test amm::swap::tests::t_out_asymmetric_no_fee ... ok
++test amm::swap::tests::t_out_symmetric_no_fee ... ok
++test amm::swap::tests::t_out_symmetric_with_fee ... ok
++test amm::swap::tests::t_small_values_min_reserve_guard ... ok
++test amm::swap::tests::t_zero_reserve_rejected ... ok
++test amm::swap::tests::t_in_for_target_out_with_fee_minimal ... ok
++test amm::swap::tests::t_tight_pool_min_reserve_regression ... ok
++[2m2025-09-28T01:56:19.958187Z[0m [31mERROR[0m  [3mname[0m[2m=[0m"BatchSpanProcessor.ExportError" [3merror[0m[2m=[0m"Operation failed: reqwest::Error { kind: Request, url: \"http://localhost:4318/\", source: hyper_util::client::legacy::Error(Connect, ConnectError(\"tcp connect error\", 127.0.0.1:4318, Os { code: 111, kind: ConnectionRefused, message: \"Connection refused\" })) }"
++test telemetry::tests::trace_context_propagator_injects_and_extracts_after_init ... ok
++
++test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
++
++     Running unittests src/bin/obs_demo.rs (target/debug/deps/obs_demo-8405b4111421259a)
++
++running 0 tests
++
++test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
++
++     Running tests/amm_error_contract.rs (target/debug/deps/amm_error_contract-9f3b0660a252654a)
++
++running 1 test
++test amm_error_contract_is_exhaustive_and_well_formed ... ok
++
++test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
++
++     Running tests/fuzz_invariants.rs (target/debug/deps/fuzz_invariants-2eac2f5243c32d2e)
++
++running 1 test
++test invariants_hold ... ok
++
++test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.33s
++
++     Running tests/golden_cpmm.rs (target/debug/deps/golden_cpmm-bf365f5c1bc91b4b)
++
++running 1 test
++test golden_cpmm_all ... ok
++
++test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
++
++     Running tests/rounding.rs (target/debug/deps/rounding-8cb7047059f6c7d1)
++
++running 6 tests
++test r1_amount_out_is_floor_of_continuous_value ... ok
++test r3_fee_is_ceil_no_undercollection ... ok
++test r2_amount_in_is_ceil_minimality ... ok
++test r5_burn_amounts_are_floor_of_proportion ... ok
++test r6_intermediate_rounding_is_nearest_even_on_tie ... ok
++test r4_mint_is_floor_of_sqrt_xy ... ok
++
++test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
++
++     Running benches/bench_liquidity.rs (target/debug/deps/bench_liquidity-8ebfad51017a24ea)
++Testing liquidity/remove_liquidity_partial
++Success
++
++     Running benches/bench_swap.rs (target/debug/deps/bench_swap-0a398b7b0f9d3add)
++Testing swap/sym_small_f0
++Success
++Testing swap/sym_large_f0
++Success
++Testing swap/asym_xgg_f0
++Success
++Testing swap/asym_ygg_f0
++Success
++Testing swap/sym_small_fee_f300
++Success
++Testing swap/asym_xgg_fee_f300
++Success
++
+diff --git a/out/logs/rustfmt.log b/out/logs/rustfmt.log
+new file mode 100644
+index 0000000..e69de29
+diff --git a/out/patches/amm_error_contract.patch b/out/patches/amm_error_contract.patch
+new file mode 100644
+index 0000000..96590db
+--- /dev/null
++++ b/out/patches/amm_error_contract.patch
+@@ -0,0 +1,602 @@
++diff --git a/PR_COMMENT.md b/PR_COMMENT.md
++index 0b73380..6b37952 100644
++--- a/PR_COMMENT.md
+++++ b/PR_COMMENT.md
++@@ -1,7 +1,8 @@
++ ## Resumo
++-- provisionada a topologia mínima dos diretórios de domínio (BE, FE, DATA, ML, SPECS, INFRA, OPS TESTS) com governança de owners/watchers
++-- adicionados Makefiles, scripts de bootstrap e lockfiles por domínio para lint/test/build/evidence
++-- inventário operacional atualizado (`ops/reports/inventory.json`) com owners, watchers e artefatos versionados
+++- Hardened `AmmError` into a stable contract with error codes, user messages, HTTP hints and descriptors, plus structured logging usage.
+++- Published the human catalog (`ops/errors/catalog_amm.yaml`), maintainer guide, QA index, and new contract regression test.
+++- Generated delivery artifacts (artifacts zip, patches zip, formatter/test logs) to support audit trails and integrators.
++ 
++ ## Testes
++-- não executados (estrutura inicial, sem código executável)
+++- `cargo test`
+++- `rustfmt --edition 2021 --check src/amm/errors.rs src/bin/obs_demo.rs tests/amm_error_contract.rs`
++diff --git a/ops/errors/README.md b/ops/errors/README.md
++new file mode 100644
++index 0000000..463f98c
++--- /dev/null
+++++ b/ops/errors/README.md
++@@ -0,0 +1,41 @@
+++# AMM Error Contract Guide
+++
+++This guide documents how to evolve the AMM error contract safely. The contract is
+++consumed by UI, API, and observability surfaces and **must remain stable**.
+++
+++## Adding a new error variant
+++
+++1. **Declare the variant** in `src/amm/errors.rs` and keep the enum payload-free.
+++2. **Assign contract metadata**:
+++   - Extend the `AmmError::ALL_VARIANTS` array with the new variant.
+++   - Provide mappings in `error_code()`, `user_message()`, `http_status()`, and `variant_name()`.
+++   - Codes must follow `CE-AMM-XXXX`, be unique, and never be reused.
+++   - Messages are short, neutral English sentences ending with a period.
+++3. **Update the catalog** in `ops/errors/catalog_amm.yaml` with the same metadata.
+++4. **Refresh the QA index** in `ops/reports/amm_error_index.json` (sorted by code).
+++5. **Extend the tests**:
+++   - Update assertions in `tests/amm_error_contract.rs` if new validation is required.
+++   - Ensure `variant_count::<AmmError>()` matches the number of variants.
+++6. **Document evidence**: regenerate the artifacts ZIP so that logs capture the
+++   formatter, linter, and test runs that cover the new variant.
+++
+++## Validating changes locally
+++
+++```bash
+++cargo fmt
+++cargo clippy --all-targets --all-features
+++cargo test
+++```
+++
+++Keep the logs for these commands; they are bundled in the artifacts ZIP.
+++
+++## Releasing the change
+++
+++1. Regenerate the artifacts ZIP under `out/` using the helper scripts or the
+++   manual steps in this repository.
+++2. Produce a patches ZIP from the merge-base with `main` to your branch HEAD.
+++3. Tag the commit with an **annotated** tag (`git tag -a`).
+++4. Update the Jira comment template in `_jira_out/amm_error_contract.txt`.
+++
+++Each release should be auditable: the catalog, QA index, tests, and logs must be
+++present so Support, Ops, and integrators can rely on the error surface.
++diff --git a/ops/errors/catalog_amm.yaml b/ops/errors/catalog_amm.yaml
++new file mode 100644
++index 0000000..f5eeaf0
++--- /dev/null
+++++ b/ops/errors/catalog_amm.yaml
++@@ -0,0 +1,29 @@
+++meta:
+++  domain: AMM
+++  prefix: CE-AMM
+++  version: 1
+++errors:
+++  - variant: ZeroAmount
+++    code: CE-AMM-0001
+++    default_message: "Input amount must be greater than zero."
+++    http_status: 400
+++  - variant: ZeroReserve
+++    code: CE-AMM-0002
+++    default_message: "Reserves must stay above zero."
+++    http_status: 400
+++  - variant: MinReserveBreached
+++    code: CE-AMM-0003
+++    default_message: "Operation would breach the minimum reserve."
+++    http_status: 409
+++  - variant: Overflow
+++    code: CE-AMM-0004
+++    default_message: "Numerical overflow or underflow detected."
+++    http_status: 500
+++  - variant: InputTooSmall
+++    code: CE-AMM-0005
+++    default_message: "Effective input amount is too small."
+++    http_status: 400
+++  - variant: InvalidFee
+++    code: CE-AMM-0006
+++    default_message: "Fee ppm must be at most 1,000,000."
+++    http_status: 400
++diff --git a/ops/reports/amm_error_index.json b/ops/reports/amm_error_index.json
++new file mode 100644
++index 0000000..85e6876
++--- /dev/null
+++++ b/ops/reports/amm_error_index.json
++@@ -0,0 +1,46 @@
+++{
+++  "meta": {
+++    "generated_at": "2025-09-28T01:17:29.202927+00:00",
+++    "domain": "AMM",
+++    "prefix": "CE-AMM",
+++    "version": 1
+++  },
+++  "errors": [
+++    {
+++      "variant": "ZeroAmount",
+++      "code": "CE-AMM-0001",
+++      "message": "Input amount must be greater than zero.",
+++      "http_status": 400
+++    },
+++    {
+++      "variant": "ZeroReserve",
+++      "code": "CE-AMM-0002",
+++      "message": "Reserves must stay above zero.",
+++      "http_status": 400
+++    },
+++    {
+++      "variant": "MinReserveBreached",
+++      "code": "CE-AMM-0003",
+++      "message": "Operation would breach the minimum reserve.",
+++      "http_status": 409
+++    },
+++    {
+++      "variant": "Overflow",
+++      "code": "CE-AMM-0004",
+++      "message": "Numerical overflow or underflow detected.",
+++      "http_status": 500
+++    },
+++    {
+++      "variant": "InputTooSmall",
+++      "code": "CE-AMM-0005",
+++      "message": "Effective input amount is too small.",
+++      "http_status": 400
+++    },
+++    {
+++      "variant": "InvalidFee",
+++      "code": "CE-AMM-0006",
+++      "message": "Fee ppm must be at most 1,000,000.",
+++      "http_status": 400
+++    }
+++  ]
+++}
++diff --git a/out/artifacts/amm_error_contract_artifacts.zip b/out/artifacts/amm_error_contract_artifacts.zip
++new file mode 100644
++index 0000000000000000000000000000000000000000..20d7807352a578377f971ec00194beab9b2702ea
++GIT binary patch
++literal 4993
++zcmaKw2{e@Z|Hp@+X^{P*Ax0==8C>aF$~v;lSjs45-^Mb;AX}!C-H=^o>|3_TzGfG3
++z$-b6^kezG^|Ixkw-*tcW>pbUq&hwn}ocH^C&gb*}d|uy=mO7Av82|vB23(+$F=$sF
++zLc_@b05}i;U<Ysj9PeRamd?(O&RCeasf($-qqVUq1|#fYim^xOfC0d`&=GVWegy66
++zP7NTVAjtr}Kk$*7noV-_t*hR_U~5r$W6S%uCQW3j15vDEMYl#WYWkPDS+@G6qiw(S
++zU*Je^$=-jz?`p*X{saUx(-!oYmf!uHL!~oP!Lc%zek(PLUTAS={h`7K`tSsX0X9L;
++zj;R>(9*&DJeb7j8Dr}3tv)Jj@6&;hymdpIg6AOM*O}AA6?A(>iloAv*a{SD4+w)V3
++zcvt}58+NlGJtZT)nYZ(hNk%(E>(<346rDm|P_}y+4m5EOId>6O;D}s__O7|u55D&f
++zSd`13g2qlY<cJs9Aik`EiCaT_pec(<BzB)*m6?87?YfH?!jp|ND&3^w4ta(12S5j5
++z+e8H|U{QTK3%B1(v*oupYO3dEhVT;k1Wy&!B{<@Q{qfK)`fwj>q{Wn-V1Y-<3aWA;
++zXn0=>wc^E~eLr%`)jKt9x}WtBto5JBTqZ?^PN@^uPKpW-2moOIcVuqD<&}_dVT{H1
++zkR<;+Bo9!X4$~6M?-m7wpCZjhsJ`B<gp=`@m)cy!By`XOI|%Am$NrJ2at5}bgqu`U
++z+h&VTGa6y!iVK)?dH^Q`fW|ymW!_1$*X9BbI9!|I>k~Gq64!1`e;z40qmby8`XMm9
++zo8y_n>ngw;`Bu)u=Rm^C3~NL(sEpa2Wxxh4+qb{Zhv8h$v{!V1Err__;%RwQzkpCB
++zGdZnk;f(Fr!cso4t)u%({*aHKgC&sZ81-Pm`YyJxH+Gha+TJL$MfMl?4W@1ntC!G$
++zoR;B=+*QX-;Y)Qod!@MefZ7Dil8sinQ?A}Q8LXan;$;UV7dzR>+_@CUZv$p8g#*#>
++z@!<ykXj>h^tDb=u!-NXQ`&<&5JA}#P$tm8|K^2&ki-)0tY`Q@9`SADWm{#i`rzW(-
++zW@ub**Z3DY=JKH!h|8WV+RHM1ej-b9+JTXvK74M~MtAOYA%bS5;@MQha^qPbDz9dl
++zO8>=S6Ub`^(fe65B3mpre5pUhnmFEt;>_w#Wmbvp-YaT(bJ~^$gRv`h;axj3&U?{a
++z)p^!S05W11pfJg+KS>95>dQGrXe%qxaCoYhKJH-#8hxX^mG!kN<%5Iur8ghPbvA;y
++z35ZRcgI503a7bDbs3FF}_g#y<k+u)BwLmosLPHt(WHP$-e$FSq%13<ddRu4f8PSa5
++z_DMY*cETEeR9zTHa#>B`+l-dv6&hBupC3G%6xtxS>VXUij};jmxr+^H(lcKGyMjDR
++zV$A9TG*<43MMt;pNP@Ax5qH_BodHrBcB93zqJ@BSjf!uMUg3D1*mNGrRmnwjw_H*I
++zk2ZP`AtSI3GyxZ-+V`O2hCqM!7+;U~)LQfe-DZJlK=myNz4l7|v%j;zQ7A7yLv4Xc
++zDXA}}KDl^K{|H?HK?6z}(We@YAYE`$mjF|kP8Pq9^sMA0c~O5z#*2X+IYHTs9ntao
++zTo`kx<dc2hQ1BNfcHKx3>tw5ms$Q7`u5f;8mdmWo82EZ^o%v&mrvpZGcO<#hC&+Ir
++zdGoG8nc|m18iQ!N!>j00WyN29icZt}=F-<#bA5Q_>`cDgc}<3#o2&UZCpit3g6oQ1
++zZ`9jgb#(rgH0aIqG_9GaN!`zHcdi<IwH?`zwwT-M?Wv#h`NG`N`O13RLT9{1NyC9j
++zAL32p3Qv|>(4(Vv1@|*(wN_oS$R3(GT}EWo7(N)^eGT_ulp}Ud36>4jIP5$>msCDy
++z_K=H_ad+2{!+(Ns$o46wqg04O(O4cypylj9zR|?-ZYFE#eWU)TD!@opp}`mF>PM>A
++znxwJ|{ktkSTi$bYcEQ3(h1&Rg?KZY?u&{I&w#7O+e6J8WKd%s(Q7;{uMCkqRCw+`A
++z13TYDvrFh}2R%AphA6mf(M}d?CS80E9pb)|1Z4IXr=bb*KH8JTmG_LZ$U%G8Q$Plg
++zTct{V{?c7p6A=(z!3AYOd}IJP#B2QlOm#dXv*X~5`L#CRd#jzLGYTFzaN<(IevN*+
++z8z1|jQvJi|{I@=Ch^Fp5GDtd}Zy`OQ<n=nXis3Fwa24%h{5djhEk0?HMw418^yO}J
++zG+M}5cQ5s_8mQL!v0%aDvrT<a%-}-<CrVkJx(6FChyqzdPPaXu)0(5qSS9-E(%>a+
++z7iu$DR!vI1#Pzq?cM*l_wz&~n0b}8%qkB{(7b?f~E1jkce1&Nws=I!VN5#w!&}V2V
++z#4>jI;7|2^VO)r>Hj7w9G8t#bu4YD~TZnThbXVlq`B84C#a#Z#jy;Tf;kCz+clZo_
++zaKR(#Dz}>*11N-&`*gLI)BC_C-+o9w%=1qny1|6G^ImOjLp6DD9wuhLZ(hvA_W@a^
++z9FeWKxW@UT(XlcgvVX!$AceQc|HXk9IRLPB>aTX}Vu}4%V9gyJT%1kKU4)&n-y`cv
++zYQ+zJY{!W@laBo&^gcbtQ+@%Nj3H9x*FM;){FXq`*9KIqg<3qD8M_mlXkuKE8hMmh
++zLdZ~!YkI<!KeJM^>ho2C_Kp?zZT^P*7_tZy%O7$2SlS`oA*WXZU)ylPX=fVGeIi<;
++z^c4Ja#WIedhE8;qfoZoV={bDDb^RG0pQdO*zkNgF=S-eNRps=YQ%)r+<OaX`%iMf_
++znP)FCE%VV21wnCoD4r_o;rz{>J-MVV7Bb;PpnC6-jOwYeQi`Z9BRWJ}Ma9R(jm_7y
++z*{~gHA%-usTc`AN8OW;a`lluu%;z$jWmNJq8qG!2Ea|0hS;ed7(%UCny&e-|oZ?I<
++zZ-R#}eam{Y>k_qH52WI`@+8!M;CiZPVce2vO<y9fQG!%7OQO5Z9p3eQLdopAcY285
++zLV@ZS)667(ZU~(^e$IYz7AYg0L7jLy6hqzJBhAQ||I!`Y5tiCBbhN9rfi%oToL{=x
++zNft!8!QJy503k*#K8BPw%?W!wlD#M-2+wm7Q$JYx48dtD^V~&fHf@KA|0%Ig)}`}F
++zu%TJWp5SgT{;rNwOgk*XgB22Aiy5);{JL6sx?3h;&;&J`H<U|opRYdB&C_bx5B5!8
++zXuuQj0(#IPv+T1pu7O%+x<#rnvT>V|`^X)5C9L@%b|nv5pHL6pp{((_QRZc3Xeyr*
++z@gi2)5>z%i=lCIqcDm7<_&}tw`q@e+^?pCAoqb(+X;2m?{Ph^7mE+sy>5^-Efl{@r
++z8EAu9p|PHN_A{Q-n5>$io264<BVEP=C59sg_w0j^Vd(n8ZyRx6Lc=lnk8_s4IkIQP
++zVBh4AzR~rp)KQ;ZtABrs=}IrxaXwQWb0MICl+WK^{(gXu%ayAOjKq{!*!S$MAZ6}P
++zVDcY{T9U-%HUAC>N#gka&O!e#;p~cavBJ0rlk~o;mHb@o@86(8Lgr{ob2}*3)!f|D
++z(!$b$>YuIGM)Ik@^I$lT5&*cv1OTv}T&lULv$dn~@lO1YRWr$|?Z<7`dZ*KQoP=Ea
++zti_FJOHHAm4E|B8EJD_T#JP&Rv2zr>Funn(956+wDhjtssnQY6S5+FB)e(w_kOA!+
++z&~wi`zAPYINsK}$b}!S<5Y^eN)PNqRm8bZj+0!>NR}rmZYzAk<V9#Cwz1$SmCSiA-
++zOCA!v%T1Q7Z`z>lk<Dbq<`&n^Xznh7A{F&{oKg>YV;3YxZef)xc}@SQ4#ZoZA1;g5
++zh}3spY^M>GVy8|DE9K5UW4{!%Rw6d7Y&NEXNNi~qc~$BAhsH%G;ti(Q#6;qJ?3E;X
++zP0x?l!2+GU&xR3m2~MVwEwatB;s$bVAW2IP4P@fYEkMGM*y|pJ=QqS4_`vG@t1M5m
++zhU79MHB$!1<sdZkAdzd@uHuQkL|H8`O{&T!Akx-POuDY#pCWdCm2n=(v~}HsqP|e_
++ztI43Lv)lMYHeZ~$Veg>m9hyuvn@$q!B%nNK0#LyTk>Fms&_;X7B!4plnAalpXS^E)
++zDA>?<P{#bV$_HX^rLxI|Q69F>BGnmu1~;+c5INaXUnG?uybd;%6L@>JJ?Z=seMVXA
++zd)7;nOc7pXB0JS*Iw_;70MmnS5#8Z~A60NGYn7qfkmZj8U&JpMUd@hss(qhb%O|9@
++zHHDU~UuUp9M`*8@jxH|#iA*+SCHXq51<Q7OeF#=rv5u?CFa=1FLZ;1pf9=q=Jb-LU
++zV+0d?U8R{y&Z_`ESDd??bh#MB?~ZyY>B1`!FTdMI;GKM{GP}HOGLdZ5t~T0c=bzQJ
++zX3uKDsW&J;qu!-k!w~K}q_(Q<#%fh{x3|_G+2PY#zfZSCw!mgY7iL%l+6IZw>QpLE
++zaLrnn<#a;lnkw2W(jLOq?PrB_ows&>i<nfOz%xCFndkoOTR*xkoIa8zUCJ;<y%hs>
++z48JZiDKS1YneF!KAy0}{f`s`vmdt4zE@rf17YO4YTeH_#K6f>?hc&)d4Ra&RU(yId
++zyf8$w>X0Tzm9`*K2~m!#2bnU$!L%9LB6Y#jvhUwf@Oj+-9o!i{Je>UE;Py^kbUww-
++zpHny&*2l?rEsqM!Hf|RbS+Hf^;EHo_+ne__{h)naxZE_kD5u&8s`_Y}Z3f(X?<mld
++zHwYA2-*GO^eILR^=9nC%AM#{^mSsq{!(EWsYCvIXf1S6MW0JNzNc+n6!V^K=7<L08
++zR@F#wSRy-ty-Tm$wn|f$|59(tTt*#w<vp#vZbW_+ytXS$B2-wJ?2zt2b#5j~epD=G
++zTGf;-slu!r@%-%-=CViMh|%aX`3)NLbJ@?caNg2T<L>VEIQeM=HTm7AZV82LiNK3q
++zHcpINn^3~<A=<5()Tb1k#MTrqZyHlkkA=(H(Os>b-_{?Ya15Pb(Gq=ZU4K#D&h>ul
++z9OEzur$>&x<-SSIsuCm`FtyKFUzSI^B7_cYC)So%WZVry*`mXyn;%hH9k{!n1@((7
++ztG8*hAq($VW58ntmbYU*5NsH02U@r!+h%NYpY1#>Stq;ZX3SyqTa<YGpX4ma^ilB@
++zTV~I%$ir81A3p?e8WxS+S^0cTYL}si)>P<HaujYDGKIt7(|kNP(nCKX^sx=hu=fz<
++zhT`Y(%ImxYB@YVF(pqQ=HQ%d%geahG_qzMUx8htuy5}Pv=J701qowgyrU{0AHbhRX
++zLSSm5;Sz4`qi35`%J|pyH8FLV?=HEtylAKJMp61m{=T$t(r%c)Jb{e$1<!sml^CCr
++z!D98YT0nG+yHY<L!xJW8+pEjoyI8%vG4XTv*;%f3-evtToIbm4RFHn<+IC%;3Z|sB
++z)pGxxO-b|>fM60NsU!L7DyEAjsCOnlkT}}i5NwS(a7ei~I(={C&l1PwPsu0=d$rY-
++zaD~bG*h8R}IvF`9@P7?C*uM885<>$r9v#2_a^ykz*U00)#vLaOemtw6G)N%%oG>_X
++zawjPtpWJ_;{3Gw5R4yX*s$=C}(?7}OnErp^@*{ShbO|R-AASj;B!goJ{i(tK;()&l
++z004Txvb-_rrxR2_k~^k?U&#H)1Si*<c2e$Ngg{b0CWN0V|CK5~Qou=ND(Vvp{ck29
++ai61k;58{+0jt2lhq$`j__0#mnU;hW^2W7ed
++
++literal 0
++HcmV?d00001
++
++diff --git a/out/artifacts/zip_artifacts.log b/out/artifacts/zip_artifacts.log
++new file mode 100644
++index 0000000..709ba4e
++--- /dev/null
+++++ b/out/artifacts/zip_artifacts.log
++@@ -0,0 +1,7 @@
+++updating: ops/errors/catalog_amm.yaml (deflated 61%)
+++updating: ops/errors/README.md (deflated 47%)
+++updating: ops/reports/amm_error_index.json (deflated 65%)
+++updating: tests/amm_error_contract.rs (deflated 64%)
+++updating: out/logs/ (stored 0%)
+++updating: out/logs/rustfmt.log (stored 0%)
+++updating: out/logs/cargo_test.log (deflated 71%)
++diff --git a/out/logs/cargo_test.log b/out/logs/cargo_test.log
++new file mode 100644
++index 0000000..d5decef
++--- /dev/null
+++++ b/out/logs/cargo_test.log
++@@ -0,0 +1,97 @@
+++   Compiling credit-engine-core v0.1.0 (/workspace/trendmarket)
+++    Finished `test` profile [unoptimized + debuginfo] target(s) in 11.74s
+++     Running unittests src/lib.rs (target/debug/deps/credit_engine_core-1479e44b344d23ac)
+++
+++running 43 tests
+++test amm::guardrails::tests::t_checked_add_sub_over_under_flow ... ok
+++test amm::guardrails::tests::t_ensure_nonzero ... ok
+++test amm::guardrails::tests::t_ensure_reserves ... ok
+++test amm::guardrails::tests::t_u256_div_nearest_even_rounding ... ok
+++test amm::guardrails::tests::t_u256_div_nearest_even_extreme_values ... ok
+++test amm::liquidity::tests::t_add_liquidity_min_by_y ... ok
+++test amm::liquidity::tests::t_add_liquidity_proportional_sym ... ok
+++test amm::liquidity::tests::t_add_liquidity_too_small ... ok
+++test amm::liquidity::tests::t_initial_mint_min_reserve_guard ... ok
+++test amm::liquidity::tests::t_initial_mint_symmetrical ... ok
+++test amm::liquidity::tests::t_initial_mint_near_u256_limit ... ok
+++test amm::liquidity::tests::t_initial_mint_u128_max_square ... ok
+++test amm::liquidity::tests::t_remove_liquidity_10_percent ... ok
+++test amm::liquidity::tests::t_remove_liquidity_burn_too_big ... ok
+++test amm::liquidity::tests::t_isqrt_u256_handles_max_range ... ok
+++test amm::liquidity::tests::t_remove_liquidity_min_reserve_guard ... ok
+++test amm::liquidity::tests::t_remove_liquidity_zero_burn ... ok
+++test amm::pricing::tests::t_exec_price_matches_ratio_out_over_dx ... ok
+++test amm::pricing::tests::t_invalid_fee_rejected ... ok
+++test amm::pricing::tests::t_max_in_with_tolerance_overflow ... ok
+++test amm::pricing::tests::t_min_out_with_tolerance ... ok
+++test amm::pricing::tests::t_safety_invalid_inputs ... ok
+++test amm::pricing::tests::t_slippage_tolerance_scaling_overflow ... ok
+++test amm::pricing::tests::t_slippage_no_fee_vs_fee ... ok
+++test amm::pricing::tests::t_spot_prices_basic ... ok
+++test amm::swap::tests::t_dx_net_overflow_errors ... ok
+++test amm::swap::tests::t_dx_tiny_due_rounding_rejected ... ok
+++test amm::swap::tests::t_dx_net_zero_due_fee_rejected ... ok
+++test amm::swap::tests::t_dx_zero_rejected ... ok
+++test amm::swap::tests::t_dy_too_large_rejected ... ok
+++test amm::swap::tests::t_fee_above_scale_rejected ... ok
+++test amm::swap::tests::t_dy_equal_min_reserve_allowed ... ok
+++test amm::pricing::tests::t_max_in_with_tolerance ... ok
+++test amm::swap::tests::t_fee_overflow_guarded ... ok
+++test amm::swap::tests::t_hi_overflow_errors ... ok
+++test amm::swap::tests::t_out_asymmetric_no_fee ... ok
+++test amm::swap::tests::t_out_symmetric_no_fee ... ok
+++test amm::swap::tests::t_out_symmetric_with_fee ... ok
+++test amm::swap::tests::t_small_values_min_reserve_guard ... ok
+++test amm::swap::tests::t_in_for_target_out_with_fee_minimal ... ok
+++test amm::swap::tests::t_zero_reserve_rejected ... ok
+++test amm::swap::tests::t_tight_pool_min_reserve_regression ... ok
+++[2m2025-09-28T01:22:11.205944Z[0m [31mERROR[0m  [3mname[0m[2m=[0m"BatchSpanProcessor.ExportError" [3merror[0m[2m=[0m"Operation failed: reqwest::Error { kind: Request, url: \"http://localhost:4318/\", source: hyper_util::client::legacy::Error(Connect, ConnectError(\"tcp connect error\", 127.0.0.1:4318, Os { code: 111, kind: ConnectionRefused, message: \"Connection refused\" })) }"
+++test telemetry::tests::trace_context_propagator_injects_and_extracts_after_init ... ok
+++
+++test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+++
+++     Running unittests src/bin/obs_demo.rs (target/debug/deps/obs_demo-8405b4111421259a)
+++
+++running 0 tests
+++
+++test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+++
+++     Running tests/amm_error_contract.rs (target/debug/deps/amm_error_contract-9f3b0660a252654a)
+++
+++running 1 test
+++test amm_error_contract_is_exhaustive_and_well_formed ... ok
+++
+++test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+++
+++     Running tests/fuzz_invariants.rs (target/debug/deps/fuzz_invariants-2eac2f5243c32d2e)
+++
+++running 1 test
+++test invariants_hold ... ok
+++
+++test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.30s
+++
+++     Running tests/golden_cpmm.rs (target/debug/deps/golden_cpmm-bf365f5c1bc91b4b)
+++
+++running 1 test
+++test golden_cpmm_all ... ok
+++
+++test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+++
+++     Running tests/rounding.rs (target/debug/deps/rounding-8cb7047059f6c7d1)
+++
+++running 6 tests
+++test r3_fee_is_ceil_no_undercollection ... ok
+++test r1_amount_out_is_floor_of_continuous_value ... ok
+++test r4_mint_is_floor_of_sqrt_xy ... ok
+++test r2_amount_in_is_ceil_minimality ... ok
+++test r5_burn_amounts_are_floor_of_proportion ... ok
+++test r6_intermediate_rounding_is_nearest_even_on_tie ... ok
+++
+++test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+++
+++   Doc-tests credit_engine_core
+++
+++running 0 tests
+++
+++test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+++
++diff --git a/out/logs/rustfmt.log b/out/logs/rustfmt.log
++new file mode 100644
++index 0000000..7761e7f
++--- /dev/null
+++++ b/out/logs/rustfmt.log
++@@ -0,0 +1 @@
+++rustfmt --check succeeded
++diff --git a/src/amm/errors.rs b/src/amm/errors.rs
++index 679dda8..5747922 100644
++--- a/src/amm/errors.rs
+++++ b/src/amm/errors.rs
++@@ -1,28 +1,116 @@
++ //! Erros padronizados do AMM
++ use core::fmt;
++ 
++-#[derive(Debug, Clone, PartialEq, Eq)]
++-pub enum AmmError {
++-    ZeroAmount,
++-    ZeroReserve,
++-    MinReserveBreached,
++-    Overflow,
++-    InputTooSmall,
++-    InvalidFee,
+++macro_rules! amm_error_contract {
+++    (
+++        $(
+++            $variant:ident => {
+++                code: $code:expr,
+++                message: $message:expr,
+++                http_status: $status:expr
+++            }
+++        ),+ $(,)?
+++    ) => {
+++        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+++        pub enum AmmError {
+++            $( $variant, )+
+++        }
+++
+++        #[derive(Debug, Clone, Copy)]
+++        pub struct AmmErrorDescriptor {
+++            pub variant: AmmError,
+++            pub code: &'static str,
+++            pub message: &'static str,
+++            pub http_status: Option<u16>,
+++        }
+++
+++        impl AmmError {
+++            pub const ALL_VARIANTS: [AmmError; amm_error_contract!(@len $($variant),+)] = [
+++                $( AmmError::$variant, )+
+++            ];
+++
+++            pub const fn error_code(self) -> &'static str {
+++                match self {
+++                    $( AmmError::$variant => $code, )+
+++                }
+++            }
+++
+++            pub const fn user_message(self) -> &'static str {
+++                match self {
+++                    $( AmmError::$variant => $message, )+
+++                }
+++            }
+++
+++            pub const fn http_status(self) -> Option<u16> {
+++                match self {
+++                    $( AmmError::$variant => Some($status), )+
+++                }
+++            }
+++
+++            pub const fn variant_name(self) -> &'static str {
+++                match self {
+++                    $( AmmError::$variant => stringify!($variant), )+
+++                }
+++            }
+++
+++            pub const fn descriptors() -> &'static [AmmErrorDescriptor] {
+++                &AMM_ERROR_DESCRIPTORS
+++            }
+++        }
+++
+++        pub const AMM_ERROR_DESCRIPTORS: [AmmErrorDescriptor; amm_error_contract!(@len $($variant),+)] = [
+++            $( AmmErrorDescriptor {
+++                variant: AmmError::$variant,
+++                code: $code,
+++                message: $message,
+++                http_status: Some($status),
+++            }, )+
+++        ];
+++    };
+++
+++    (@len $($variant:ident),+) => {
+++        <[()]>::len(&[ $(amm_error_contract!(@unit $variant)),+ ])
+++    };
+++
+++    (@unit $variant:ident) => { () };
+++}
+++
+++amm_error_contract! {
+++    ZeroAmount => {
+++        code: "CE-AMM-0001",
+++        message: "Input amount must be greater than zero.",
+++        http_status: 400
+++    },
+++    ZeroReserve => {
+++        code: "CE-AMM-0002",
+++        message: "Reserves must stay above zero.",
+++        http_status: 400
+++    },
+++    MinReserveBreached => {
+++        code: "CE-AMM-0003",
+++        message: "Operation would breach the minimum reserve.",
+++        http_status: 409
+++    },
+++    Overflow => {
+++        code: "CE-AMM-0004",
+++        message: "Numerical overflow or underflow detected.",
+++        http_status: 500
+++    },
+++    InputTooSmall => {
+++        code: "CE-AMM-0005",
+++        message: "Effective input amount is too small.",
+++        http_status: 400
+++    },
+++    InvalidFee => {
+++        code: "CE-AMM-0006",
+++        message: "Fee ppm must be at most 1,000,000.",
+++        http_status: 400
+++    }
++ }
++ 
++ impl fmt::Display for AmmError {
++     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
++-        use AmmError::*;
++-        let s = match self {
++-            ZeroAmount => "amount deve ser > 0",
++-            ZeroReserve => "reserve deve ser > 0",
++-            MinReserveBreached => "reserva ficaria abaixo do mínimo",
++-            Overflow => "overflow/underflow numérico",
++-            InputTooSmall => "input efetivo após taxa é 0",
++-            InvalidFee => "fee_ppm deve ser ≤ 1e6",
++-        };
++-        write!(f, "{}", s)
+++        write!(f, "{}", self.user_message())
++     }
++ }
++ 
++diff --git a/src/bin/obs_demo.rs b/src/bin/obs_demo.rs
++index e3e7375..790e8cb 100644
++--- a/src/bin/obs_demo.rs
+++++ b/src/bin/obs_demo.rs
++@@ -2,6 +2,7 @@ use anyhow::Result;
++ use opentelemetry::KeyValue;
++ use std::time::Instant;
++ 
+++use credit_engine_core::amm::errors::AmmError;
++ use credit_engine_core::telemetry; // troque para ce_core se o crate tiver esse nome
++ 
++ #[tokio::main]
++@@ -22,6 +23,25 @@ async fn main() -> Result<()> {
++             .record(0.001_f64, &[KeyValue::new("op", "swap")]);
++     }
++ 
+++    // Emit an example error log with the hardened contract fields.
+++    let sample_error = AmmError::MinReserveBreached;
+++    if let Some(status) = sample_error.http_status() {
+++        tracing::error!(
+++            error_code = sample_error.error_code(),
+++            error_message = sample_error.user_message(),
+++            error_variant = sample_error.variant_name(),
+++            http_status = status,
+++            "sample AMM error emitted"
+++        );
+++    } else {
+++        tracing::error!(
+++            error_code = sample_error.error_code(),
+++            error_message = sample_error.user_message(),
+++            error_variant = sample_error.variant_name(),
+++            "sample AMM error emitted"
+++        );
+++    }
+++
++     tel.shutdown();
++     Ok(())
++ }
++diff --git a/tests/amm_error_contract.rs b/tests/amm_error_contract.rs
++new file mode 100644
++index 0000000..d975973
++--- /dev/null
+++++ b/tests/amm_error_contract.rs
++@@ -0,0 +1,52 @@
+++use credit_engine_core::amm::errors::AmmError;
+++use std::collections::HashSet;
+++
+++#[test]
+++fn amm_error_contract_is_exhaustive_and_well_formed() {
+++    let descriptors = AmmError::descriptors();
+++    assert_eq!(descriptors.len(), AmmError::ALL_VARIANTS.len());
+++
+++    let mut codes = HashSet::new();
+++    let mut variants = HashSet::new();
+++    for descriptor in descriptors.iter() {
+++        let variant = descriptor.variant;
+++        variants.insert(variant.variant_name());
+++        let code = descriptor.code;
+++        assert!(code.starts_with("CE-AMM-"), "code prefix incorrect: {code}");
+++        assert_eq!(code.len(), 11, "code length incorrect: {code}");
+++        assert!(codes.insert(code), "duplicate code detected: {code}");
+++
+++        let message = descriptor.message;
+++        assert!(
+++            !message.trim().is_empty(),
+++            "user message must be non-empty for {}",
+++            variant.variant_name()
+++        );
+++        assert!(
+++            message.ends_with('.'),
+++            "user message must end with period: {message}"
+++        );
+++
+++        if let Some(status) = descriptor.http_status {
+++            match status {
+++                400 | 403 | 404 | 409 | 500 | 502 | 503 => {}
+++                other => panic!(
+++                    "unexpected http status {other} for {}",
+++                    variant.variant_name()
+++                ),
+++            }
+++        }
+++
+++        assert_eq!(variant.error_code(), code);
+++        assert_eq!(variant.user_message(), message);
+++        assert_eq!(variant.http_status(), descriptor.http_status);
+++    }
+++
+++    for variant in AmmError::ALL_VARIANTS.iter() {
+++        assert!(
+++            variants.contains(variant.variant_name()),
+++            "variant {} missing from descriptor list",
+++            variant.variant_name()
+++        );
+++    }
+++}
+diff --git a/out/patches/zip_patches.log b/out/patches/zip_patches.log
+new file mode 100644
+index 0000000..61d4971
+--- /dev/null
++++ b/out/patches/zip_patches.log
+@@ -0,0 +1 @@
++  adding: amm_error_contract.patch (deflated 57%)
+diff --git a/src/amm/errors.rs b/src/amm/errors.rs
+index 679dda8..5747922 100644
+--- a/src/amm/errors.rs
++++ b/src/amm/errors.rs
+@@ -1,28 +1,116 @@
+ //! Erros padronizados do AMM
+ use core::fmt;
+ 
+-#[derive(Debug, Clone, PartialEq, Eq)]
+-pub enum AmmError {
+-    ZeroAmount,
+-    ZeroReserve,
+-    MinReserveBreached,
+-    Overflow,
+-    InputTooSmall,
+-    InvalidFee,
++macro_rules! amm_error_contract {
++    (
++        $(
++            $variant:ident => {
++                code: $code:expr,
++                message: $message:expr,
++                http_status: $status:expr
++            }
++        ),+ $(,)?
++    ) => {
++        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
++        pub enum AmmError {
++            $( $variant, )+
++        }
++
++        #[derive(Debug, Clone, Copy)]
++        pub struct AmmErrorDescriptor {
++            pub variant: AmmError,
++            pub code: &'static str,
++            pub message: &'static str,
++            pub http_status: Option<u16>,
++        }
++
++        impl AmmError {
++            pub const ALL_VARIANTS: [AmmError; amm_error_contract!(@len $($variant),+)] = [
++                $( AmmError::$variant, )+
++            ];
++
++            pub const fn error_code(self) -> &'static str {
++                match self {
++                    $( AmmError::$variant => $code, )+
++                }
++            }
++
++            pub const fn user_message(self) -> &'static str {
++                match self {
++                    $( AmmError::$variant => $message, )+
++                }
++            }
++
++            pub const fn http_status(self) -> Option<u16> {
++                match self {
++                    $( AmmError::$variant => Some($status), )+
++                }
++            }
++
++            pub const fn variant_name(self) -> &'static str {
++                match self {
++                    $( AmmError::$variant => stringify!($variant), )+
++                }
++            }
++
++            pub const fn descriptors() -> &'static [AmmErrorDescriptor] {
++                &AMM_ERROR_DESCRIPTORS
++            }
++        }
++
++        pub const AMM_ERROR_DESCRIPTORS: [AmmErrorDescriptor; amm_error_contract!(@len $($variant),+)] = [
++            $( AmmErrorDescriptor {
++                variant: AmmError::$variant,
++                code: $code,
++                message: $message,
++                http_status: Some($status),
++            }, )+
++        ];
++    };
++
++    (@len $($variant:ident),+) => {
++        <[()]>::len(&[ $(amm_error_contract!(@unit $variant)),+ ])
++    };
++
++    (@unit $variant:ident) => { () };
++}
++
++amm_error_contract! {
++    ZeroAmount => {
++        code: "CE-AMM-0001",
++        message: "Input amount must be greater than zero.",
++        http_status: 400
++    },
++    ZeroReserve => {
++        code: "CE-AMM-0002",
++        message: "Reserves must stay above zero.",
++        http_status: 400
++    },
++    MinReserveBreached => {
++        code: "CE-AMM-0003",
++        message: "Operation would breach the minimum reserve.",
++        http_status: 409
++    },
++    Overflow => {
++        code: "CE-AMM-0004",
++        message: "Numerical overflow or underflow detected.",
++        http_status: 500
++    },
++    InputTooSmall => {
++        code: "CE-AMM-0005",
++        message: "Effective input amount is too small.",
++        http_status: 400
++    },
++    InvalidFee => {
++        code: "CE-AMM-0006",
++        message: "Fee ppm must be at most 1,000,000.",
++        http_status: 400
++    }
+ }
+ 
+ impl fmt::Display for AmmError {
+     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+-        use AmmError::*;
+-        let s = match self {
+-            ZeroAmount => "amount deve ser > 0",
+-            ZeroReserve => "reserve deve ser > 0",
+-            MinReserveBreached => "reserva ficaria abaixo do mínimo",
+-            Overflow => "overflow/underflow numérico",
+-            InputTooSmall => "input efetivo após taxa é 0",
+-            InvalidFee => "fee_ppm deve ser ≤ 1e6",
+-        };
+-        write!(f, "{}", s)
++        write!(f, "{}", self.user_message())
+     }
+ }
+ 
+diff --git a/src/bin/obs_demo.rs b/src/bin/obs_demo.rs
+index e3e7375..790e8cb 100644
+--- a/src/bin/obs_demo.rs
++++ b/src/bin/obs_demo.rs
+@@ -2,6 +2,7 @@ use anyhow::Result;
+ use opentelemetry::KeyValue;
+ use std::time::Instant;
+ 
++use credit_engine_core::amm::errors::AmmError;
+ use credit_engine_core::telemetry; // troque para ce_core se o crate tiver esse nome
+ 
+ #[tokio::main]
+@@ -22,6 +23,25 @@ async fn main() -> Result<()> {
+             .record(0.001_f64, &[KeyValue::new("op", "swap")]);
+     }
+ 
++    // Emit an example error log with the hardened contract fields.
++    let sample_error = AmmError::MinReserveBreached;
++    if let Some(status) = sample_error.http_status() {
++        tracing::error!(
++            error_code = sample_error.error_code(),
++            error_message = sample_error.user_message(),
++            error_variant = sample_error.variant_name(),
++            http_status = status,
++            "sample AMM error emitted"
++        );
++    } else {
++        tracing::error!(
++            error_code = sample_error.error_code(),
++            error_message = sample_error.user_message(),
++            error_variant = sample_error.variant_name(),
++            "sample AMM error emitted"
++        );
++    }
++
+     tel.shutdown();
+     Ok(())
+ }
+diff --git a/tests/amm_error_contract.rs b/tests/amm_error_contract.rs
+new file mode 100644
+index 0000000..d975973
+--- /dev/null
++++ b/tests/amm_error_contract.rs
+@@ -0,0 +1,52 @@
++use credit_engine_core::amm::errors::AmmError;
++use std::collections::HashSet;
++
++#[test]
++fn amm_error_contract_is_exhaustive_and_well_formed() {
++    let descriptors = AmmError::descriptors();
++    assert_eq!(descriptors.len(), AmmError::ALL_VARIANTS.len());
++
++    let mut codes = HashSet::new();
++    let mut variants = HashSet::new();
++    for descriptor in descriptors.iter() {
++        let variant = descriptor.variant;
++        variants.insert(variant.variant_name());
++        let code = descriptor.code;
++        assert!(code.starts_with("CE-AMM-"), "code prefix incorrect: {code}");
++        assert_eq!(code.len(), 11, "code length incorrect: {code}");
++        assert!(codes.insert(code), "duplicate code detected: {code}");
++
++        let message = descriptor.message;
++        assert!(
++            !message.trim().is_empty(),
++            "user message must be non-empty for {}",
++            variant.variant_name()
++        );
++        assert!(
++            message.ends_with('.'),
++            "user message must end with period: {message}"
++        );
++
++        if let Some(status) = descriptor.http_status {
++            match status {
++                400 | 403 | 404 | 409 | 500 | 502 | 503 => {}
++                other => panic!(
++                    "unexpected http status {other} for {}",
++                    variant.variant_name()
++                ),
++            }
++        }
++
++        assert_eq!(variant.error_code(), code);
++        assert_eq!(variant.user_message(), message);
++        assert_eq!(variant.http_status(), descriptor.http_status);
++    }
++
++    for variant in AmmError::ALL_VARIANTS.iter() {
++        assert!(
++            variants.contains(variant.variant_name()),
++            "variant {} missing from descriptor list",
++            variant.variant_name()
++        );
++    }
++}

--- a/out/patches/zip_patches.log
+++ b/out/patches/zip_patches.log
@@ -1,0 +1,1 @@
+  adding: amm_error_contract.patch (deflated 72%)

--- a/src/amm/errors.rs
+++ b/src/amm/errors.rs
@@ -1,28 +1,116 @@
 //! Erros padronizados do AMM
 use core::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AmmError {
-    ZeroAmount,
-    ZeroReserve,
-    MinReserveBreached,
-    Overflow,
-    InputTooSmall,
-    InvalidFee,
+macro_rules! amm_error_contract {
+    (
+        $(
+            $variant:ident => {
+                code: $code:expr,
+                message: $message:expr,
+                http_status: $status:expr
+            }
+        ),+ $(,)?
+    ) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum AmmError {
+            $( $variant, )+
+        }
+
+        #[derive(Debug, Clone, Copy)]
+        pub struct AmmErrorDescriptor {
+            pub variant: AmmError,
+            pub code: &'static str,
+            pub message: &'static str,
+            pub http_status: Option<u16>,
+        }
+
+        impl AmmError {
+            pub const ALL_VARIANTS: [AmmError; amm_error_contract!(@len $($variant),+)] = [
+                $( AmmError::$variant, )+
+            ];
+
+            pub const fn error_code(self) -> &'static str {
+                match self {
+                    $( AmmError::$variant => $code, )+
+                }
+            }
+
+            pub const fn user_message(self) -> &'static str {
+                match self {
+                    $( AmmError::$variant => $message, )+
+                }
+            }
+
+            pub const fn http_status(self) -> Option<u16> {
+                match self {
+                    $( AmmError::$variant => Some($status), )+
+                }
+            }
+
+            pub const fn variant_name(self) -> &'static str {
+                match self {
+                    $( AmmError::$variant => stringify!($variant), )+
+                }
+            }
+
+            pub const fn descriptors() -> &'static [AmmErrorDescriptor] {
+                &AMM_ERROR_DESCRIPTORS
+            }
+        }
+
+        pub const AMM_ERROR_DESCRIPTORS: [AmmErrorDescriptor; amm_error_contract!(@len $($variant),+)] = [
+            $( AmmErrorDescriptor {
+                variant: AmmError::$variant,
+                code: $code,
+                message: $message,
+                http_status: Some($status),
+            }, )+
+        ];
+    };
+
+    (@len $($variant:ident),+) => {
+        <[()]>::len(&[ $(amm_error_contract!(@unit $variant)),+ ])
+    };
+
+    (@unit $variant:ident) => { () };
+}
+
+amm_error_contract! {
+    ZeroAmount => {
+        code: "CE-AMM-0001",
+        message: "Input amount must be greater than zero.",
+        http_status: 400
+    },
+    ZeroReserve => {
+        code: "CE-AMM-0002",
+        message: "Reserves must stay above zero.",
+        http_status: 400
+    },
+    MinReserveBreached => {
+        code: "CE-AMM-0003",
+        message: "Operation would breach the minimum reserve.",
+        http_status: 409
+    },
+    Overflow => {
+        code: "CE-AMM-0004",
+        message: "Numerical overflow or underflow detected.",
+        http_status: 500
+    },
+    InputTooSmall => {
+        code: "CE-AMM-0005",
+        message: "Effective input amount is too small.",
+        http_status: 400
+    },
+    InvalidFee => {
+        code: "CE-AMM-0006",
+        message: "Fee ppm must be at most 1,000,000.",
+        http_status: 400
+    }
 }
 
 impl fmt::Display for AmmError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use AmmError::*;
-        let s = match self {
-            ZeroAmount => "amount deve ser > 0",
-            ZeroReserve => "reserve deve ser > 0",
-            MinReserveBreached => "reserva ficaria abaixo do mínimo",
-            Overflow => "overflow/underflow numérico",
-            InputTooSmall => "input efetivo após taxa é 0",
-            InvalidFee => "fee_ppm deve ser ≤ 1e6",
-        };
-        write!(f, "{}", s)
+        write!(f, "{}", self.user_message())
     }
 }
 

--- a/src/bin/obs_demo.rs
+++ b/src/bin/obs_demo.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use opentelemetry::KeyValue;
 use std::time::Instant;
 
+use credit_engine_core::amm::errors::AmmError;
 use credit_engine_core::telemetry; // troque para ce_core se o crate tiver esse nome
 
 #[tokio::main]
@@ -20,6 +21,25 @@ async fn main() -> Result<()> {
             .record(elapsed_ms, &[KeyValue::new("op", "swap")]);
         tel.invariant_error_rel
             .record(0.001_f64, &[KeyValue::new("op", "swap")]);
+    }
+
+    // Emit an example error log with the hardened contract fields.
+    let sample_error = AmmError::MinReserveBreached;
+    if let Some(status) = sample_error.http_status() {
+        tracing::error!(
+            error_code = sample_error.error_code(),
+            error_message = sample_error.user_message(),
+            error_variant = sample_error.variant_name(),
+            http_status = status,
+            "sample AMM error emitted"
+        );
+    } else {
+        tracing::error!(
+            error_code = sample_error.error_code(),
+            error_message = sample_error.user_message(),
+            error_variant = sample_error.variant_name(),
+            "sample AMM error emitted"
+        );
     }
 
     tel.shutdown();

--- a/tests/amm_error_contract.rs
+++ b/tests/amm_error_contract.rs
@@ -1,0 +1,52 @@
+use credit_engine_core::amm::errors::AmmError;
+use std::collections::HashSet;
+
+#[test]
+fn amm_error_contract_is_exhaustive_and_well_formed() {
+    let descriptors = AmmError::descriptors();
+    assert_eq!(descriptors.len(), AmmError::ALL_VARIANTS.len());
+
+    let mut codes = HashSet::new();
+    let mut variants = HashSet::new();
+    for descriptor in descriptors.iter() {
+        let variant = descriptor.variant;
+        variants.insert(variant.variant_name());
+        let code = descriptor.code;
+        assert!(code.starts_with("CE-AMM-"), "code prefix incorrect: {code}");
+        assert_eq!(code.len(), 11, "code length incorrect: {code}");
+        assert!(codes.insert(code), "duplicate code detected: {code}");
+
+        let message = descriptor.message;
+        assert!(
+            !message.trim().is_empty(),
+            "user message must be non-empty for {}",
+            variant.variant_name()
+        );
+        assert!(
+            message.ends_with('.'),
+            "user message must end with period: {message}"
+        );
+
+        if let Some(status) = descriptor.http_status {
+            match status {
+                400 | 403 | 404 | 409 | 500 | 502 | 503 => {}
+                other => panic!(
+                    "unexpected http status {other} for {}",
+                    variant.variant_name()
+                ),
+            }
+        }
+
+        assert_eq!(variant.error_code(), code);
+        assert_eq!(variant.user_message(), message);
+        assert_eq!(variant.http_status(), descriptor.http_status);
+    }
+
+    for variant in AmmError::ALL_VARIANTS.iter() {
+        assert!(
+            variants.contains(variant.variant_name()),
+            "variant {} missing from descriptor list",
+            variant.variant_name()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- replace the checked-in AMM artifacts/patch ZIPs with a reproducible packaging script and ignore generated archives
- document the new workflow in the guide, Jira template, and PR comment so consumers know how to regenerate deliverables
- refresh the evidence logs and diff bundle with the script to keep the audit trail current without binary files in git

## Testing
- `ops/scripts/package_amm_error_contract.sh 81ea18d`


------
https://chatgpt.com/codex/tasks/task_e_68d88bf3f6808330a507678bca5ac6e8