### PR TITLE
OBS-1: publish canonical observability contract

### DIFF
--- a/docs/obs1_contract.md
+++ b/docs/obs1_contract.md
@@ -1,0 +1,171 @@
+# OBS-1 Telemetry Contract
+
+**Versão do contrato:** 1.0.0
+
+Este documento define o contrato canônico da thread OBS-1 para métricas, spans e logs estruturados. Ele é a única fonte de verdade consumida pelos demais componentes do projeto CRD-8. Nenhum código pode emitir telemetria fora das convenções aqui descritas.
+
+## 1. Métricas autorizadas
+
+Todas as métricas seguem `snake_case` com sufixo de unidade quando aplicável. Labels válidos obedecem o regex `^[a-z0-9_]{1,32}$`. A lista completa de labels permitidos é `{op, service, env, version, hook_id, status, source, domain, stream, partition, feature}`. É proibido introduzir qualquer label diferente desta lista. Labels proibidos explícitos: `{user_id, account_id, request_id, session_id}` e qualquer chave com sufixo `_uuid` ou `_hash`.
+
+| Nome | Tipo | Unidade | Labels | Buckets | Descrição | Notas de cardinalidade |
+| --- | --- | --- | --- | --- | --- | --- |
+| `amm_op_latency_seconds` | Histograma | segundos | `op`, `service`, `env`, `version` | `[0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0]` | Latência por operação do AMM, em segundos (por op/versão). | `op` deve usar o mapeamento de spans; `service` fixo em `ce-amm`. | 
+| `hook_executions_total` | Counter | n/a | `hook_id`, `status` | n/a | Número de execuções de hooks por id e status. | `status` ∈ {`success`, `error`}. `hook_id` deve ser estável, sem IDs por requisição. |
+| `data_freshness_seconds` | Gauge | segundos | `source`, `domain` | n/a | Freshness de dados por fonte e domínio. | Registrar apenas valores reais provenientes dos sistemas de ingestão. |
+| `cdc_lag_seconds` | Gauge | segundos | `stream`, `partition` | n/a | Atraso de CDC por stream e partição. | Não utilizar partições dinâmicas sem agregação. |
+| `drift_score` | Gauge | adimensional | `feature`, `domain` | n/a | Indicador de drift de features. | Valor esperado entre 0 e 1; nunca usar valores sintéticos nesta fase. |
+
+### 1.1 Exemplo de exposição Prometheus
+
+```
+# HELP amm_op_latency_seconds Latência por operação do AMM em segundos
+# TYPE amm_op_latency_seconds histogram
+amm_op_latency_seconds_bucket{op="swap",service="ce-amm",env="dev",version="1.2.3",le="0.005"} 2
+amm_op_latency_seconds_bucket{op="swap",service="ce-amm",env="dev",version="1.2.3",le="0.01"} 5
+...
+amm_op_latency_seconds_bucket{op="swap",service="ce-amm",env="dev",version="1.2.3",le="5"} 42
+amm_op_latency_seconds_sum{op="swap",service="ce-amm",env="dev",version="1.2.3"} 12.34
+amm_op_latency_seconds_count{op="swap",service="ce-amm",env="dev",version="1.2.3"} 42
+```
+
+### 1.2 Considerações OTLP
+
+* Histograma deve ser reportado como `HistogramDataPoint` com os limites de bucket listados.
+* Counter deve usar `Sum` monotônico com `aggregation_temporality = CUMULATIVE`.
+* Gauges devem ser reportados como `Gauge` com valores `double` reais. Nunca registrar placeholders.
+
+## 2. Spans e atributos obrigatórios
+
+Spans usam nomes em `dot.notation` e devem incluir os atributos obrigatórios listados. O label de métrica `op` deve coincidir com a coluna "Op" abaixo.
+
+| Span | Atributos obrigatórios (tipo) | Op correspondente |
+| --- | --- | --- |
+| `amm.swap` | `amm.k_before` (double), `amm.k_after` (double), `amm.delta_k_ratio` (double), `amm.fee_ppm` (integer), `amm.input` (double), `amm.output` (double) | `swap` |
+| `amm.add_liquidity` | mesmos atributos acima | `add_liquidity` |
+| `amm.remove_liquidity` | mesmos atributos acima | `remove_liquidity` |
+| `pricing.quote` | mesmos atributos acima | `pricing` |
+| `cdc.consume` | mesmos atributos acima | `cdc_consume` |
+
+#### Exemplo conceitual de span
+
+```
+name=amm.swap
+attributes={
+  "op":"swap",
+  "amm.k_before":1.0,
+  "amm.k_after":1.05,
+  "amm.delta_k_ratio":0.05,
+  "amm.fee_ppm":300,
+  "amm.input":100.0,
+  "amm.output":99.7
+}
+```
+
+## 3. Log JSON estruturado
+
+Logs são objetos JSON com campos obrigatórios e opcionais descritos abaixo. Campos obrigatórios não podem faltar; campos opcionais devem seguir os formatos especificados.
+
+| Campo | Obrigatório | Tipo/Formato | Observações |
+| --- | --- | --- | --- |
+| `ts` | Sim | `string` (`date-time` RFC3339 UTC, termina com `Z`) | Ex.: `2025-10-03T12:34:56Z`. |
+| `level` | Sim | `string` enum (`trace`, `debug`, `info`, `warn`, `error`) | Sensível a caixa. |
+| `msg` | Sim | `string` | Mensagem humana curta. |
+| `trace_id` | Sim | `string` (`^[0-9a-f]{32}$`) | Hex minúsculo de 16 bytes. |
+| `span_id` | Sim | `string` (`^[0-9a-f]{16}$`) | Hex minúsculo de 8 bytes. |
+| `service` | Sim | `string` (`ce-amm`) | Deve coincidir com resource attribute. |
+| `env` | Sim | `string` enum (`dev`, `stg`, `prod`) | |
+| `op` | Sim | `string` (`swap`, `add_liquidity`, `remove_liquidity`, `pricing`, `cdc_consume`) | Regex `^(swap|add_liquidity|remove_liquidity|pricing|cdc_consume)$`. |
+| `version` | Sim | `string` (SemVer ou git SHA) | Ex.: `1.2.3` ou `4fd0c2a64b7f1a3e9c0b2e1d5a6c7b8f`. |
+| `hook_id` | Não | `string` (`^[a-z0-9]+([-_][a-z0-9]+)*$`) | Identificador estável de hook. |
+| `error.kind` | Não | `string` | Tipo curto de erro. |
+| `error.message` | Não | `string` | Mensagem curta, sem PII. |
+| `extra` | Não | `object` | Chaves estáveis; valores podem ser `string`, `number`, `boolean` ou `object`. |
+
+### 3.1 Exemplo válido
+
+```json
+{
+  "ts": "2025-10-03T12:34:56Z",
+  "level": "info",
+  "msg": "swap executed",
+  "trace_id": "4fd0c2a64b7f1a3e9c0b2e1d5a6c7b8f",
+  "span_id": "9a3b7c1d2e3f4a5b",
+  "service": "ce-amm",
+  "env": "dev",
+  "op": "swap",
+  "version": "1.2.3",
+  "hook_id": "risk-check",
+  "extra": { "amm": {"k_before": 1.0, "k_after": 1.05, "delta_k_ratio": 0.05, "fee_ppm": 300 } }
+}
+```
+
+### 3.2 Exemplo inválido (contém PII)
+
+```json
+{
+  "ts": "2025-10-03T12:34:56Z",
+  "level": "info",
+  "msg": "swap",
+  "trace_id": "4fd0c2...",
+  "span_id": "9a3b7c...",
+  "service": "ce-amm",
+  "env": "dev",
+  "op": "swap",
+  "version": "1.2.3",
+  "email": "cliente@exemplo.com"
+}
+```
+
+Motivo: o campo `email` viola a política de PII e deve ser removido ou mascarado.
+
+## 4. Resource attributes
+
+| Chave | Valor | Notas |
+| --- | --- | --- |
+| `service.name` | `ce-amm` | Constante para todos os emissores. |
+| `service.version` | SemVer ou git SHA | Deve refletir a versão real em produção. |
+| `deployment.environment` | `dev`, `stg`, `prod` | Mesmo valor utilizado nos logs e métricas. |
+
+## 5. Flags e variáveis de ambiente
+
+| Nome | Valores permitidos | Uso |
+| --- | --- | --- |
+| `OBSERVABILITY_LEVEL` | `off`, `min`, `full` | Controla o volume de telemetria emitida. |
+| `PROM_SCRAPE` | `on`, `off` | Habilita a exposição `/metrics` em ambientes Dev/Stage. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | URL (ex.: `http://127.0.0.1:4317`) | Endpoint OTLP para exportação em produção. |
+
+## 6. Política de versionamento
+
+O contrato segue SemVer:
+
+* **MAJOR**: renomear ou remover métricas/spans/labels; alterar semântica de campos obrigatórios; mudar os buckets do histograma.
+* **MINOR**: adicionar spans, labels ou buckets opcionais sem quebrar consumidores.
+* **PATCH**: correções textuais ou de documentação sem impacto estrutural.
+
+Consumidores devem verificar `OBS1_CONTRACT_VERSION` antes de aplicar mudanças. Alterações incompatíveis exigem bump de versão e comunicação prévia.
+
+## 7. FAQ curta
+
+**P: Posso adicionar um label novo para depuração?**
+R: Não. Labels fora da lista canônica quebram cardinalidade controlada e são rejeitados.
+
+**P: Como lidar com hooks que ainda não existem?**
+R: Registre a métrica `hook_executions_total` somente quando o hook estiver implementado. Não use valores artificiais.
+
+**P: Preciso enviar logs em ambientes sem OTLP?**
+R: Sim, use JSON estruturado e respeite o schema. O downstream decidirá sobre exportação.
+
+## 8. Glossário
+
+* **AMM**: Automated Market Maker responsável pelas operações `swap` e de liquidez.
+* **CDC**: Change Data Capture, origem dos eventos monitorados por `cdc_lag_seconds`.
+* **PII**: Personally Identifiable Information, terminantemente proibida nos logs.
+* **PPM**: Parts per million, unidade usada para `amm.fee_ppm`.
+
+## 9. Conformidade cruzada
+
+* Todos os campos e nomes aqui descritos estão refletidos nos arquivos `src/telemetry_contract.rs`, `schemas/obs1_log_record.schema.json` e `schemas/obs1_contract.yaml`.
+* A exposição em `/metrics` deve utilizar exatamente os nomes de métricas aprovados e apenas os buckets listados.
+* Antes de publicar alterações, execute as checagens desta thread para garantir aderência ao contrato.
+

--- a/out/obs_gatecheck/docs/OBS1_CONTRACT_README.md
+++ b/out/obs_gatecheck/docs/OBS1_CONTRACT_README.md
@@ -1,0 +1,68 @@
+# OBS-1 Contract Consumption Guide
+
+Este guia explica como consumir o contrato OBS-1 definido nesta thread.
+
+## 1. Referências de código
+
+Use o módulo `telemetry_contract` para importar todos os identificadores:
+
+```rust
+use trendmarket::telemetry_contract::{
+    OBS1_CONTRACT_VERSION,
+    METRIC_AMM_OP_LATENCY_SECONDS,
+    AMM_OP_LATENCY_BUCKETS,
+    LABELS_PERMITIDOS,
+    OPERATION_VALUES,
+};
+```
+
+Garanta que qualquer emissor de métricas utilize exclusivamente os nomes e labels publicados. Compare labels candidatos contra `LABELS_PERMITIDOS` e rejeite qualquer item em `LABELS_PROIBIDOS`.
+
+## 2. Validação de logs
+
+O schema `schemas/obs1_log_record.schema.json` é a referência para validação estática de logs estruturados. Antes de liberar alterações, valide arquivos de exemplo:
+
+```bash
+ajv validate -s schemas/obs1_log_record.schema.json -d docs/obs1_log_example.json
+```
+
+Em ambientes sem `ajv`, utilize qualquer validador compatível com Draft-07. Campos PII (`email`, `cpf`, `phone`, `address`, `name`, `geo`, `person_*`) devem ser bloqueados automaticamente.
+
+## 3. Métricas e spans
+
+* Histograma `amm_op_latency_seconds`: use `AMM_OP_LATENCY_BUCKETS` e respeite o conjunto de labels `{op, service, env, version}`.
+* Counter `hook_executions_total`: somente incremente com `status` em `{success, error}`.
+* Gauges `data_freshness_seconds`, `cdc_lag_seconds` e `drift_score`: publicar apenas valores reais; nada de placeholders.
+* Spans devem usar os nomes `amm.swap`, `amm.add_liquidity`, `amm.remove_liquidity`, `pricing.quote` e `cdc.consume`, incluindo todos os atributos `amm.*` definidos.
+
+## 4. Flags e resource attributes
+
+* Configure `service.name=ce-amm`, `service.version=<semver|git_sha>` e `deployment.environment` conforme ambiente.
+* Flags disponíveis: `OBSERVABILITY_LEVEL` (`off|min|full`), `PROM_SCRAPE` (`on|off`) e `OTEL_EXPORTER_OTLP_ENDPOINT` (URL OTLP).
+
+## 5. Versionamento e breaking changes
+
+* Verifique `OBS1_CONTRACT_VERSION` antes de introduzir novidades.
+* Alterações incompatíveis exigem incremento MAJOR e comunicação prévia.
+* Adições compatíveis (labels opcionais, novos spans) usam incremento MINOR.
+* Correções textuais usam PATCH.
+
+## 6. Checklist rápido
+
+- [ ] Utilize apenas métricas e spans canônicos.
+- [ ] Valide todos os logs contra o schema JSON.
+- [ ] Rejeite labels fora de `LABELS_PERMITIDOS` e campos PII.
+- [ ] Garanta alinhamento de `op` entre métricas, spans e logs.
+- [ ] Atualize dependentes ao mudar `OBS1_CONTRACT_VERSION`.
+
+## 7. Perguntas frequentes
+
+**Como lidar com ambientes sem Prometheus?**
+Use `OBSERVABILITY_LEVEL=min` e mantenha o histograma local; a exportação OTLP pode ser desativada definindo `PROM_SCRAPE=off`.
+
+**Posso adicionar métricas novas?**
+Não nesta thread. Submeta uma proposta com bump de versão seguindo SemVer.
+
+**Como validar o histograma?**
+Compare os limites dos buckets com `AMM_OP_LATENCY_BUCKETS` e configure o SDK OTel para usar o modo explícito.
+

--- a/out/obs_gatecheck/evidence/obs1_contract_report.json
+++ b/out/obs_gatecheck/evidence/obs1_contract_report.json
@@ -1,0 +1,32 @@
+{
+  "timestamp_utc": "2025-10-03T04:14:41Z",
+  "contract_version": "1.0.0",
+  "counts": {
+    "metrics": 5,
+    "spans": 5,
+    "log_required_fields": 9,
+    "log_optional_fields": 4
+  },
+  "files": [
+    {
+      "path": "docs/obs1_contract.md",
+      "sha256": "28e017d43af4f8521c738da82f002f91fe197c33fec83aeab31f0ae1361ebb6b"
+    },
+    {
+      "path": "src/telemetry_contract.rs",
+      "sha256": "493bace8558affed20cc99155bfeaef64ede6a3ea2980e03579c0769d34810a0"
+    },
+    {
+      "path": "schemas/obs1_log_record.schema.json",
+      "sha256": "7099f75df86df53dd0c0ea2764082446788b03a8345917aadb28f524ac276cfd"
+    },
+    {
+      "path": "schemas/obs1_contract.yaml",
+      "sha256": "a7cd9082aa8e724c366351485d6c5724790db723378c2b3b023a4450ac38c41a"
+    },
+    {
+      "path": "out/obs_gatecheck/docs/OBS1_CONTRACT_README.md",
+      "sha256": "ff02d020030d04e9e9305d07b8781543232e1a8f1158ff04233c2ebd35461b9c"
+    }
+  ]
+}

--- a/schemas/obs1_contract.yaml
+++ b/schemas/obs1_contract.yaml
@@ -1,0 +1,244 @@
+version: "1.0.0"
+label_policy:
+  regex: "^[a-z0-9_]{1,32}$"
+  allowed:
+    - op
+    - service
+    - env
+    - version
+    - hook_id
+    - status
+    - source
+    - domain
+    - stream
+    - partition
+    - feature
+  forbidden:
+    - user_id
+    - account_id
+    - request_id
+    - session_id
+  forbidden_patterns:
+    - "*_uuid"
+    - "*_hash"
+metrics:
+  - name: amm_op_latency_seconds
+    type: histogram
+    unit: seconds
+    description: "Latência por operação do AMM, em segundos (por op/versão)."
+    labels:
+      required:
+        - op
+        - service
+        - env
+        - version
+      optional: []
+    buckets:
+      - 0.005
+      - 0.01
+      - 0.02
+      - 0.03
+      - 0.05
+      - 0.075
+      - 0.1
+      - 0.15
+      - 0.2
+      - 0.3
+      - 0.5
+      - 0.75
+      - 1.0
+      - 1.5
+      - 2.0
+      - 3.0
+      - 5.0
+    notes: "Usar HistogramDataPoint com temporality cumulativa."
+  - name: hook_executions_total
+    type: counter
+    unit: count
+    description: "Número de execuções de hooks por id e status."
+    labels:
+      required:
+        - hook_id
+        - status
+      optional: []
+    allowed_values:
+      status:
+        - success
+        - error
+    notes: "Sum monotônico cumulativo."
+  - name: data_freshness_seconds
+    type: gauge
+    unit: seconds
+    description: "Freshness de dados por fonte e domínio."
+    labels:
+      required:
+        - source
+        - domain
+      optional: []
+    notes: "Somente valores reais provenientes dos sistemas de ingestão."
+  - name: cdc_lag_seconds
+    type: gauge
+    unit: seconds
+    description: "Atraso de CDC por stream e partição."
+    labels:
+      required:
+        - stream
+        - partition
+      optional: []
+    notes: "Não utilizar partições dinâmicas sem agregação."
+  - name: drift_score
+    type: gauge
+    unit: ratio
+    description: "Indicador de drift de features."
+    labels:
+      required:
+        - feature
+        - domain
+      optional: []
+    notes: "Valor esperado entre 0 e 1; proíbe valores sintéticos."
+spans:
+  operations:
+    - name: amm.swap
+      op: swap
+      required_attributes:
+        amm.k_before: double
+        amm.k_after: double
+        amm.delta_k_ratio: double
+        amm.fee_ppm: integer
+        amm.input: double
+        amm.output: double
+    - name: amm.add_liquidity
+      op: add_liquidity
+      required_attributes:
+        amm.k_before: double
+        amm.k_after: double
+        amm.delta_k_ratio: double
+        amm.fee_ppm: integer
+        amm.input: double
+        amm.output: double
+    - name: amm.remove_liquidity
+      op: remove_liquidity
+      required_attributes:
+        amm.k_before: double
+        amm.k_after: double
+        amm.delta_k_ratio: double
+        amm.fee_ppm: integer
+        amm.input: double
+        amm.output: double
+    - name: pricing.quote
+      op: pricing
+      required_attributes:
+        amm.k_before: double
+        amm.k_after: double
+        amm.delta_k_ratio: double
+        amm.fee_ppm: integer
+        amm.input: double
+        amm.output: double
+    - name: cdc.consume
+      op: cdc_consume
+      required_attributes:
+        amm.k_before: double
+        amm.k_after: double
+        amm.delta_k_ratio: double
+        amm.fee_ppm: integer
+        amm.input: double
+        amm.output: double
+logs:
+  required_fields:
+    ts:
+      type: string
+      format: rfc3339_utc
+      pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+    level:
+      type: string
+      enum:
+        - trace
+        - debug
+        - info
+        - warn
+        - error
+    msg:
+      type: string
+    trace_id:
+      type: string
+      pattern: "^[0-9a-f]{32}$"
+    span_id:
+      type: string
+      pattern: "^[0-9a-f]{16}$"
+    service:
+      type: string
+      enum:
+        - ce-amm
+    env:
+      type: string
+      enum:
+        - dev
+        - stg
+        - prod
+    op:
+      type: string
+      enum:
+        - swap
+        - add_liquidity
+        - remove_liquidity
+        - pricing
+        - cdc_consume
+    version:
+      type: string
+      pattern: "^(?:\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)?|[0-9a-f]{7,40})$"
+  optional_fields:
+    hook_id:
+      type: string
+      pattern: "^[a-z0-9]+(?:[-_][a-z0-9]+)*$"
+    error.kind:
+      type: string
+    error.message:
+      type: string
+    extra:
+      type: object
+      property_name_policy: "^(?!(?:email|cpf|phone|address|name|geo|person_)).{1,64}$"
+pii_policy:
+  forbidden_fields:
+    - email
+    - cpf
+    - phone
+    - address
+    - name
+    - geo
+    - person_*
+  description: "Campos que representem PII são rejeitados no schema e na ingestão."
+resource_attributes:
+  service.name: ce-amm
+  service.version: semver_or_git_sha
+  deployment.environment:
+    - dev
+    - stg
+    - prod
+env_flags:
+  - name: OBSERVABILITY_LEVEL
+    values:
+      - off
+      - min
+      - full
+    description: "Controla volume de telemetria."
+  - name: PROM_SCRAPE
+    values:
+      - on
+      - off
+    description: "Expõe /metrics para Prometheus."
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    values:
+      - url
+    description: "Endpoint OTLP em produção."
+operations:
+  canonical:
+    - swap
+    - add_liquidity
+    - remove_liquidity
+    - pricing
+    - cdc_consume
+versioning:
+  semver:
+    major: "Quebra de compatibilidade: renomear/remover métricas ou alterar buckets/semântica obrigatória."
+    minor: "Mudanças compatíveis: adicionar spans/labels opcionais ou buckets complementares."
+    patch: "Correções textuais sem impacto estrutural."

--- a/schemas/obs1_log_record.schema.json
+++ b/schemas/obs1_log_record.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://creditengine.dev/schemas/obs1_log_record.schema.json",
+  "title": "OBS-1 Log Record",
+  "type": "object",
+  "required": [
+    "ts",
+    "level",
+    "msg",
+    "trace_id",
+    "span_id",
+    "service",
+    "env",
+    "op",
+    "version"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "description": "Timestamp RFC3339 UTC com sufixo Z."
+    },
+    "level": {
+      "type": "string",
+      "enum": ["trace", "debug", "info", "warn", "error"],
+      "description": "Nível de severidade do log."
+    },
+    "msg": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Mensagem humana curta."
+    },
+    "trace_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$",
+      "description": "Trace ID hexadecimal (16 bytes)."
+    },
+    "span_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$",
+      "description": "Span ID hexadecimal (8 bytes)."
+    },
+    "service": {
+      "type": "string",
+      "enum": ["ce-amm"],
+      "description": "Nome do serviço emissor."
+    },
+    "env": {
+      "type": "string",
+      "enum": ["dev", "stg", "prod"],
+      "description": "Ambiente de execução."
+    },
+    "op": {
+      "type": "string",
+      "pattern": "^(swap|add_liquidity|remove_liquidity|pricing|cdc_consume)$",
+      "description": "Operação correlacionada ao span."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(?:\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)?|[0-9a-f]{7,40})$",
+      "description": "Versão SemVer ou git SHA."
+    },
+    "hook_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$",
+      "description": "Identificador estável de hook."
+    },
+    "error.kind": {
+      "type": "string",
+      "description": "Tipo curto do erro."
+    },
+    "error.message": {
+      "type": "string",
+      "description": "Mensagem curta do erro."
+    },
+    "extra": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^(?!(?:email|cpf|phone|address|name|geo|person_)).{1,64}$"
+      },
+      "additionalProperties": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" },
+          { "type": "object" },
+          { "type": "array" }
+        ]
+      },
+      "description": "Objeto para campos adicionais estáveis sem PII."
+    }
+  },
+  "allOf": [
+    {
+      "not": {
+        "anyOf": [
+          { "required": ["email"] },
+          { "required": ["cpf"] },
+          { "required": ["phone"] },
+          { "required": ["address"] },
+          { "required": ["name"] },
+          { "required": ["geo"] }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/obs1_contract_check.sh
+++ b/scripts/obs1_contract_check.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+declare -a TARGETS=(
+  "docs/obs1_contract.md"
+  "schemas/obs1_log_record.schema.json"
+  "schemas/obs1_contract.yaml"
+  "src/telemetry_contract.rs"
+  "out/obs_gatecheck/docs/OBS1_CONTRACT_README.md"
+  "out/obs_gatecheck/evidence/obs1_contract_report.json"
+)
+
+if rg -n "TBD|FIXME|…|PLACEHOLDER" "${TARGETS[@]}"; then
+  echo "Forbidden token detected" >&2
+  exit 1
+fi
+
+python - <<'PY'
+import json, re
+from pathlib import Path
+
+schema = json.loads(Path('schemas/obs1_log_record.schema.json').read_text())
+required = set(schema['required'])
+properties = schema['properties']
+
+valid_example = {
+    "ts": "2025-10-03T12:34:56Z",
+    "level": "info",
+    "msg": "swap executed",
+    "trace_id": "4fd0c2a64b7f1a3e9c0b2e1d5a6c7b8f",
+    "span_id": "9a3b7c1d2e3f4a5b",
+    "service": "ce-amm",
+    "env": "dev",
+    "op": "swap",
+    "version": "1.2.3",
+    "hook_id": "risk-check",
+    "extra": {"amm": {"k_before": 1.0, "k_after": 1.05, "delta_k_ratio": 0.05, "fee_ppm": 300}}
+}
+
+invalid_example = {
+    "ts": "2025-10-03T12:34:56Z",
+    "level": "info",
+    "msg": "swap",
+    "trace_id": "4fd0c2...",
+    "span_id": "9a3b7c...",
+    "service": "ce-amm",
+    "env": "dev",
+    "op": "swap",
+    "version": "1.2.3",
+    "email": "cliente@exemplo.com"
+}
+
+pattern_cache = {}
+
+def check(instance):
+    keys = set(instance)
+    missing = required - keys
+    if missing:
+        raise SystemExit(f"missing required fields: {sorted(missing)}")
+    extra = keys - set(properties)
+    if extra:
+        raise SystemExit(f"unexpected fields: {sorted(extra)}")
+    for key, value in instance.items():
+        spec = properties[key]
+        if spec.get('type') == 'string':
+            if not isinstance(value, str):
+                raise SystemExit(f"{key} must be string")
+            pattern = spec.get('pattern')
+            if pattern:
+                compiled = pattern_cache.setdefault(pattern, re.compile(pattern))
+                if not compiled.fullmatch(value):
+                    raise SystemExit(f"{key} pattern mismatch: {value}")
+            enum = spec.get('enum')
+            if enum and value not in enum:
+                raise SystemExit(f"{key} invalid enum value: {value}")
+        elif spec.get('type') == 'object':
+            if not isinstance(value, dict):
+                raise SystemExit(f"{key} must be object")
+            name_pattern = spec.get('propertyNames', {}).get('pattern')
+            if name_pattern:
+                compiled = pattern_cache.setdefault(name_pattern, re.compile(name_pattern))
+                for child_key in value:
+                    if not compiled.fullmatch(child_key):
+                        raise SystemExit(f"{key}.{child_key} violates name policy")
+    for clause in schema.get('allOf', []):
+        neg = clause.get('not')
+        if not neg:
+            continue
+        for condition in neg.get('anyOf', []):
+            req = condition.get('required')
+            if req and all(field in instance for field in req):
+                raise SystemExit(f"PII field present: {req}")
+
+check(valid_example)
+try:
+    check(invalid_example)
+except SystemExit:
+    pass
+else:
+    raise SystemExit('invalid example should fail')
+PY
+
+echo "OBS-1 contract checks passed."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod amm; // existe
 pub mod ce_core; // expõe o namespace ce_core
 
 pub mod telemetry;
+pub mod telemetry_contract; // contrato OBS-1 (constantes canônicas)

--- a/src/telemetry_contract.rs
+++ b/src/telemetry_contract.rs
@@ -1,0 +1,145 @@
+//! OBS-1 canonical telemetry contract constants.
+
+pub const OBS1_CONTRACT_VERSION: &str = "1.0.0";
+
+// Metric names
+pub const METRIC_AMM_OP_LATENCY_SECONDS: &str = "amm_op_latency_seconds";
+pub const METRIC_HOOK_EXECUTIONS_TOTAL: &str = "hook_executions_total";
+pub const METRIC_DATA_FRESHNESS_SECONDS: &str = "data_freshness_seconds";
+pub const METRIC_CDC_LAG_SECONDS: &str = "cdc_lag_seconds";
+pub const METRIC_DRIFT_SCORE: &str = "drift_score";
+
+// Histogram buckets (seconds)
+pub const AMM_OP_LATENCY_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.02, 0.03, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0,
+];
+
+// Allowed label keys
+pub const LABELS_PERMITIDOS: &[&str] = &[
+    "op",
+    "service",
+    "env",
+    "version",
+    "hook_id",
+    "status",
+    "source",
+    "domain",
+    "stream",
+    "partition",
+    "feature",
+];
+
+// Forbidden label keys
+pub const LABELS_PROIBIDOS: &[&str] = &[
+    "user_id",
+    "account_id",
+    "request_id",
+    "session_id",
+    "*_uuid",
+    "*_hash",
+];
+
+// Counter label values
+pub const HOOK_EXECUTION_STATUS_VALUES: &[&str] = &["success", "error"];
+
+// Span names
+pub const SPAN_AMM_SWAP: &str = "amm.swap";
+pub const SPAN_AMM_ADD_LIQUIDITY: &str = "amm.add_liquidity";
+pub const SPAN_AMM_REMOVE_LIQUIDITY: &str = "amm.remove_liquidity";
+pub const SPAN_PRICING_QUOTE: &str = "pricing.quote";
+pub const SPAN_CDC_CONSUME: &str = "cdc.consume";
+
+pub const SPAN_NAMES: &[&str] = &[
+    SPAN_AMM_SWAP,
+    SPAN_AMM_ADD_LIQUIDITY,
+    SPAN_AMM_REMOVE_LIQUIDITY,
+    SPAN_PRICING_QUOTE,
+    SPAN_CDC_CONSUME,
+];
+
+// Span attributes
+pub const SPAN_ATTR_AMM_K_BEFORE: &str = "amm.k_before";
+pub const SPAN_ATTR_AMM_K_AFTER: &str = "amm.k_after";
+pub const SPAN_ATTR_AMM_DELTA_K_RATIO: &str = "amm.delta_k_ratio";
+pub const SPAN_ATTR_AMM_FEE_PPM: &str = "amm.fee_ppm";
+pub const SPAN_ATTR_AMM_INPUT: &str = "amm.input";
+pub const SPAN_ATTR_AMM_OUTPUT: &str = "amm.output";
+
+pub const SPAN_REQUIRED_ATTRIBUTES: &[&str] = &[
+    SPAN_ATTR_AMM_K_BEFORE,
+    SPAN_ATTR_AMM_K_AFTER,
+    SPAN_ATTR_AMM_DELTA_K_RATIO,
+    SPAN_ATTR_AMM_FEE_PPM,
+    SPAN_ATTR_AMM_INPUT,
+    SPAN_ATTR_AMM_OUTPUT,
+];
+
+// Operation mapping shared by spans, metrics and logs
+pub const OPERATION_VALUES: &[&str] = &[
+    "swap",
+    "add_liquidity",
+    "remove_liquidity",
+    "pricing",
+    "cdc_consume",
+];
+
+pub const OPERATION_REGEX: &str = "^(swap|add_liquidity|remove_liquidity|pricing|cdc_consume)$";
+pub const LABEL_REGEX: &str = "^[a-z0-9_]{1,32}$";
+
+// Log field names
+pub const LOG_FIELD_TIMESTAMP: &str = "ts";
+pub const LOG_FIELD_LEVEL: &str = "level";
+pub const LOG_FIELD_MESSAGE: &str = "msg";
+pub const LOG_FIELD_TRACE_ID: &str = "trace_id";
+pub const LOG_FIELD_SPAN_ID: &str = "span_id";
+pub const LOG_FIELD_SERVICE: &str = "service";
+pub const LOG_FIELD_ENV: &str = "env";
+pub const LOG_FIELD_OPERATION: &str = "op";
+pub const LOG_FIELD_VERSION: &str = "version";
+pub const LOG_FIELD_HOOK_ID: &str = "hook_id";
+pub const LOG_FIELD_ERROR_KIND: &str = "error.kind";
+pub const LOG_FIELD_ERROR_MESSAGE: &str = "error.message";
+pub const LOG_FIELD_EXTRA: &str = "extra";
+
+pub const LOG_LEVEL_VALUES: &[&str] = &["trace", "debug", "info", "warn", "error"];
+pub const LOG_TIMESTAMP_PATTERN_UTC: &str = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$";
+pub const LOG_TRACE_ID_PATTERN: &str = "^[0-9a-f]{32}$";
+pub const LOG_SPAN_ID_PATTERN: &str = "^[0-9a-f]{16}$";
+pub const LOG_VERSION_PATTERN: &str = "^(?:\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)?|[0-9a-f]{7,40})$";
+pub const LOG_HOOK_ID_PATTERN: &str = "^[a-z0-9]+(?:[-_][a-z0-9]+)*$";
+
+// Resource attributes
+pub const RESOURCE_SERVICE_NAME: &str = "service.name";
+pub const RESOURCE_SERVICE_VERSION: &str = "service.version";
+pub const RESOURCE_DEPLOYMENT_ENVIRONMENT: &str = "deployment.environment";
+
+pub const RESOURCE_SERVICE_NAME_VALUE: &str = "ce-amm";
+pub const RESOURCE_ENV_VALUES: &[&str] = &["dev", "stg", "prod"];
+
+// Flags and environment variables
+pub const ENV_OBSERVABILITY_LEVEL: &str = "OBSERVABILITY_LEVEL";
+pub const ENV_PROM_SCRAPE: &str = "PROM_SCRAPE";
+pub const ENV_OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+pub const OBSERVABILITY_LEVEL_VALUES: &[&str] = &["off", "min", "full"];
+pub const PROM_SCRAPE_VALUES: &[&str] = &["on", "off"];
+
+// PII forbidden keys
+pub const PII_FORBIDDEN_FIELDS: &[&str] = &[
+    "email",
+    "cpf",
+    "phone",
+    "address",
+    "name",
+    "geo",
+];
+
+// File manifest for evidence reports
+pub const CONTRACT_FILES: &[&str] = &[
+    "docs/obs1_contract.md",
+    "src/telemetry_contract.rs",
+    "schemas/obs1_log_record.schema.json",
+    "schemas/obs1_contract.yaml",
+    "out/obs_gatecheck/docs/OBS1_CONTRACT_README.md",
+    "out/obs_gatecheck/evidence/obs1_contract_report.json",
+];


### PR DESCRIPTION
## Summary
- Documented the OBS-1 telemetry contract with canonical metrics, spans, logs, resource attributes and usage guidance.
- Added the `telemetry_contract` Rust module plus JSON/YAML schemas that encode the normative contract.
- Published consumption README, evidence manifest with SHA256 fingerprints, and a helper script to enforce static checks.

## Testing
- `cargo check --lib`
- `scripts/obs1_contract_check.sh`

## Checklist (OBS-1 Thread 1)
- [x] Criar branch `docs/obs1-contract`
- [x] Redigir `docs/obs1_contract.md`
- [x] Implementar `src/telemetry_contract.rs`
- [x] Criar `schemas/obs1_log_record.schema.json`
- [x] Criar `schemas/obs1_contract.yaml`
- [x] Escrever `out/obs_gatecheck/docs/OBS1_CONTRACT_README.md`
- [x] Gerar `out/obs_gatecheck/evidence/obs1_contract_report.json`
- [x] (Opcional) Publicar `scripts/obs1_contract_check.sh`
- [x] Abrir PR e solicitar review


------
https://chatgpt.com/codex/tasks/task_e_68df4bdf7834833088cba9713a58a50f