### PR TITLE
Add permission checks before writing ORR evidence

### DIFF
--- a/scripts/orr_t2_parse_unit.py
+++ b/scripts/orr_t2_parse_unit.py
@@ -6,6 +6,27 @@ import re
 import sys
 import tempfile
 
+
+def _nearest_existing_dir(path: pathlib.Path) -> pathlib.Path | None:
+    current = path
+    while True:
+        if current.exists():
+            if current.is_dir():
+                return current
+            parent = current.parent
+            return parent if parent != current else None
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def _is_dir_writable(path: pathlib.Path) -> bool:
+    existing_dir = _nearest_existing_dir(path)
+    if existing_dir is None:
+        return False
+    return os.access(existing_dir, os.W_OK | os.X_OK)
+
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 ROOT = SCRIPT_DIR.parent
 LOG = ROOT / 'out' / 'orr_gatecheck' / 'logs' / 'cargo_test_unit.txt'
@@ -39,6 +60,9 @@ outp = {
 }
 
 evidence_dir = ROOT / 'out' / 'orr_gatecheck' / 'evidence' / 'unit'
+if not _is_dir_writable(evidence_dir):
+    print(json.dumps(outp, separators=(',', ':')))
+    sys.exit(95)
 evidence_dir.mkdir(parents=True, exist_ok=True)
 target = evidence_dir / 'summary.json'
 

--- a/scripts/orr_t5_collect_criterion.py
+++ b/scripts/orr_t5_collect_criterion.py
@@ -5,11 +5,31 @@ import sys
 import tempfile
 from pathlib import Path
 
+
+def _nearest_existing_dir(path: Path) -> Path | None:
+    current = path
+    while True:
+        if current.exists():
+            if current.is_dir():
+                return current
+            parent = current.parent
+            return parent if parent != current else None
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def _is_dir_writable(path: Path) -> bool:
+    existing_dir = _nearest_existing_dir(path)
+    if existing_dir is None:
+        return False
+    return os.access(existing_dir, os.W_OK | os.X_OK)
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT = SCRIPT_DIR.parent
 OUT = ROOT / 'out' / 'orr_gatecheck'
 EVI = OUT / 'evidence' / 'bench' / 'baseline'
-EVI.mkdir(parents=True, exist_ok=True)
 
 paths = sorted(ROOT.glob('target/criterion/**/new/estimates.json'))
 benchmarks = []
@@ -32,6 +52,15 @@ output = {
     'benchmarks': benchmarks,
 }
 
+if output['count'] == 0:
+    sys.stderr.write('No Criterion artifacts found; run benches then collect.\n')
+    sys.exit(3)
+
+if not _is_dir_writable(EVI):
+    print(json.dumps(output, separators=(',', ':')))
+    sys.exit(95)
+
+EVI.mkdir(parents=True, exist_ok=True)
 target = EVI / 'criterion_summary.json'
 with tempfile.NamedTemporaryFile('w', encoding='utf-8', delete=False, dir=str(EVI), prefix='criterion_summary.', suffix='.json') as tmp:
     json.dump(output, tmp, indent=2)
@@ -39,9 +68,5 @@ with tempfile.NamedTemporaryFile('w', encoding='utf-8', delete=False, dir=str(EV
     os.fsync(tmp.fileno())
 temp_path = Path(tmp.name)
 temp_path.replace(target)
-
-if output['count'] == 0:
-    sys.stderr.write('No Criterion artifacts found; run benches then collect.\n')
-    sys.exit(3)
 
 print(json.dumps({'count': output['count']}))


### PR DESCRIPTION
## Summary
- add reusable helpers to verify evidence directories are writable before persisting JSON outputs
- print the would-be payload to stdout and exit with a distinct status when evidence paths cannot be written
- skip criterion summary creation when no benchmarks are found so the bench fallback can run

## Testing
- python -m compileall scripts/orr_t2_parse_unit.py scripts/orr_t5_collect_criterion.py

------
https://chatgpt.com/codex/tasks/task_e_68de004b97a48330b2f86332c90f90af