### PR TITLE
Align AMM error catalog tests with runtime descriptors

### DIFF
--- a/tests/amm_error_catalog.rs
+++ b/tests/amm_error_catalog.rs
@@ -1,76 +1,52 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
-use credit_engine_core::amm::errors::{AmmError, AmmErrorDescriptor, AMM_ERROR_DESCRIPTORS};
+use credit_engine_core::amm::errors::AmmError;
 
 #[path = "catalog_utils.rs"]
 mod catalog_utils;
 
-fn descriptor_map() -> BTreeMap<String, &'static AmmErrorDescriptor> {
-    AMM_ERROR_DESCRIPTORS
-        .iter()
-        .map(|descriptor| (descriptor.variant.variant_name().to_string(), descriptor))
-        .collect()
+#[test]
+fn catalog_metadata_is_consistent() {
+    let catalog = catalog_utils::load_catalog();
+
+    assert_eq!(catalog.meta.domain, "AMM", "unexpected catalog domain");
+    assert_eq!(catalog.meta.prefix, "CE-AMM", "unexpected catalog prefix");
+    assert_eq!(catalog.meta.version, 1, "unexpected catalog version");
 }
 
 #[test]
-fn catalog_is_structurally_valid() {
+fn catalog_entries_match_runtime_descriptors() {
     let catalog = catalog_utils::load_catalog();
-
-    assert_eq!(catalog.meta.domain, "AMM");
-    assert_eq!(catalog.meta.prefix, "CE-AMM");
-    assert_eq!(catalog.meta.version, 1);
-
-    let mut seen_codes = BTreeSet::new();
-    for entry in &catalog.errors {
-        assert!(
-            seen_codes.insert(entry.code.clone()),
-            "código duplicado: {}",
-            entry.code
-        );
-    }
-}
-
-#[test]
-fn catalog_matches_runtime_descriptors() {
-    let catalog = catalog_utils::load_catalog();
-    let descriptors = descriptor_map();
-
+    let yaml_map = catalog.entries_by_variant();
     assert_eq!(
+        yaml_map.len(),
         catalog.errors.len(),
-        descriptors.len(),
-        "quantidade de entradas divergente"
+        "catalog contains duplicated variants"
     );
 
-    for entry in &catalog.errors {
-        let descriptor = descriptors
-            .get(&entry.variant)
-            .unwrap_or_else(|| panic!("descriptor ausente para {}", entry.variant));
+    let runtime_snapshot = catalog_utils::runtime_catalog_snapshot();
+    assert_eq!(
+        runtime_snapshot.len(),
+        AmmError::ALL_VARIANTS.len(),
+        "runtime descriptors and enum variants diverge"
+    );
 
-        assert_eq!(
-            descriptor.code, entry.code,
-            "code divergente para {}",
-            entry.variant
-        );
-        assert_eq!(
-            descriptor.message, entry.message,
-            "mensagem divergente para {}",
-            entry.variant
-        );
-        assert_eq!(
-            descriptor.http_status, entry.http_status,
-            "http_status divergente para {}",
-            entry.variant
-        );
-    }
+    let yaml_variants: BTreeSet<_> = yaml_map.keys().cloned().collect();
+    let runtime_variants: BTreeSet<_> = runtime_snapshot.keys().cloned().collect();
+    assert_eq!(
+        yaml_variants, runtime_variants,
+        "YAML catalog variants diverge from runtime descriptors"
+    );
 
-    for variant in AmmError::ALL_VARIANTS {
-        let variant_name = variant.variant_name();
-        assert!(
-            catalog
-                .errors
-                .iter()
-                .any(|entry| entry.variant == variant_name),
-            "variant {variant_name} ausente do catálogo"
-        );
-    }
+    let yaml_codes: BTreeSet<_> = yaml_map.values().map(|entry| entry.code.clone()).collect();
+    assert_eq!(
+        yaml_codes.len(),
+        yaml_map.len(),
+        "catalog contains duplicated error codes"
+    );
+
+    assert_eq!(
+        yaml_map, runtime_snapshot,
+        "YAML catalog contents diverge from runtime descriptors"
+    );
 }

--- a/tests/amm_error_contract.rs
+++ b/tests/amm_error_contract.rs
@@ -1,21 +1,15 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
-use credit_engine_core::amm::errors::{AmmError, AmmErrorDescriptor, AMM_ERROR_DESCRIPTORS};
+use credit_engine_core::amm::errors::{AmmError, AMM_ERROR_DESCRIPTORS};
 use once_cell::sync::Lazy;
 use regex::Regex;
 
 #[path = "catalog_utils.rs"]
 mod catalog_utils;
+use catalog_utils::{descriptors_by_variant, runtime_catalog_snapshot};
 
 static CODE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^CE-AMM-\d{4}$").unwrap());
 const ALLOWED_HTTP_STATUSES: &[u16] = &[400, 403, 404, 409, 500, 502, 503];
-
-fn descriptors_by_variant() -> BTreeMap<String, &'static AmmErrorDescriptor> {
-    AMM_ERROR_DESCRIPTORS
-        .iter()
-        .map(|descriptor| (descriptor.variant.variant_name().to_string(), descriptor))
-        .collect()
-}
 
 #[test]
 fn amm_error_runtime_metadata_is_exhaustive() {
@@ -28,11 +22,7 @@ fn amm_error_runtime_metadata_is_exhaustive() {
     );
     assert_eq!(catalog.meta.version, 1, "versão inválida no catálogo");
 
-    let yaml_map: BTreeMap<_, _> = catalog
-        .errors
-        .iter()
-        .map(|entry| (entry.variant.clone(), entry.clone()))
-        .collect();
+    let yaml_map = catalog.entries_by_variant();
     assert_eq!(
         yaml_map.len(),
         catalog.errors.len(),
@@ -40,11 +30,17 @@ fn amm_error_runtime_metadata_is_exhaustive() {
     );
 
     let descriptors = descriptors_by_variant();
+    let runtime_snapshot = runtime_catalog_snapshot();
     assert_eq!(descriptors.len(), AMM_ERROR_DESCRIPTORS.len());
     assert_eq!(
         descriptors.len(),
         AmmError::ALL_VARIANTS.len(),
         "descriptors e ALL_VARIANTS divergem"
+    );
+    assert_eq!(
+        descriptors.len(),
+        runtime_snapshot.len(),
+        "snapshot e descriptors divergem"
     );
 
     let yaml_variants: BTreeSet<_> = yaml_map.keys().cloned().collect();
@@ -67,6 +63,9 @@ fn amm_error_runtime_metadata_is_exhaustive() {
         let descriptor = descriptors
             .get(variant_name)
             .unwrap_or_else(|| panic!("descriptor ausente para {variant_name}"));
+        let snapshot = runtime_snapshot
+            .get(variant_name)
+            .unwrap_or_else(|| panic!("snapshot ausente para {variant_name}"));
 
         let code = variant.error_code();
         let message = variant.user_message();
@@ -122,6 +121,18 @@ fn amm_error_runtime_metadata_is_exhaustive() {
         assert_eq!(
             descriptor.http_status, status,
             "descriptor divergente (http_status) para {variant_name}"
+        );
+        assert_eq!(
+            snapshot.code, code,
+            "snapshot divergente (code) para {variant_name}"
+        );
+        assert_eq!(
+            snapshot.message, message,
+            "snapshot divergente (message) para {variant_name}"
+        );
+        assert_eq!(
+            snapshot.http_status, status,
+            "snapshot divergente (http_status) para {variant_name}"
         );
     }
 }

--- a/tests/catalog_utils.rs
+++ b/tests/catalog_utils.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+
+use credit_engine_core::amm::errors::{AmmErrorDescriptor, AMM_ERROR_DESCRIPTORS};
 
 #[derive(Debug, Clone)]
 pub struct CatalogDocument {
@@ -7,14 +10,14 @@ pub struct CatalogDocument {
     pub errors: Vec<CatalogEntry>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CatalogMeta {
     pub domain: String,
     pub prefix: String,
     pub version: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CatalogEntry {
     pub variant: String,
     pub code: String,
@@ -160,4 +163,36 @@ pub fn load_catalog() -> CatalogDocument {
     let raw = fs::read_to_string(&path)
         .unwrap_or_else(|err| panic!("não foi possível ler {path:?}: {err}"));
     parse_catalog(&raw)
+}
+
+pub fn descriptors_by_variant() -> BTreeMap<String, &'static AmmErrorDescriptor> {
+    AMM_ERROR_DESCRIPTORS
+        .iter()
+        .map(|descriptor| (descriptor.variant.variant_name().to_string(), descriptor))
+        .collect()
+}
+
+pub fn runtime_catalog_snapshot() -> BTreeMap<String, CatalogEntry> {
+    descriptors_by_variant()
+        .into_iter()
+        .map(|(variant, descriptor)| {
+            let entry = CatalogEntry {
+                variant: variant.clone(),
+                code: descriptor.code.to_string(),
+                message: descriptor.message.to_string(),
+                http_status: descriptor.http_status,
+            };
+            (variant, entry)
+        })
+        .collect()
+}
+
+impl CatalogDocument {
+    pub fn entries_by_variant(&self) -> BTreeMap<String, CatalogEntry> {
+        self.errors
+            .iter()
+            .cloned()
+            .map(|entry| (entry.variant.clone(), entry))
+            .collect()
+    }
 }


### PR DESCRIPTION
## Summary
- load the AMM error catalog entries into per-variant maps and check metadata explicitly
- share descriptor snapshot helpers between the contract and catalog tests to reuse the canonical code/message/status set
- verify the contract test against both descriptors and the shared snapshot to keep YAML validation and runtime metadata in sync

## Testing
- cargo test amm_error_catalog --tests

------
https://chatgpt.com/codex/tasks/task_e_68d963e7b9d48330a5439eb7ae2dee28