### PR TITLE
OBS1: add span helpers for AMM and pricing telemetry

### DIFF
--- a/docs/obs1_spans_amm_contract.md
+++ b/docs/obs1_spans_amm_contract.md
@@ -1,0 +1,160 @@
+# OBS-1 • Contrato de spans para AMM & Pricing (`telemetry_spans_amm`)
+
+Este documento normativo define o contrato canônico dos spans do AMM e de precificação no escopo **OBS-1 / Thread 10**. Ele serve
+como referência única para squads de produto, engenharia e SRE manterem telemetria consistente, auditável e alinhada aos packs de
+observabilidade (T4/T7/T8/T9).
+
+## 1. Objetivo e abrangência
+
+- Padronizar os nomes de spans e seus atributos obrigatórios para operações de AMM (`swap`, `add_liquidity`, `remove_liquidity`) e
+  precificação (`pricing.quote`).
+- Fornecer helpers (`span_*` e `in_*`) que encapsulam criação, validação e atribuição dos atributos de telemetria sem acoplar a um
+  provider específico (integração com T4 fica a cargo do chamador).
+- Validar valores numéricos, evitando NaN/Inf e limites inválidos que possam quebrar dashboards, traces ou gatilhos A110.
+
+## 2. APIs expostas
+
+Todas as APIs residem no módulo `credit_engine_core::telemetry_spans_amm`.
+
+### 2.1 RAII (`span_*`)
+
+| Função | Span | `op` | Struct de entrada |
+| --- | --- | --- | --- |
+| `span_amm_swap(&SwapAttrs)` | `amm.swap` | `swap` | `SwapAttrs` |
+| `span_amm_add_liquidity(&AddLiquidityAttrs)` | `amm.add_liquidity` | `add_liquidity` | `AddLiquidityAttrs` |
+| `span_amm_remove_liquidity(&RemoveLiquidityAttrs)` | `amm.remove_liquidity` | `remove_liquidity` | `RemoveLiquidityAttrs` |
+| `span_pricing_quote(&PricingQuoteAttrs)` | `pricing.quote` | `pricing` | `PricingQuoteAttrs` |
+
+Cada helper retorna um `tracing::Span` já populado com os atributos obrigatórios. O chamador é responsável por entrar e sair do span
+(`let _guard = span.enter();`).
+
+### 2.2 Wrapper (`in_*`)
+
+| Função | Span | Uso |
+| --- | --- | --- |
+| `in_amm_swap(&SwapAttrs, F)` | `amm.swap` | Executa `F` dentro do span e retorna o resultado |
+| `in_amm_add_liquidity(&AddLiquidityAttrs, F)` | `amm.add_liquidity` | Idem |
+| `in_amm_remove_liquidity(&RemoveLiquidityAttrs, F)` | `amm.remove_liquidity` | Idem |
+| `in_pricing_quote(&PricingQuoteAttrs, F)` | `pricing.quote` | Idem |
+
+As funções wrapper garantem abertura, entrada e fechamento do span automaticamente, mantendo o código de negócio enxuto e
+telemetria confiável.
+
+## 3. Estruturas de atributos
+
+Todos os helpers utilizam o mesmo conjunto de campos numéricos para homogeneidade de telemetria.
+
+```rust
+pub struct SwapAttrs {
+    pub k_before: f64,
+    pub k_after: f64,
+    pub delta_k_ratio: f64,
+    pub fee_ppm: i64,
+    pub input: f64,
+    pub output: f64,
+}
+// ... AddLiquidityAttrs, RemoveLiquidityAttrs e PricingQuoteAttrs seguem exatamente a mesma assinatura.
+```
+
+## 4. Regras do contrato
+
+### 4.1 Nomes de spans
+
+- `amm.swap`
+- `amm.add_liquidity`
+- `amm.remove_liquidity`
+- `pricing.quote`
+
+### 4.2 Atributos obrigatórios
+
+| Chave | Tipo | Observação |
+| --- | --- | --- |
+| `amm.k_before` | `f64` | Invariante antes da operação (deve ser > 0) |
+| `amm.k_after` | `f64` | Invariante após a operação (deve ser > 0) |
+| `amm.delta_k_ratio` | `f64` | Variação relativa (`|valor| ≤ 1e6`) |
+| `amm.fee_ppm` | `i64` | Fee em ppm (≥ 0) |
+| `amm.input` | `f64` | Quantidade recebida pelo AMM (≥ 0) |
+| `amm.output` | `f64` | Quantidade entregue pelo AMM (≥ 0) |
+| `op` | `&'static str` | `swap`, `add_liquidity`, `remove_liquidity` ou `pricing` |
+
+### 4.3 Validações
+
+- Nenhum valor pode ser `NaN`, `+∞` ou `-∞`.
+- `k_before > 0` e `k_after > 0`.
+- `amm.delta_k_ratio.is_finite()` e `|amm.delta_k_ratio| ≤ 1e6`.
+- `amm.fee_ppm ≥ 0`.
+- `amm.input ≥ 0` e `amm.output ≥ 0`.
+- Helpers **panicam** com mensagem clara caso alguma regra seja violada (`invalid telemetry attributes for ...`).
+
+## 5. Exemplos normativos
+
+### 5.1 Span RAII (`amm.swap`)
+
+```rust
+use credit_engine_core::telemetry_spans_amm::{span_amm_swap, SwapAttrs};
+
+let attrs = SwapAttrs {
+    k_before: 1.0,
+    k_after: 1.05,
+    delta_k_ratio: 0.05,
+    fee_ppm: 300,
+    input: 100.0,
+    output: 99.7,
+};
+let span = span_amm_swap(&attrs);
+let _enter = span.enter();
+// ... código de swap ...
+```
+
+### 5.2 Wrapper (`amm.swap`)
+
+```rust
+use credit_engine_core::telemetry_spans_amm::{in_amm_swap, SwapAttrs};
+
+let attrs = SwapAttrs {
+    k_before: 1.0,
+    k_after: 1.05,
+    delta_k_ratio: 0.05,
+    fee_ppm: 300,
+    input: 100.0,
+    output: 99.7,
+};
+let result = in_amm_swap(&attrs, || do_swap());
+```
+
+### 5.3 Pricing quote
+
+```rust
+use credit_engine_core::telemetry_spans_amm::{in_pricing_quote, PricingQuoteAttrs};
+
+let attrs = PricingQuoteAttrs {
+    k_before: 1.0,
+    k_after: 1.0,
+    delta_k_ratio: 0.0,
+    fee_ppm: 120,
+    input: 150.0,
+    output: 149.94,
+};
+let price = in_pricing_quote(&attrs, || quote_price(request));
+```
+
+## 6. Erros comuns & troubleshooting
+
+| Sintoma | Causa provável | Mitigação |
+| --- | --- | --- |
+| Panic `invalid telemetry attributes for amm.swap: amm.k_before must be > 0` | Valor de `k_before` ≤ 0 | Corrigir upstream (ex.: snapshot inconsistente do pool) |
+| Panic `... must be finite` | Valor `NaN`/`±inf` propagado de cálculo anterior | Normalizar entradas antes de chamar helper |
+| Span sem atributo `op` | Span criado manualmente sem usar helpers | Migrar para `telemetry_spans_amm` para cumprir contrato |
+| Dashboards vazios | Atributos faltantes rompem filtros | Verificar validações e os testes de contrato (`cargo test --features obs --test telemetry_spans_amm_tests`) |
+
+## 7. Próximos passos (fora do escopo desta thread)
+
+- Integração com providers OTLP/Jaeger (Thread 4).
+- Métricas derivadas e watchers automáticos (Threads 8/9).
+- Automatizar geração de evidências em pipeline A110.
+
+---
+
+**Owner:** OBS-1 / Produto & Telemetria.
+
+**Última atualização:** (manter alinhado com o hash em `out/obs_gatecheck/evidence/obs1_spans_amm_report.json`).

--- a/out/obs_gatecheck/docs/OBS1_SPANS_AMM_README.md
+++ b/out/obs_gatecheck/docs/OBS1_SPANS_AMM_README.md
@@ -1,0 +1,69 @@
+# OBS-1 Gatecheck • Helpers de spans AMM & Pricing
+
+Este README orienta squads sobre como usar o módulo `telemetry_spans_amm` no Credit Engine Core, como conectá-lo a um provider de
+traces (Thread 4) e como depurar atributos ausentes durante validações de gate OBS-1.
+
+## 1. Uso rápido
+
+```rust
+use credit_engine_core::telemetry_spans_amm::{in_amm_swap, SwapAttrs};
+
+let attrs = SwapAttrs {
+    k_before: 1.0,
+    k_after: 1.05,
+    delta_k_ratio: 0.05,
+    fee_ppm: 300,
+    input: 100.0,
+    output: 99.7,
+};
+let quote = in_amm_swap(&attrs, || execute_swap(request));
+```
+
+Helpers disponíveis:
+
+- `span_amm_swap` / `in_amm_swap`
+- `span_amm_add_liquidity` / `in_amm_add_liquidity`
+- `span_amm_remove_liquidity` / `in_amm_remove_liquidity`
+- `span_pricing_quote` / `in_pricing_quote`
+
+Todos validam atributos (NaN/Inf, limites mínimos e máximos) e populam os campos obrigatórios:
+`amm.k_before`, `amm.k_after`, `amm.delta_k_ratio`, `amm.fee_ppm`, `amm.input`, `amm.output`, `op`.
+
+## 2. Conectando a um tracer provider (Thread 4)
+
+1. Inicialize o provider desejado (ex.: OTLP → collector) em sua aplicação, usando `tracing_subscriber` ou equivalente.
+2. Registre o layer/opentelemetry antes de chamar qualquer helper.
+   ```rust
+   use opentelemetry::sdk::trace as sdktrace;
+   use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+   let tracer = opentelemetry_otlp::new_pipeline().tracing().install_simple()?;
+   let otel = tracing_opentelemetry::layer().with_tracer(tracer);
+   let subscriber = Registry::default().with(otel);
+   tracing::subscriber::set_global_default(subscriber)?;
+   ```
+3. Use os helpers normalmente. Eles **não** instalam subscriber global, garantindo compatibilidade com o bootstrap da Thread 4.
+
+## 3. Troubleshooting
+
+| Sintoma | Checagem | Ação |
+| --- | --- | --- |
+| Panic `invalid telemetry attributes ...` | Validadores detectaram valor inválido | Corrigir upstream; revisitar cálculos/normalizações |
+| Span exportado sem `op` | Span criado manualmente | Migrar para os helpers; teste com `cargo test --features obs --test telemetry_spans_amm_tests` |
+| Dashboards/alertas vazios | Filtro depende de `amm.*` | Validar se atributos foram preenchidos; checar `obs1_spans_amm_report.json` |
+| Collector sem spans | Subscriber não inicializado | Revise inicialização do provider (Thread 4) e filtros de sampling |
+
+## 4. Validação local
+
+- `cargo test --features obs --test telemetry_spans_amm_tests`
+- `rg 'TBD|FIXME|…' -n` (deve retornar vazio)
+- Conferir `out/obs_gatecheck/evidence/obs1_spans_amm_report.json`
+
+## 5. Evidências / Gate OBS-1
+
+- `out/obs_gatecheck/evidence/obs1_spans_amm_report.json` contém timestamp, hash SHA256 do módulo e amostra de span exportado.
+- Manter README, contrato (`docs/obs1_spans_amm_contract.md`) e evidências sincronizados antes do merge.
+
+---
+
+**Owner:** OBS-1 Telemetria.

--- a/out/obs_gatecheck/evidence/obs1_spans_amm_report.json
+++ b/out/obs_gatecheck/evidence/obs1_spans_amm_report.json
@@ -1,0 +1,23 @@
+{
+  "timestamp_utc": "2025-10-03T04:49:54Z",
+  "module_sha256": "2439f3e9fdd81c62d14fe5db91c4fef725156e29ebd97a04bb46d855118705ae",
+  "tests": [
+    {
+      "command": "cargo test --features obs --test telemetry_spans_amm_tests",
+      "status": "passed",
+      "output_reference": "458187"
+    }
+  ],
+  "sample_span": {
+    "name": "amm.swap",
+    "attributes": {
+      "op": "swap",
+      "amm.k_before": 1.0,
+      "amm.k_after": 1.05,
+      "amm.delta_k_ratio": 0.05,
+      "amm.fee_ppm": 300,
+      "amm.input": 100.0,
+      "amm.output": 99.7
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod ce_core; // expõe o namespace ce_core
 
 pub mod telemetry;
 pub mod telemetry_contract; // contrato OBS-1 (constantes canônicas)
+pub mod telemetry_spans_amm; // spans canônicos para AMM e pricing (OBS-1/T10)

--- a/src/telemetry_spans_amm.rs
+++ b/src/telemetry_spans_amm.rs
@@ -1,0 +1,370 @@
+use std::fmt;
+
+use tracing::{span, Level, Span};
+
+/// Attributes for canonical `amm.swap` spans.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SwapAttrs {
+    pub k_before: f64,
+    pub k_after: f64,
+    pub delta_k_ratio: f64,
+    pub fee_ppm: i64,
+    pub input: f64,
+    pub output: f64,
+}
+
+/// Attributes for canonical `amm.add_liquidity` spans.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AddLiquidityAttrs {
+    pub k_before: f64,
+    pub k_after: f64,
+    pub delta_k_ratio: f64,
+    pub fee_ppm: i64,
+    pub input: f64,
+    pub output: f64,
+}
+
+/// Attributes for canonical `amm.remove_liquidity` spans.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoveLiquidityAttrs {
+    pub k_before: f64,
+    pub k_after: f64,
+    pub delta_k_ratio: f64,
+    pub fee_ppm: i64,
+    pub input: f64,
+    pub output: f64,
+}
+
+/// Attributes for canonical `pricing.quote` spans.
+///
+/// Although pricing operations may not mutate the invariant `k`,
+/// this helper keeps the same attribute set for uniformity across
+/// telemetry data, following the OBS-1 contract.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PricingQuoteAttrs {
+    pub k_before: f64,
+    pub k_after: f64,
+    pub delta_k_ratio: f64,
+    pub fee_ppm: i64,
+    pub input: f64,
+    pub output: f64,
+}
+
+#[derive(Debug)]
+struct ValidationError {
+    op: &'static str,
+    field: &'static str,
+    message: &'static str,
+}
+
+impl ValidationError {
+    fn new(op: &'static str, field: &'static str, message: &'static str) -> Self {
+        Self { op, field, message }
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid telemetry attributes for {}: {} {}",
+            self.op, self.field, self.message
+        )
+    }
+}
+
+fn panic_on_invalid(result: Result<(), ValidationError>) {
+    if let Err(err) = result {
+        panic!("{}", err);
+    }
+}
+
+fn validate_common(
+    op: &'static str,
+    k_before: f64,
+    k_after: f64,
+    delta_k_ratio: f64,
+    fee_ppm: i64,
+    input: f64,
+    output: f64,
+) -> Result<(), ValidationError> {
+    ensure_finite_positive(op, "amm.k_before", k_before)?;
+    ensure_finite_positive(op, "amm.k_after", k_after)?;
+    ensure_finite(op, "amm.delta_k_ratio", delta_k_ratio)?;
+    if delta_k_ratio.abs() > 1_000_000.0 {
+        return Err(ValidationError::new(
+            op,
+            "amm.delta_k_ratio",
+            "absolute value must be ≤ 1e6",
+        ));
+    }
+    ensure_fee(op, fee_ppm)?;
+    ensure_non_negative(op, "amm.input", input)?;
+    ensure_non_negative(op, "amm.output", output)?;
+    Ok(())
+}
+
+fn ensure_finite_positive(
+    op: &'static str,
+    field: &'static str,
+    value: f64,
+) -> Result<(), ValidationError> {
+    ensure_finite(op, field, value)?;
+    if value <= 0.0 {
+        return Err(ValidationError::new(op, field, "must be > 0"));
+    }
+    Ok(())
+}
+
+fn ensure_non_negative(
+    op: &'static str,
+    field: &'static str,
+    value: f64,
+) -> Result<(), ValidationError> {
+    ensure_finite(op, field, value)?;
+    if value < 0.0 {
+        return Err(ValidationError::new(op, field, "must be ≥ 0"));
+    }
+    Ok(())
+}
+
+fn ensure_finite(op: &'static str, field: &'static str, value: f64) -> Result<(), ValidationError> {
+    if !value.is_finite() {
+        return Err(ValidationError::new(op, field, "must be finite"));
+    }
+    Ok(())
+}
+
+fn ensure_fee(op: &'static str, fee_ppm: i64) -> Result<(), ValidationError> {
+    if fee_ppm < 0 {
+        return Err(ValidationError::new(op, "amm.fee_ppm", "must be ≥ 0"));
+    }
+    Ok(())
+}
+
+fn build_span(
+    name: &'static str,
+    op: &'static str,
+    k_before: f64,
+    k_after: f64,
+    delta_k_ratio: f64,
+    fee_ppm: i64,
+    input: f64,
+    output: f64,
+) -> Span {
+    let span = match name {
+        "amm.swap" => span!(
+            Level::INFO,
+            "amm.swap",
+            op = tracing::field::Empty,
+            "amm.k_before" = tracing::field::Empty,
+            "amm.k_after" = tracing::field::Empty,
+            "amm.delta_k_ratio" = tracing::field::Empty,
+            "amm.fee_ppm" = tracing::field::Empty,
+            "amm.input" = tracing::field::Empty,
+            "amm.output" = tracing::field::Empty,
+        ),
+        "amm.add_liquidity" => span!(
+            Level::INFO,
+            "amm.add_liquidity",
+            op = tracing::field::Empty,
+            "amm.k_before" = tracing::field::Empty,
+            "amm.k_after" = tracing::field::Empty,
+            "amm.delta_k_ratio" = tracing::field::Empty,
+            "amm.fee_ppm" = tracing::field::Empty,
+            "amm.input" = tracing::field::Empty,
+            "amm.output" = tracing::field::Empty,
+        ),
+        "amm.remove_liquidity" => span!(
+            Level::INFO,
+            "amm.remove_liquidity",
+            op = tracing::field::Empty,
+            "amm.k_before" = tracing::field::Empty,
+            "amm.k_after" = tracing::field::Empty,
+            "amm.delta_k_ratio" = tracing::field::Empty,
+            "amm.fee_ppm" = tracing::field::Empty,
+            "amm.input" = tracing::field::Empty,
+            "amm.output" = tracing::field::Empty,
+        ),
+        "pricing.quote" => span!(
+            Level::INFO,
+            "pricing.quote",
+            op = tracing::field::Empty,
+            "amm.k_before" = tracing::field::Empty,
+            "amm.k_after" = tracing::field::Empty,
+            "amm.delta_k_ratio" = tracing::field::Empty,
+            "amm.fee_ppm" = tracing::field::Empty,
+            "amm.input" = tracing::field::Empty,
+            "amm.output" = tracing::field::Empty,
+        ),
+        _ => unreachable!("unexpected span name: {}", name),
+    };
+    span.record("op", &op);
+    span.record("amm.k_before", &k_before);
+    span.record("amm.k_after", &k_after);
+    span.record("amm.delta_k_ratio", &delta_k_ratio);
+    span.record("amm.fee_ppm", &fee_ppm);
+    span.record("amm.input", &input);
+    span.record("amm.output", &output);
+    span
+}
+
+/// Creates a canonical span for `amm.swap` with validated attributes.
+pub fn span_amm_swap(attrs: &SwapAttrs) -> Span {
+    panic_on_invalid(validate_common(
+        "amm.swap",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    ));
+    build_span(
+        "amm.swap",
+        "swap",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    )
+}
+
+/// Executes `f` within an `amm.swap` span, returning `f`'s output.
+pub fn in_amm_swap<F, T>(attrs: &SwapAttrs, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let span = span_amm_swap(attrs);
+    let _guard = span.enter();
+    let result = f();
+    drop(_guard);
+    result
+}
+
+/// Creates a canonical span for `amm.add_liquidity` with validated attributes.
+pub fn span_amm_add_liquidity(attrs: &AddLiquidityAttrs) -> Span {
+    panic_on_invalid(validate_common(
+        "amm.add_liquidity",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    ));
+    build_span(
+        "amm.add_liquidity",
+        "add_liquidity",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    )
+}
+
+/// Executes `f` within an `amm.add_liquidity` span, returning `f`'s output.
+pub fn in_amm_add_liquidity<F, T>(attrs: &AddLiquidityAttrs, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let span = span_amm_add_liquidity(attrs);
+    let _guard = span.enter();
+    let result = f();
+    drop(_guard);
+    result
+}
+
+/// Creates a canonical span for `amm.remove_liquidity` with validated attributes.
+pub fn span_amm_remove_liquidity(attrs: &RemoveLiquidityAttrs) -> Span {
+    panic_on_invalid(validate_common(
+        "amm.remove_liquidity",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    ));
+    build_span(
+        "amm.remove_liquidity",
+        "remove_liquidity",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    )
+}
+
+/// Executes `f` within an `amm.remove_liquidity` span, returning `f`'s output.
+pub fn in_amm_remove_liquidity<F, T>(attrs: &RemoveLiquidityAttrs, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let span = span_amm_remove_liquidity(attrs);
+    let _guard = span.enter();
+    let result = f();
+    drop(_guard);
+    result
+}
+
+/// Creates a canonical span for `pricing.quote` with validated attributes.
+pub fn span_pricing_quote(attrs: &PricingQuoteAttrs) -> Span {
+    panic_on_invalid(validate_common(
+        "pricing.quote",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    ));
+    build_span(
+        "pricing.quote",
+        "pricing",
+        attrs.k_before,
+        attrs.k_after,
+        attrs.delta_k_ratio,
+        attrs.fee_ppm,
+        attrs.input,
+        attrs.output,
+    )
+}
+
+/// Executes `f` within a `pricing.quote` span, returning `f`'s output.
+pub fn in_pricing_quote<F, T>(attrs: &PricingQuoteAttrs, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let span = span_pricing_quote(attrs);
+    let _guard = span.enter();
+    let result = f();
+    drop(_guard);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_positive_k() {
+        let attrs = SwapAttrs {
+            k_before: -1.0,
+            k_after: 1.0,
+            delta_k_ratio: 0.0,
+            fee_ppm: 0,
+            input: 0.0,
+            output: 0.0,
+        };
+
+        let err = std::panic::catch_unwind(|| span_amm_swap(&attrs));
+        assert!(err.is_err());
+    }
+}

--- a/tests/telemetry_spans_amm_tests.rs
+++ b/tests/telemetry_spans_amm_tests.rs
@@ -1,0 +1,505 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use credit_engine_core::telemetry_spans_amm::{
+    in_amm_add_liquidity, in_amm_remove_liquidity, in_amm_swap, in_pricing_quote,
+    span_amm_add_liquidity, span_amm_remove_liquidity, span_amm_swap, span_pricing_quote,
+    AddLiquidityAttrs, PricingQuoteAttrs, RemoveLiquidityAttrs, SwapAttrs,
+};
+use tracing::{span::Id, subscriber::with_default};
+use tracing_subscriber::{layer::Context, layer::SubscriberExt, registry::Registry, Layer};
+
+#[derive(Debug, Clone, PartialEq)]
+struct CapturedSpan {
+    name: String,
+    fields: BTreeMap<String, CapturedValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum CapturedValue {
+    F64(f64),
+    I64(i64),
+    Str(String),
+    Bool(bool),
+}
+
+#[derive(Clone, Default)]
+struct CapturingLayer {
+    inner: Arc<CapturingInner>,
+}
+
+#[derive(Default)]
+struct CapturingInner {
+    open: Mutex<HashMap<Id, CapturedSpan>>,
+    completed: Mutex<Vec<CapturedSpan>>,
+}
+
+impl CapturingLayer {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(CapturingInner::default()),
+        }
+    }
+
+    fn finished_spans(&self) -> Vec<CapturedSpan> {
+        self.inner
+            .completed
+            .lock()
+            .expect("lock completed spans")
+            .clone()
+    }
+}
+
+struct FieldRecorder<'a> {
+    fields: &'a mut BTreeMap<String, CapturedValue>,
+}
+
+impl<'a> tracing::field::Visit for FieldRecorder<'a> {
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.fields
+            .insert(field.name().to_string(), CapturedValue::F64(value));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), CapturedValue::I64(value));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields.insert(
+            field.name().to_string(),
+            CapturedValue::Str(value.to_string()),
+        );
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), CapturedValue::Bool(value));
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+        self.fields.insert(
+            field.name().to_string(),
+            CapturedValue::Str(format!("{:?}", value)),
+        );
+    }
+}
+
+impl<S> Layer<S> for CapturingLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_new_span(&self, attrs: &tracing::span::Attributes<'_>, id: &Id, _: Context<'_, S>) {
+        let mut fields = BTreeMap::new();
+        attrs.record(&mut FieldRecorder {
+            fields: &mut fields,
+        });
+        let span = CapturedSpan {
+            name: attrs.metadata().name().to_string(),
+            fields,
+        };
+        self.inner
+            .open
+            .lock()
+            .expect("lock open spans")
+            .insert(id.clone(), span);
+    }
+
+    fn on_record(&self, id: &Id, values: &tracing::span::Record<'_>, _: Context<'_, S>) {
+        if let Some(span) = self.inner.open.lock().expect("lock open spans").get_mut(id) {
+            values.record(&mut FieldRecorder {
+                fields: &mut span.fields,
+            });
+        }
+    }
+
+    fn on_close(&self, id: Id, _: Context<'_, S>) {
+        if let Some(span) = self.inner.open.lock().expect("lock open spans").remove(&id) {
+            self.inner
+                .completed
+                .lock()
+                .expect("lock completed spans")
+                .push(span);
+        }
+    }
+}
+
+fn with_capturing_layer<F>(f: F) -> Vec<CapturedSpan>
+where
+    F: FnOnce(),
+{
+    let layer = CapturingLayer::new();
+    let subscriber = Registry::default().with(layer.clone());
+    with_default(subscriber, || {
+        f();
+    });
+    layer.finished_spans()
+}
+
+fn expect_common_fields(span: &CapturedSpan, op: &str, attrs: &SwapAttrs) {
+    assert_eq!(
+        span.fields.get("op"),
+        Some(&CapturedValue::Str(op.to_string()))
+    );
+    assert_eq!(
+        span.fields.get("amm.k_before"),
+        Some(&CapturedValue::F64(attrs.k_before))
+    );
+    assert_eq!(
+        span.fields.get("amm.k_after"),
+        Some(&CapturedValue::F64(attrs.k_after))
+    );
+    assert_eq!(
+        span.fields.get("amm.delta_k_ratio"),
+        Some(&CapturedValue::F64(attrs.delta_k_ratio))
+    );
+    assert_eq!(
+        span.fields.get("amm.fee_ppm"),
+        Some(&CapturedValue::I64(attrs.fee_ppm))
+    );
+    assert_eq!(
+        span.fields.get("amm.input"),
+        Some(&CapturedValue::F64(attrs.input))
+    );
+    assert_eq!(
+        span.fields.get("amm.output"),
+        Some(&CapturedValue::F64(attrs.output))
+    );
+}
+
+#[test]
+fn swap_span_exports_expected_attributes() {
+    let attrs = SwapAttrs {
+        k_before: 1.0,
+        k_after: 1.05,
+        delta_k_ratio: 0.05,
+        fee_ppm: 300,
+        input: 100.0,
+        output: 99.7,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let span = span_amm_swap(&attrs);
+        let _guard = span.enter();
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "amm.swap");
+    expect_common_fields(span, "swap", &attrs);
+}
+
+#[test]
+fn swap_wrapper_runs_inside_span() {
+    let attrs = SwapAttrs {
+        k_before: 2.0,
+        k_after: 2.1,
+        delta_k_ratio: 0.05,
+        fee_ppm: 120,
+        input: 50.0,
+        output: 49.94,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let value = in_amm_swap(&attrs, || 42);
+        assert_eq!(value, 42);
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "amm.swap");
+    expect_common_fields(span, "swap", &attrs);
+}
+
+#[test]
+fn add_liquidity_span_exports_expected_attributes() {
+    let attrs = AddLiquidityAttrs {
+        k_before: 5.0,
+        k_after: 5.5,
+        delta_k_ratio: 0.1,
+        fee_ppm: 45,
+        input: 1000.0,
+        output: 1000.0,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let span = span_amm_add_liquidity(&attrs);
+        let _guard = span.enter();
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "amm.add_liquidity");
+    expect_common_fields(
+        span,
+        "add_liquidity",
+        &SwapAttrs {
+            k_before: attrs.k_before,
+            k_after: attrs.k_after,
+            delta_k_ratio: attrs.delta_k_ratio,
+            fee_ppm: attrs.fee_ppm,
+            input: attrs.input,
+            output: attrs.output,
+        },
+    );
+}
+
+#[test]
+fn add_liquidity_wrapper_exports_expected_attributes() {
+    let attrs = AddLiquidityAttrs {
+        k_before: 3.0,
+        k_after: 3.3,
+        delta_k_ratio: 0.1,
+        fee_ppm: 60,
+        input: 500.0,
+        output: 499.5,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let result = in_amm_add_liquidity(&attrs, || "ok");
+        assert_eq!(result, "ok");
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "amm.add_liquidity");
+    expect_common_fields(
+        span,
+        "add_liquidity",
+        &SwapAttrs {
+            k_before: attrs.k_before,
+            k_after: attrs.k_after,
+            delta_k_ratio: attrs.delta_k_ratio,
+            fee_ppm: attrs.fee_ppm,
+            input: attrs.input,
+            output: attrs.output,
+        },
+    );
+}
+
+#[test]
+fn remove_liquidity_span_exports_expected_attributes() {
+    let attrs = RemoveLiquidityAttrs {
+        k_before: 4.0,
+        k_after: 3.8,
+        delta_k_ratio: -0.05,
+        fee_ppm: 80,
+        input: 10.0,
+        output: 9.5,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let span = span_amm_remove_liquidity(&attrs);
+        let _guard = span.enter();
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "amm.remove_liquidity");
+    expect_common_fields(
+        span,
+        "remove_liquidity",
+        &SwapAttrs {
+            k_before: attrs.k_before,
+            k_after: attrs.k_after,
+            delta_k_ratio: attrs.delta_k_ratio,
+            fee_ppm: attrs.fee_ppm,
+            input: attrs.input,
+            output: attrs.output,
+        },
+    );
+}
+
+#[test]
+fn remove_liquidity_wrapper_exports_expected_attributes() {
+    let attrs = RemoveLiquidityAttrs {
+        k_before: 4.5,
+        k_after: 4.2,
+        delta_k_ratio: -0.0666,
+        fee_ppm: 75,
+        input: 12.0,
+        output: 11.2,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let result = in_amm_remove_liquidity(&attrs, || 11u32);
+        assert_eq!(result, 11);
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "amm.remove_liquidity");
+    expect_common_fields(
+        span,
+        "remove_liquidity",
+        &SwapAttrs {
+            k_before: attrs.k_before,
+            k_after: attrs.k_after,
+            delta_k_ratio: attrs.delta_k_ratio,
+            fee_ppm: attrs.fee_ppm,
+            input: attrs.input,
+            output: attrs.output,
+        },
+    );
+}
+
+#[test]
+fn pricing_quote_span_exports_expected_attributes() {
+    let attrs = PricingQuoteAttrs {
+        k_before: 7.0,
+        k_after: 7.0,
+        delta_k_ratio: 0.0,
+        fee_ppm: 30,
+        input: 200.0,
+        output: 199.4,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let span = span_pricing_quote(&attrs);
+        let _guard = span.enter();
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "pricing.quote");
+    expect_common_fields(
+        span,
+        "pricing",
+        &SwapAttrs {
+            k_before: attrs.k_before,
+            k_after: attrs.k_after,
+            delta_k_ratio: attrs.delta_k_ratio,
+            fee_ppm: attrs.fee_ppm,
+            input: attrs.input,
+            output: attrs.output,
+        },
+    );
+}
+
+#[test]
+fn pricing_quote_wrapper_exports_expected_attributes() {
+    let attrs = PricingQuoteAttrs {
+        k_before: 6.0,
+        k_after: 6.0,
+        delta_k_ratio: 0.0,
+        fee_ppm: 25,
+        input: 80.0,
+        output: 79.98,
+    };
+
+    let spans = with_capturing_layer(|| {
+        let final_value = in_pricing_quote(&attrs, || 7);
+        assert_eq!(final_value, 7);
+    });
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "pricing.quote");
+    expect_common_fields(
+        span,
+        "pricing",
+        &SwapAttrs {
+            k_before: attrs.k_before,
+            k_after: attrs.k_after,
+            delta_k_ratio: attrs.delta_k_ratio,
+            fee_ppm: attrs.fee_ppm,
+            input: attrs.input,
+            output: attrs.output,
+        },
+    );
+}
+
+fn expect_panic<F>(f: F, message_contains: &str)
+where
+    F: FnOnce() + std::panic::UnwindSafe,
+{
+    let result = std::panic::catch_unwind(f);
+    assert!(result.is_err(), "expected panic but function completed");
+    let payload = result.err().unwrap();
+    let panic_str = if let Some(msg) = payload.downcast_ref::<String>() {
+        msg.as_str().to_owned()
+    } else if let Some(msg) = payload.downcast_ref::<&'static str>() {
+        msg.to_string()
+    } else {
+        format!("{:?}", payload)
+    };
+    assert!(
+        panic_str.contains(message_contains),
+        "panic message `{}` did not contain `{}`",
+        panic_str,
+        message_contains
+    );
+}
+
+#[test]
+fn invalid_attributes_trigger_panics() {
+    let mut attrs = SwapAttrs {
+        k_before: 1.0,
+        k_after: 1.0,
+        delta_k_ratio: 0.0,
+        fee_ppm: 0,
+        input: 0.0,
+        output: 0.0,
+    };
+
+    attrs.k_before = f64::NAN;
+    expect_panic(
+        || {
+            span_amm_swap(&attrs);
+        },
+        "must be finite",
+    );
+    attrs.k_before = 1.0;
+
+    attrs.k_after = 0.0;
+    expect_panic(
+        || {
+            span_amm_swap(&attrs);
+        },
+        "must be > 0",
+    );
+    attrs.k_after = 1.0;
+
+    attrs.delta_k_ratio = f64::INFINITY;
+    expect_panic(
+        || {
+            span_amm_swap(&attrs);
+        },
+        "must be finite",
+    );
+    attrs.delta_k_ratio = 1_000_001.0;
+    expect_panic(
+        || {
+            span_amm_swap(&attrs);
+        },
+        "absolute value must be ≤ 1e6",
+    );
+    attrs.delta_k_ratio = 0.0;
+
+    attrs.fee_ppm = -1;
+    expect_panic(
+        || {
+            span_amm_swap(&attrs);
+        },
+        "must be ≥ 0",
+    );
+    attrs.fee_ppm = 0;
+
+    attrs.input = -0.1;
+    expect_panic(
+        || {
+            span_amm_swap(&attrs);
+        },
+        "must be ≥ 0",
+    );
+    attrs.input = 0.0;
+
+    attrs.output = -0.1;
+    expect_panic(
+        || {
+            span_amm_swap(&attrs);
+        },
+        "must be ≥ 0",
+    );
+}


### PR DESCRIPTION
## Summary
- add `telemetry_spans_amm` helpers with validation for swap/add/remove liquidity and pricing spans plus closure wrappers
- document the OBS-1 span contract and gatecheck usage, and publish evidence for thread 10

## Testing
- `cargo fmt`
- `cargo test --features obs --test telemetry_spans_amm_tests`

## Checklist
- [x] 1. Criar branch `obs1/spans-amm`.
- [x] 2. Implementar `src/telemetry_spans_amm.rs` com structs, helpers e validações.
- [x] 3. Redigir `docs/obs1_spans_amm_contract.md`.
- [x] 4. Criar `tests/telemetry_spans_amm_tests.rs`.
- [x] 5. Gerar `out/obs_gatecheck/docs/OBS1_SPANS_AMM_README.md`.
- [x] 6. Produzir `out/obs_gatecheck/evidence/obs1_spans_amm_report.json`.
- [x] 7. Abrir PR com checklist da Seção 7.


------
https://chatgpt.com/codex/tasks/task_e_68df53cb5df08330a286daab634b1af2