### PR TITLE
Add write access guard to ORR scripts

### DIFF
--- a/scripts/orr_t1_run.sh
+++ b/scripts/orr_t1_run.sh
@@ -4,9 +4,40 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 OUT="$ROOT/out/orr_gatecheck"
 LOG="$OUT/logs"
+STEP="T1"
+
+fail_read_only() {
+  printf '{ "step":"%s", "error":"read_only" }\n' "$STEP"
+  exit 95
+}
+
+require_write_access() {
+  local target="$1"
+  local dir="$target"
+  if [ ! -d "$dir" ]; then
+    dir="$(dirname "$dir")"
+  fi
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ]; do
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -w "$dir" ]; then
+    fail_read_only
+  fi
+  local probe
+  if ! probe="$(mktemp "$dir/.writecheck.XXXXXX" 2>/dev/null)"; then
+    fail_read_only
+  fi
+  rm -f "$probe"
+}
+
+require_write_access "$OUT"
+require_write_access "$LOG"
+
 mkdir -p "$LOG"
 
 TMPDIS=""
+LOG_TMP=""
+
 restore_bin() {
   if [ -n "$TMPDIS" ] && [ -f "$TMPDIS" ]; then
     mv "$TMPDIS" "$ROOT/src/bin/telemetry_smoke.rs"
@@ -14,15 +45,43 @@ restore_bin() {
   fi
 }
 
+cleanup() {
+  restore_bin
+  if [ -n "$LOG_TMP" ] && [ -f "$LOG_TMP" ]; then
+    rm -f "$LOG_TMP"
+    LOG_TMP=""
+  fi
+}
+
+trap 'cleanup' EXIT INT TERM
+
 if [ -f "$ROOT/src/bin/telemetry_smoke.rs" ]; then
   TMPDIS="$ROOT/src/bin/telemetry_smoke.rs.bak.$$"
   mv "$ROOT/src/bin/telemetry_smoke.rs" "$TMPDIS"
-  trap 'restore_bin' EXIT INT TERM
 fi
 
 cd "$ROOT"
-cargo test -- --nocapture | tee "$LOG/cargo_test_unit.txt"
+LOG_TMP="$(mktemp "$LOG/cargo_test_unit.txt.XXXXXX")"
+set +e
+cargo test -- --nocapture | tee "$LOG_TMP"
 RC=${PIPESTATUS[0]}
-restore_bin
+set -e
+
+python3 - "$LOG_TMP" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+
+mv "$LOG_TMP" "$LOG/cargo_test_unit.txt"
+LOG_TMP=""
+
+cleanup
 trap - EXIT INT TERM || true
 exit $RC

--- a/scripts/orr_t3_props_run.sh
+++ b/scripts/orr_t3_props_run.sh
@@ -6,9 +6,42 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 OUT="$ROOT/out/orr_gatecheck"
 LOG_DIR="$OUT/logs"
 EVI_DIR="$OUT/evidence/property"
+STEP="T3"
+
+fail_read_only() {
+  printf '{ "step":"%s", "error":"read_only" }\n' "$STEP"
+  exit 95
+}
+
+require_write_access() {
+  local target="$1"
+  local dir="$target"
+  if [ ! -d "$dir" ]; then
+    dir="$(dirname "$dir")"
+  fi
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ]; do
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -w "$dir" ]; then
+    fail_read_only
+  fi
+  local probe
+  if ! probe="$(mktemp "$dir/.writecheck.XXXXXX" 2>/dev/null)"; then
+    fail_read_only
+  fi
+  rm -f "$probe"
+}
+
+require_write_access "$OUT"
+require_write_access "$LOG_DIR"
+require_write_access "$EVI_DIR"
+
 mkdir -p "$LOG_DIR" "$EVI_DIR"
 
 TMPDIS=""
+LOG_TMP=""
+SEEDS_TMP=""
+
 restore_bin() {
   if [ -n "$TMPDIS" ] && [ -f "$TMPDIS" ]; then
     mv "$TMPDIS" "$ROOT/src/bin/telemetry_smoke.rs"
@@ -16,18 +49,47 @@ restore_bin() {
   fi
 }
 
+cleanup() {
+  restore_bin
+  if [ -n "$LOG_TMP" ] && [ -f "$LOG_TMP" ]; then
+    rm -f "$LOG_TMP"
+    LOG_TMP=""
+  fi
+  if [ -n "$SEEDS_TMP" ] && [ -f "$SEEDS_TMP" ]; then
+    rm -f "$SEEDS_TMP"
+    SEEDS_TMP=""
+  fi
+}
+
+trap 'cleanup' EXIT INT TERM
+
 if [ -f "$ROOT/src/bin/telemetry_smoke.rs" ]; then
   TMPDIS="$ROOT/src/bin/telemetry_smoke.rs.bak.$$"
   mv "$ROOT/src/bin/telemetry_smoke.rs" "$TMPDIS"
-  trap 'restore_bin' EXIT INT TERM
 fi
 
 cd "$ROOT"
 LOG_FILE="$LOG_DIR/cargo_test_property.txt"
-cargo test --test property -- --nocapture | tee "$LOG_FILE"
+LOG_TMP="$(mktemp "$LOG_FILE.XXXXXX")"
+set +e
+cargo test --test property -- --nocapture | tee "$LOG_TMP"
 RC=${PIPESTATUS[0]}
-restore_bin
-trap - EXIT INT TERM || true
+set -e
+
+python3 - "$LOG_TMP" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+
+mv "$LOG_TMP" "$LOG_FILE"
+LOG_TMP=""
 
 python3 - "$ROOT" "$RC" <<'PY'
 import json
@@ -70,6 +132,20 @@ if grep -E '^seed:[0-9]+' "$LOG_FILE" >"$SEEDS_TMP"; then
 else
   : >"$SEEDS_TMP"
 fi
-mv "$SEEDS_TMP" "$EVI_DIR/seeds.jsonl"
+python3 - "$SEEDS_TMP" <<'PY'
+import os
+import sys
 
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+mv "$SEEDS_TMP" "$EVI_DIR/seeds.jsonl"
+SEEDS_TMP=""
+
+cleanup
+trap - EXIT INT TERM || true
 exit $RC

--- a/scripts/orr_t4_goldens_run.sh
+++ b/scripts/orr_t4_goldens_run.sh
@@ -1,13 +1,47 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 OUT="$ROOT/out/orr_gatecheck"
 LOG="$OUT/logs"
 EVI="$OUT/evidence/goldens"
+STEP="T4"
+
+fail_read_only() {
+  printf '{ "step":"%s", "error":"read_only" }\n' "$STEP"
+  exit 95
+}
+
+require_write_access() {
+  local target="$1"
+  local dir="$target"
+  if [ ! -d "$dir" ]; then
+    dir="$(dirname "$dir")"
+  fi
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ]; do
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -w "$dir" ]; then
+    fail_read_only
+  fi
+  local probe
+  if ! probe="$(mktemp "$dir/.writecheck.XXXXXX" 2>/dev/null)"; then
+    fail_read_only
+  fi
+  rm -f "$probe"
+}
+
+require_write_access "$OUT"
+require_write_access "$LOG"
+require_write_access "$EVI"
+
 mkdir -p "$LOG" "$EVI"
 
 TMPDIS=""
+LOG_TMP=""
+SUMMARY_TMP=""
+
 restore_bin() {
   if [ -n "$TMPDIS" ] && [ -f "$TMPDIS" ]; then
     mv "$TMPDIS" "$ROOT/src/bin/telemetry_smoke.rs"
@@ -15,17 +49,46 @@ restore_bin() {
   fi
 }
 
+cleanup() {
+  restore_bin
+  if [ -n "$LOG_TMP" ] && [ -f "$LOG_TMP" ]; then
+    rm -f "$LOG_TMP"
+    LOG_TMP=""
+  fi
+  if [ -n "$SUMMARY_TMP" ] && [ -f "$SUMMARY_TMP" ]; then
+    rm -f "$SUMMARY_TMP"
+    SUMMARY_TMP=""
+  fi
+}
+
+trap 'cleanup' EXIT INT TERM
+
 if [ -f "$ROOT/src/bin/telemetry_smoke.rs" ]; then
   TMPDIS="$ROOT/src/bin/telemetry_smoke.rs.bak.$$"
   mv "$ROOT/src/bin/telemetry_smoke.rs" "$TMPDIS"
-  trap 'restore_bin' EXIT INT TERM
 fi
 
 cd "$ROOT"
-cargo test --test golden_cpmm -- --nocapture | tee "$LOG/cargo_test_goldens.txt"
+LOG_TMP="$(mktemp "$LOG/cargo_test_goldens.txt.XXXXXX")"
+set +e
+cargo test --test golden_cpmm -- --nocapture | tee "$LOG_TMP"
 RC=${PIPESTATUS[0]}
-restore_bin
-trap - EXIT INT TERM || true
+set -e
+
+python3 - "$LOG_TMP" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+
+mv "$LOG_TMP" "$LOG/cargo_test_goldens.txt"
+LOG_TMP=""
 
 STATUS="GREEN"
 MISMATCH=0
@@ -34,8 +97,8 @@ if [ "$RC" -ne 0 ]; then
   MISMATCH=999
 fi
 
-TMP_JSON="$(mktemp "$EVI/summary.json.XXXXXX")"
-cat >"$TMP_JSON" <<EOF
+SUMMARY_TMP="$(mktemp "$EVI/summary.json.XXXXXX")"
+cat >"$SUMMARY_TMP" <<EOF2
 {
   "expected_files": 2,
   "actual_files": 2,
@@ -43,7 +106,23 @@ cat >"$TMP_JSON" <<EOF
   "mismatch": $MISMATCH,
   "status": "$STATUS"
 }
-EOF
-mv "$TMP_JSON" "$EVI/summary.json"
+EOF2
 
+python3 - "$SUMMARY_TMP" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+
+mv "$SUMMARY_TMP" "$EVI/summary.json"
+SUMMARY_TMP=""
+
+cleanup
+trap - EXIT INT TERM || true
 exit $RC

--- a/scripts/orr_t5_bench_run.sh
+++ b/scripts/orr_t5_bench_run.sh
@@ -1,12 +1,44 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 OUT="$ROOT/out/orr_gatecheck"
 LOG="$OUT/logs"
+STEP="T5"
+
+fail_read_only() {
+  printf '{ "step":"%s", "error":"read_only" }\n' "$STEP"
+  exit 95
+}
+
+require_write_access() {
+  local target="$1"
+  local dir="$target"
+  if [ ! -d "$dir" ]; then
+    dir="$(dirname "$dir")"
+  fi
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ]; do
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -w "$dir" ]; then
+    fail_read_only
+  fi
+  local probe
+  if ! probe="$(mktemp "$dir/.writecheck.XXXXXX" 2>/dev/null)"; then
+    fail_read_only
+  fi
+  rm -f "$probe"
+}
+
+require_write_access "$OUT"
+require_write_access "$LOG"
+
 mkdir -p "$LOG"
 
 TMPDIS=""
+LOG_TMP=""
+
 restore_bin() {
   if [ -n "$TMPDIS" ] && [ -f "$TMPDIS" ]; then
     mv "$TMPDIS" "$ROOT/src/bin/telemetry_smoke.rs"
@@ -14,15 +46,43 @@ restore_bin() {
   fi
 }
 
+cleanup() {
+  restore_bin
+  if [ -n "$LOG_TMP" ] && [ -f "$LOG_TMP" ]; then
+    rm -f "$LOG_TMP"
+    LOG_TMP=""
+  fi
+}
+
+trap 'cleanup' EXIT INT TERM
+
 if [ -f "$ROOT/src/bin/telemetry_smoke.rs" ]; then
   TMPDIS="$ROOT/src/bin/telemetry_smoke.rs.bak.$$"
   mv "$ROOT/src/bin/telemetry_smoke.rs" "$TMPDIS"
-  trap 'restore_bin' EXIT INT TERM
 fi
 
 cd "$ROOT"
-cargo bench | tee "$LOG/cargo_bench.txt"
+LOG_TMP="$(mktemp "$LOG/cargo_bench.txt.XXXXXX")"
+set +e
+cargo bench | tee "$LOG_TMP"
 RC=${PIPESTATUS[0]}
-restore_bin
+set -e
+
+python3 - "$LOG_TMP" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+
+mv "$LOG_TMP" "$LOG/cargo_bench.txt"
+LOG_TMP=""
+
+cleanup
 trap - EXIT INT TERM || true
 exit $RC

--- a/scripts/orr_t6_metrics_run.sh
+++ b/scripts/orr_t6_metrics_run.sh
@@ -5,7 +5,52 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 OUT="$ROOT/out/orr_gatecheck"
 EVI="$OUT/evidence/metrics"
+STEP="T6"
+
+fail_read_only() {
+  printf '{ "step":"%s", "error":"read_only" }\n' "$STEP"
+  exit 95
+}
+
+require_write_access() {
+  local target="$1"
+  local dir="$target"
+  if [ ! -d "$dir" ]; then
+    dir="$(dirname "$dir")"
+  fi
+  while [ ! -d "$dir" ] && [ "$dir" != "/" ]; do
+    dir="$(dirname "$dir")"
+  done
+  if [ ! -w "$dir" ]; then
+    fail_read_only
+  fi
+  local probe
+  if ! probe="$(mktemp "$dir/.writecheck.XXXXXX" 2>/dev/null)"; then
+    fail_read_only
+  fi
+  rm -f "$probe"
+}
+
+require_write_access "$OUT"
+require_write_access "$EVI"
+
 mkdir -p "$EVI"
+
+SMOKE_TMP=""
+PORTS_TMP=""
+
+cleanup() {
+  if [ -n "$SMOKE_TMP" ] && [ -f "$SMOKE_TMP" ]; then
+    rm -f "$SMOKE_TMP"
+    SMOKE_TMP=""
+  fi
+  if [ -n "$PORTS_TMP" ] && [ -f "$PORTS_TMP" ]; then
+    rm -f "$PORTS_TMP"
+    PORTS_TMP=""
+  fi
+}
+
+trap 'cleanup' EXIT INT TERM
 
 cd "$ROOT"
 
@@ -22,10 +67,37 @@ fi
 timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 SMOKE_TMP="$(mktemp "$EVI/smoke.txt.XXXXXX")"
 printf '%s\n' "$timestamp" >"$SMOKE_TMP"
+python3 - "$SMOKE_TMP" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
 mv "$SMOKE_TMP" "$EVI/smoke.txt"
+SMOKE_TMP=""
 
 PORTS_TMP="$(mktemp "$EVI/ports.json.XXXXXX")"
 cat >"$PORTS_TMP" <<'JSON'
 {"http": 0, "grpc": 0}
 JSON
+python3 - "$PORTS_TMP" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+fd = os.open(path, os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
 mv "$PORTS_TMP" "$EVI/ports.json"
+PORTS_TMP=""
+
+cleanup
+trap - EXIT INT TERM || true


### PR DESCRIPTION
## Summary
- add a `require_write_access` helper to the ORR gatecheck scripts so read-only outputs emit JSON diagnostics and exit with code 95
- switch log and evidence writes to `mktemp` + `mv` with explicit `fsync` to keep filesystem updates atomic on macOS

## Testing
- bash -n scripts/orr_t1_run.sh
- bash -n scripts/orr_t3_props_run.sh
- bash -n scripts/orr_t4_goldens_run.sh
- bash -n scripts/orr_t5_bench_run.sh
- bash -n scripts/orr_t6_metrics_run.sh

------
https://chatgpt.com/codex/tasks/task_e_68de004b9c608330ba4e2517f407e3c6