### PR TITLE
Fix AMM error catalog generator invocation

### DIFF
--- a/ops/scripts/generate_amm_error_index.py
+++ b/ops/scripts/generate_amm_error_index.py
@@ -129,4 +129,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    main()
    


### PR DESCRIPTION
## Summary
- Verified the AMM error catalog keeps the agreed metadata schema (domain `AMM`, prefix `CE-AMM`, version `1`) and only allowed HTTP status codes.
- Enabled `generate_amm_error_index.py` to execute directly so the catalog validation/regeneration script succeeds again.

## Testing
- cargo test --package credit-engine-core amm_error_contract
- python ops/scripts/generate_amm_error_index.py

------
https://chatgpt.com/codex/tasks/task_e_68d963e9fe3c8330a30a443fbc772b8c