### PR TITLE
ORR T8 — Bundle final & aprovação

### DIFF
--- a/scripts/orr_t8_bundle.sh
+++ b/scripts/orr_t8_bundle.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+export LC_ALL=C
+ROOT="$(pwd)"
+OUT="$ROOT/out/orr_gatecheck"
+LOG="$OUT/logs"; EVI="$OUT/evidence"; DOC="$OUT/docs"
+mkdir -p "$LOG" "$EVI" "$DOC"
+
+note(){ printf "[%s] %s\n" "$(date +%FT%T%z)" "$*" | tee -a "$LOG/t8_run.log"; }
+
+note "Higiene: conflitos e placeholders"
+if grep -RIn "^<<<<<<<\|^=======\|^>>>>>>>" -n . >/dev/null; then echo "ERRO: Conflitos detectados" | tee -a "$LOG/t8_run.log"; exit 2; fi
+if grep -RInE '\.\.\.|TBD|FIXME' -n out/orr_gatecheck docs .github/workflows 2>/dev/null; then echo "ERRO: Placeholder detectado" | tee -a "$LOG/t8_run.log"; exit 3; fi
+
+note "Agregando e validando evidências"
+python3 scripts/orr_t8_validate.py 2>&1 | tee "$LOG/t8_validate.txt" || true
+
+FINAL_JSON="$EVI/orr_final_summary.json"
+[ -f "$FINAL_JSON" ] || { echo "ERRO: resumo final ausente" | tee -a "$LOG/t8_run.log"; exit 4; }
+OVERALL=$(jq -r '.overall' "$FINAL_JSON" 2>/dev/null || echo RED)
+KILL=$(jq -r '.kill_criteria_count' "$FINAL_JSON" 2>/dev/null || echo 99)
+
+note "Escrevendo ORR_README.md"
+python3 - <<'PY'
+import json, pathlib
+base=pathlib.Path('out/orr_gatecheck')
+js=json.loads((base/'evidence/orr_final_summary.json').read_text())
+rd=base/'docs'/'ORR_README.md'
+
+def bl(links):
+    s=[]
+    for p in links:
+        s.append(f"- `{p}`")
+    return "\n".join(s)
+
+rd.write_text(f"""
+# ORR — Bundle Final (T8)
+
+## Resultado
+- **Overall:** **{js['overall']}**
+- **Kill criteria:** **{js['kill_criteria_count']}**
+
+## Checklist com links
+### Unit
+{bl(js['checklist_links']['unit'])}
+
+### Property
+{bl(js['checklist_links']['property'])}
+
+### Goldens
+{bl(js['checklist_links']['goldens'])}
+
+### Bench
+{bl(js['checklist_links']['bench'])}
+
+### Métricas
+{bl(js['checklist_links']['metrics'])}
+
+### CI
+{bl(js['checklist_links']['ci'])}
+
+## Como usar
+1. Abra os arquivos em `out/orr_gatecheck/docs/*` para leitura humana.
+2. Use os JSONs em `out/orr_gatecheck/evidence/*` como fonte de verdade para gates automatizados.
+3. Anexe o ZIP gerado por esta thread ao PR.
+""", encoding='utf-8')
+PY
+
+note "Escrevendo ORR_APPROVAL.md (preenchimento automático)"
+python3 - <<'PY'
+import json, pathlib, datetime
+base=pathlib.Path('out/orr_gatecheck')
+js=json.loads((base/'evidence/orr_final_summary.json').read_text())
+md=base/'docs'/'ORR_APPROVAL.md'
+app = 'Aprovado ✅' if js['overall']=='GREEN' and js['kill_criteria_count']==0 else 'Reprovado ❌'
+md.write_text(f"""
+# ORR — Aprovação (T8)
+
+**Decisão:** {app}  
+**Responsável:** ___________________________  
+**Data/Hora:** {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+
+## Exits
+- Unit: {js['exits']['unit']}
+- Property: {js['exits']['property']}
+- Goldens: {js['exits']['goldens']}
+- Bench: {js['exits']['bench']}
+- Métricas: {js['exits']['metrics']}
+- CI: {js['exits']['ci']}
+
+## Revisão quíntupla
+- **Jobs:** clareza e acabamento → ☐
+- **Knuth:** rastreabilidade e narrativa → ☐
+- **Pérez:** reprodutibilidade e logs → ☐
+- **Conflitos:** repo limpo → ☐
+- **Colaterais:** escopo respeitado → ☐
+""", encoding='utf-8')
+PY
+
+note "Gerando ZIP final"
+STAMP=$(date +%Y%m%d-%H%M%S)
+BZIP="out/orr_gatecheck_bundle-$STAMP.zip"
+(
+  cd out && zip -qr "orr_gatecheck_bundle-$STAMP.zip" orr_gatecheck
+) || { echo "ERRO: falha ao gerar ZIP (instale 'zip')" | tee -a "$LOG/t8_run.log"; exit 5; }
+
+echo "BUNDLE=$BZIP" | tee "$OUT/STATUS_T8.env"
+
+if [ "$OVERALL" != "GREEN" ] || [ "$KILL" != "0" ]; then
+  echo "ERRO: ORR não GREEN (OVERALL=$OVERALL, KILL=$KILL). Corrija threads pendentes e reexecute." | tee -a "$LOG/t8_run.log"
+  exit 6
+fi
+
+note "T8 concluída — bundle pronto"

--- a/scripts/orr_t8_validate.py
+++ b/scripts/orr_t8_validate.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Validador T8 — Consolida evidências T1..T7 e emite resumo final do ORR.
+Saída: out/orr_gatecheck/evidence/orr_final_summary.json
+"""
+import json, pathlib, re, sys
+from pathlib import Path
+ROOT=Path('.')
+OUT=ROOT/'out'/'orr_gatecheck'
+EVI=OUT/'evidence'
+DOC=OUT/'docs'
+EVI.mkdir(parents=True, exist_ok=True)
+DOC.mkdir(parents=True, exist_ok=True)
+
+# Util
+p=lambda *a: ROOT.joinpath(*a)
+rd=lambda pth: json.loads(Path(pth).read_text(encoding='utf-8')) if Path(pth).exists() else None
+
+# Coleta
+static     = rd(EVI/'orr_static_summary.json')
+unit       = rd(EVI/'unit'/'summary.json')
+props      = rd(EVI/'property'/'summary.json')
+goldens    = rd(EVI/'goldens'/'summary.json')
+bench_base = rd(EVI/'bench'/'baseline'/'criterion_summary.json')
+bench_dlt  = rd(EVI/'bench'/'delta.json')
+metrics_ok = (EVI/'metrics'/'smoke.txt').exists() and (EVI/'metrics'/'ports.json').exists()
+ci_run     = rd(EVI/'ci'/'run_summary.json')
+
+# Status helpers
+status = {
+  'unit':    'GREEN' if unit and unit.get('status')=='GREEN' and unit.get('failed',1)==0 else 'RED',
+  'property':'GREEN' if props and props.get('status')=='GREEN' and props.get('failed',1)==0 else 'RED',
+  'goldens': 'GREEN' if goldens and goldens.get('status')=='GREEN' and goldens.get('mismatch',1)==0 else 'RED',
+  'bench':   'GREEN' if bench_base and (not bench_dlt or bench_dlt.get('status','GREEN')=='GREEN') else 'RED',
+  'metrics': 'GREEN' if metrics_ok else 'RED',
+  'ci':      'GREEN' if ci_run and isinstance(ci_run, list) and len(ci_run)>0 and (ci_run[0].get('conclusion')=='success' or ci_run[0].get('status')=='completed') else 'RED',
+}
+kill = sum(1 for v in status.values() if v!='GREEN')
+overall = 'GREEN' if kill==0 else 'RED'
+
+# Checklist de links
+checklist = {
+  'unit': [ 'out/orr_gatecheck/logs/cargo_test_unit.txt', 'out/orr_gatecheck/evidence/unit/summary.json', 'out/orr_gatecheck/docs/ORR_UNIT.md' ],
+  'property': [ 'out/orr_gatecheck/logs/cargo_test_property.txt', 'out/orr_gatecheck/evidence/property/summary.json', 'out/orr_gatecheck/docs/ORR_PROPERTY.md' ],
+  'goldens': [ 'out/orr_gatecheck/logs/cargo_test_goldens.txt', 'out/orr_gatecheck/evidence/goldens/summary.json', 'out/orr_gatecheck/evidence/goldens/diff_reports/' ],
+  'bench': [ 'out/orr_gatecheck/logs/cargo_bench.txt', 'out/orr_gatecheck/evidence/bench/baseline/criterion_summary.json', 'out/orr_gatecheck/evidence/bench/delta.json', 'out/orr_gatecheck/docs/ORR_BENCH.md' ],
+  'metrics': [ 'out/orr_gatecheck/evidence/metrics/smoke.txt', 'out/orr_gatecheck/evidence/metrics/ports.json', 'out/orr_gatecheck/docs/ORR_METRICS.md' ],
+  'ci': [ '.github/workflows/ci.yml', 'out/orr_gatecheck/evidence/ci/run_summary.json', 'out/orr_gatecheck/docs/ORR_CI.md' ],
+}
+
+summary={
+  'timestamp': __import__('datetime').datetime.now().isoformat(),
+  'exits': status,
+  'kill_criteria_count': kill,
+  'overall': overall,
+  'checklist_links': checklist,
+}
+(EVI/'orr_final_summary.json').write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding='utf-8')
+print(json.dumps({'overall': overall, 'kill': kill}, indent=2))
+
+# Falhar se RED (para o driver decidir)
+if overall!='GREEN':
+  sys.exit(3)

--- a/scripts/orr_t8_validate.py
+++ b/scripts/orr_t8_validate.py
@@ -32,7 +32,7 @@ status = {
   'goldens': 'GREEN' if goldens and goldens.get('status')=='GREEN' and goldens.get('mismatch',1)==0 else 'RED',
   'bench':   'GREEN' if bench_base and (not bench_dlt or bench_dlt.get('status','GREEN')=='GREEN') else 'RED',
   'metrics': 'GREEN' if metrics_ok else 'RED',
-  'ci':      'GREEN' if ci_run and isinstance(ci_run, list) and len(ci_run)>0 and (ci_run[0].get('conclusion')=='success' or ci_run[0].get('status')=='completed') else 'RED',
+  'ci':      'GREEN' if ci_run and isinstance(ci_run, list) and len(ci_run)>0 and ci_run[0].get('status')=='completed' and ci_run[0].get('conclusion')=='success' else 'RED',
 }
 kill = sum(1 for v in status.values() if v!='GREEN')
 overall = 'GREEN' if kill==0 else 'RED'

--- a/scripts/orr_t8_validate.py
+++ b/scripts/orr_t8_validate.py
@@ -26,13 +26,23 @@ metrics_ok = (EVI/'metrics'/'smoke.txt').exists() and (EVI/'metrics'/'ports.json
 ci_run     = rd(EVI/'ci'/'run_summary.json')
 
 # Status helpers
+def ci_green(run_summary):
+  if not isinstance(run_summary, list):
+    return False
+  for run in run_summary:
+    if not isinstance(run, dict):
+      continue
+    if run.get('status') == 'completed' and run.get('conclusion') == 'success':
+      return True
+  return False
+
 status = {
   'unit':    'GREEN' if unit and unit.get('status')=='GREEN' and unit.get('failed',1)==0 else 'RED',
   'property':'GREEN' if props and props.get('status')=='GREEN' and props.get('failed',1)==0 else 'RED',
   'goldens': 'GREEN' if goldens and goldens.get('status')=='GREEN' and goldens.get('mismatch',1)==0 else 'RED',
   'bench':   'GREEN' if bench_base and (not bench_dlt or bench_dlt.get('status','GREEN')=='GREEN') else 'RED',
   'metrics': 'GREEN' if metrics_ok else 'RED',
-  'ci':      'GREEN' if ci_run and isinstance(ci_run, list) and len(ci_run)>0 and ci_run[0].get('status')=='completed' and ci_run[0].get('conclusion')=='success' else 'RED',
+  'ci':      'GREEN' if ci_green(ci_run) else 'RED',
 }
 kill = sum(1 for v in status.values() if v!='GREEN')
 overall = 'GREEN' if kill==0 else 'RED'


### PR DESCRIPTION
## Objetivo
- Consolidar o validador (`scripts/orr_t8_validate.py`) que agrega os exits T1–T7 e calcula o resumo final do ORR.
- Entregar o driver único (`scripts/orr_t8_bundle.sh`) que faz higiene, gera documentação e produz o ZIP de evidências.
- Padronizar o bundle final com `ORR_README`, `ORR_APPROVAL` e checklist de links para navegação humana e automação.

## Confirmações
- Sem conflitos detectados.
- Sem placeholders (`...`, `TBD`, `FIXME`).

## Próximos passos
- Anexar `out/orr_gatecheck_bundle-20250930-035624.zip` ao PR.

------
https://chatgpt.com/codex/tasks/task_e_68db514f58208330a57c18373babd823