### PR TITLE
Refresh guardrail search logs

### DIFF
--- a/out/logs/guardrail_no_bail_in_okor.log
+++ b/out/logs/guardrail_no_bail_in_okor.log
@@ -1,0 +1,10 @@
+$ rg --stats "bail" src/amm
+
+0 matches
+0 matched lines
+0 files contained matches
+8 files searched
+0 bytes printed
+37747 bytes searched
+0.000116 seconds spent searching
+0.008166 seconds

--- a/out/logs/guardrail_no_code.log
+++ b/out/logs/guardrail_no_code.log
@@ -1,0 +1,10 @@
+$ rg --stats --fixed-strings "CODE" src/amm
+
+0 matches
+0 matched lines
+0 files contained matches
+8 files searched
+0 bytes printed
+37747 bytes searched
+0.000100 seconds spent searching
+0.006837 seconds


### PR DESCRIPTION
## Summary
- re-run the guardrail search that ensures the src/amm tree has no "CODE" placeholders and store the command/output in out/logs/guardrail_no_code.log
- re-run the guardrail search that ensures the src/amm tree has no "bail" occurrences and store the command/output in out/logs/guardrail_no_bail_in_okor.log

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95e0046a083309ef88e66288f03df