### PR TITLE
OBS1: add telemetry latency helpers module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ name = "credit_engine_core"
 path = "src/lib.rs"
 crate-type = ["rlib"]
 
+[[bin]]
+name = "telemetry_smoke"
+path = "src/bin/telemetry_smoke.rs"
+required-features = ["obs"]
+
 [[bench]]
 name = "bench_swap"
 harness = false

--- a/docs/obs1_latency_contract.md
+++ b/docs/obs1_latency_contract.md
@@ -1,0 +1,118 @@
+# OBS-1 — Contrato de Medição de Latência (`telemetry_latency`)
+
+Este documento estabelece o padrão operacional para uso do módulo `telemetry_latency` (Thread 9 / CRD-8 OBS-1). O objetivo é medir a latência de operações críticas e registrar no histograma canônico `amm_op_latency_seconds` sem duplicar lógica de cronômetros no código de negócio.
+
+## 1. Tipos expostos
+
+- `Label { key, value }` — representa um rótulo validado.
+- `LatencySink` — *trait* que recebe a duração (em segundos) e a lista de labels.
+- `LatencyGuard` — RAII guard que mede a operação e publica na queda (`Drop`).
+- Funções utilitárias: `with_latency`, `guard`, `is_valid_label_key`, `is_valid_label_value`.
+
+## 2. Formatos e validação de labels
+
+| Chave    | Regex / Valores permitidos                  | Obrigatório | Observações |
+|----------|---------------------------------------------|-------------|-------------|
+| `op`     | `^(swap|add_liquidity|remove_liquidity|pricing|cdc_consume)$` | Sim | Injetado automaticamente a partir do parâmetro `op` das funções públicas.|
+| `service`| `^[a-z0-9._-]{3,64}$`                       | Recomendado | Identifica o serviço chamador; usar nomes canônicos (`amm.core`, `fx.router`, etc.). |
+| `env`    | `dev`, `stg`, `prod`                        | Recomendado | Mantém cardinalidade controlada. |
+| `version`| `^[A-Za-z0-9+._-]{2,64}$`                   | Opcional    | Use release/tag real. |
+
+Qualquer chave fora da lista resulta em `LatencyError::ForbiddenLabel`. Valores fora do padrão também são rejeitados: nada de `tbd`, `unknown` ou placeholders similares.
+
+## 3. Estilos de uso
+
+### 3.1 Função wrapper
+
+Use quando a operação cabe em um closure simples:
+
+```rust
+let labels = vec![
+    Label::new("service", "amm.core"),
+    Label::new("env", "prod"),
+    Label::new("version", "2025.09.1"),
+];
+let result = with_latency("swap", &labels, &sink, || execute_swap(order));
+```
+
+O valor retornado por `with_latency` é o retorno do closure. A medição começa antes da execução e é registrada ao final (mesmo se o closure panic? => a duração ainda é enviada durante o `Drop` do guard interno).
+
+### 3.2 RAII Guard
+
+Útil para escopos maiores, múltiplos retornos ou estruturas complexas:
+
+```rust
+let labels = [Label::new("service", "pricing"), Label::new("env", "stg")];
+let _guard = guard("pricing", &labels, &sink);
+// ... lógica a ser medida ...
+```
+
+Ao sair do escopo (normal ou por panic), o `Drop` envia a duração para o `LatencySink` associado.
+
+### 3.3 `LatencyGuard::new`
+
+Para cenários em que queremos tratar falhas de validação manualmente, use `LatencyGuard::new(...) -> Result`. O wrapper `guard(...)` faz `panic!` em caso de erro para manter API enxuta.
+
+## 4. Exemplos normativos
+
+### 4.1 Invocação válida (`with_latency`)
+
+```rust
+let labels = vec![
+    Label::new("service", "amm.core"),
+    Label::new("env", "prod"),
+];
+let price = with_latency("swap", &labels, &sink, || quote_price(input));
+```
+
+### 4.2 Invocação válida (`guard`)
+
+```rust
+let labels = [Label::new("service", "amm.core"), Label::new("env", "stg")];
+let _g = guard("pricing", &labels, &sink);
+// cálculo extenso
+```
+
+### 4.3 Invocação inválida (será rejeitada)
+
+```rust
+let labels = [Label::new("team", "risk")]; // chave proibida
+let _g = guard("swap", &labels, &sink); // panic! em runtime
+```
+
+Outro caso inválido:
+
+```rust
+let labels = [Label::new("service", "Amm-Core")]; // valor não corresponde ao regex
+LatencyGuard::new("swap", &labels, &sink)?; // retorna Err(LatencyError::ForbiddenLabel(_))
+```
+
+## 5. Performance e boas práticas
+
+- O cronômetro usa `Instant::now()` (monotônico) e converte para segundos com `as_secs_f64()`, garantindo precisão adequada para histogramas.
+- O overhead é mínimo (alocação de `Vec<Label>` + clonagem dos labels fornecidos). Evite construir labels dentro de loops apertados; reutilize slices pré-alocados sempre que possível.
+- Prefira manter `base_labels` imutáveis e compartilhadas (`lazy_static!`, `OnceLock`, etc.).
+- O `LatencySink` é desacoplado: a Thread 8/T12 vai fornecer a implementação concreta conectada ao OTLP. Em testes, use um sink in-memory.
+
+## 6. Troubleshooting
+
+| Sintoma | Diagnóstico | Ação |
+|---------|-------------|------|
+| `panic!` com "latency guard error" | Label inválido ou `op` fora do contrato | Corrija a chave/valor; use `LatencyGuard::new` em caminhos sensíveis para propagar erro. |
+| Métricas sem label `op` | Uso incorreto do sink | Nunca chame `LatencySink::record` diretamente; sempre passe pelo guard ou wrapper. |
+| Cardinalidade explodindo | `service`/`version` com valores dinâmicos | Normalize: use valores fixos (ex.: `amm.core`, `2025.09.1`). |
+
+## 7. Integração com outras threads
+
+- T8/T12 devem implementar `LatencySink` para enviar dados ao histograma `amm_op_latency_seconds`.
+- T10/T7 podem correlacionar spans/logs usando os mesmos labels.
+- Este módulo não depende de `opentelemetry`; basta injetar o sink adequado.
+
+---
+
+**Checklist interno (Thread 9)**
+
+- [x] Validação rígida de labels (`op`, `service`, `env`, `version`).
+- [x] Medição por `Instant` + RAII guard.
+- [x] Wrapper `with_latency` exposto.
+- [x] Documentação e exemplos em conformidade com OBS-1.

--- a/out/obs_gatecheck/docs/OBS1_LATENCY_README.md
+++ b/out/obs_gatecheck/docs/OBS1_LATENCY_README.md
@@ -1,0 +1,55 @@
+# OBS-1 Latency Helpers — Guia de Integração
+
+Este README documenta como consumir o módulo `telemetry_latency` em serviços que precisam publicar métricas no histograma `amm_op_latency_seconds`.
+
+## 1. Como injetar um `LatencySink`
+
+A Thread 8/T12 disponibilizará uma implementação conectada ao registry de instrumentos. Enquanto isso, o padrão é expor um sink via *dependency injection*:
+
+```rust
+pub struct OtlpSink {
+    meter: Arc<dyn HistogramExporter>,
+}
+
+impl LatencySink for OtlpSink {
+    fn record(&self, seconds: f64, labels: &[Label]) {
+        self.meter.observe(seconds, labels);
+    }
+}
+```
+
+Na camada de composição:
+
+```rust
+let base_labels = vec![Label::new("service", "amm.core"), Label::new("env", "prod")];
+let sink = Arc::new(OtlpSink::new(meter.clone()));
+let response = with_latency("swap", &base_labels, sink.as_ref(), || orchestrate_swap(req));
+```
+
+## 2. Uso recomendado por camada
+
+| Camada | Sugestão |
+|--------|----------|
+| Adapters (HTTP/gRPC) | Usar `with_latency` para blocos curtos e retornos imediatos. |
+| Core (pricing, swap, CDC) | Usar `guard` no início da função principal para cobrir o fluxo inteiro. |
+| Jobs/Workers | Criar um guard por unidade de trabalho (ex.: cada mensagem consumida). |
+
+## 3. Anti-padrões a evitar
+
+- **Labels dinâmicos**: não gere `service`/`version` por request; mantenha valores fixos.
+- **Ignorar erros de validação**: trate `LatencyGuard::new` quando estiver em caminhos críticos (ex.: inicialização). Nunca silencie `panic!` sem entender a causa.
+- **Cronômetros paralelos**: não misture `std::time::Instant` manual com este módulo; centralize tudo nele para manter consistência.
+
+## 4. Troubleshooting rápido
+
+| Sintoma | Possível causa | Mitigação |
+|---------|----------------|-----------|
+| Métrica não aparece | Sink não foi injetado ou guard dropado antes do fim | Assegure que o guard viva pelo escopo desejado e o sink esteja registrado. |
+| `panic!` na inicialização | Labels inválidos | Valide na partida usando `LatencyGuard::new` e falhe rápido com mensagens claras. |
+| Valores zerados | Operações muito curtas (<1µs) | Adicione pequenas `std::thread::yield_now()` ou agregue operações para medições significativas. |
+
+## 5. Próximos passos
+
+- Conectar `LatencySink` à pipeline OTLP (Thread 8/T12).
+- Expor dashboards com `amm_op_latency_seconds` segmentado por `service`/`env`.
+- Validar a integração via `scripts/obs1_latency_smoke.sh` (opcional nesta thread).

--- a/out/obs_gatecheck/evidence/obs1_latency_report.json
+++ b/out/obs_gatecheck/evidence/obs1_latency_report.json
@@ -1,0 +1,23 @@
+{
+  "timestamp": "2025-10-03T04:52:54Z",
+  "mock_sink_samples": [
+    {
+      "seconds": 0.002111,
+      "labels": [
+        { "key": "service", "value": "amm.core" },
+        { "key": "env", "value": "dev" },
+        { "key": "version", "value": "v1.0.0" },
+        { "key": "op", "value": "swap" }
+      ],
+      "source": "cargo test --test telemetry_latency_tests wrapper_records_latency_and_labels -- --nocapture"
+    }
+  ],
+  "tests": [
+    {
+      "command": "cargo test",
+      "status": "passed",
+      "evidence_chunk": "dd94a2"
+    }
+  ],
+  "module_sha256": "80b5cbd1f933dd5b49688c74a5844008dfbc8943f08f784745e70f42472aee34"
+}

--- a/scripts/obs1_latency_smoke.sh
+++ b/scripts/obs1_latency_smoke.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# OBS-1 latency smoke: executa o teste principal com saída capturada para evidência rápida.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+cargo test --test telemetry_latency_tests wrapper_records_latency_and_labels -- --nocapture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod ce_core; // expõe o namespace ce_core
 
 pub mod telemetry;
 pub mod telemetry_contract; // contrato OBS-1 (constantes canônicas)
+pub mod telemetry_latency;

--- a/src/telemetry_latency.rs
+++ b/src/telemetry_latency.rs
@@ -1,0 +1,239 @@
+use std::fmt;
+use std::time::Instant;
+
+pub const OP_REGEX: &str = "^(swap|add_liquidity|remove_liquidity|pricing|cdc_consume)$";
+pub const SERVICE_REGEX: &str = "^[a-z0-9._-]{3,64}$";
+pub const ENV_REGEX: &str = "^(dev|stg|prod)$";
+pub const VERSION_REGEX: &str = "^[A-Za-z0-9+._-]{2,64}$";
+
+#[derive(Debug, Clone)]
+pub struct Label {
+    pub key: String,
+    pub value: String,
+}
+
+pub trait LatencySink: Send + Sync {
+    fn record(&self, seconds: f64, labels: &[Label]);
+}
+
+#[derive(Debug)]
+pub enum LatencyError {
+    ForbiddenLabel(String),
+    InvalidOp(String),
+}
+
+impl fmt::Display for LatencyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LatencyError::ForbiddenLabel(label) => write!(f, "forbidden label: {label}"),
+            LatencyError::InvalidOp(op) => write!(f, "invalid op: {op}"),
+        }
+    }
+}
+
+impl std::error::Error for LatencyError {}
+
+#[derive(Debug)]
+pub struct LatencyGuard<'a, S: LatencySink> {
+    sink: &'a S,
+    start: Instant,
+    labels: Vec<Label>,
+    recorded: bool,
+}
+
+pub fn is_valid_label_key(k: &str) -> bool {
+    matches!(k, "op" | "service" | "env" | "version")
+}
+
+pub fn is_valid_label_value(v: &str) -> bool {
+    is_valid_op(v) || is_valid_service(v) || is_valid_env(v) || is_valid_version(v)
+}
+
+impl Label {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+impl<'a, S: LatencySink> LatencyGuard<'a, S> {
+    pub fn new(op: &'static str, base_labels: &[Label], sink: &'a S) -> Result<Self, LatencyError> {
+        validate_op(op)?;
+        let mut labels = Vec::with_capacity(base_labels.len() + 1);
+        let mut has_op_label = false;
+
+        for label in base_labels {
+            validate_label(label, op)?;
+            if label.key == "op" {
+                has_op_label = true;
+            }
+            labels.push(label.clone());
+        }
+
+        if !has_op_label {
+            labels.push(Label::new("op", op));
+        }
+
+        Ok(Self {
+            sink,
+            start: Instant::now(),
+            labels,
+            recorded: false,
+        })
+    }
+}
+
+impl<'a, S: LatencySink> Drop for LatencyGuard<'a, S> {
+    fn drop(&mut self) {
+        if self.recorded {
+            return;
+        }
+        let seconds = self.start.elapsed().as_secs_f64();
+        self.sink.record(seconds, &self.labels);
+        self.recorded = true;
+    }
+}
+
+pub fn guard<'a, S: LatencySink>(
+    op: &'static str,
+    base_labels: &[Label],
+    sink: &'a S,
+) -> LatencyGuard<'a, S> {
+    LatencyGuard::new(op, base_labels, sink)
+        .unwrap_or_else(|err| panic!("latency guard error: {err}"))
+}
+
+pub fn with_latency<S: LatencySink, T, F: FnOnce() -> T>(
+    op: &'static str,
+    base_labels: &[Label],
+    sink: &S,
+    f: F,
+) -> T {
+    let guard = LatencyGuard::new(op, base_labels, sink)
+        .unwrap_or_else(|err| panic!("with_latency validation error: {err}"));
+    let out = f();
+    drop(guard);
+    out
+}
+
+fn validate_op(op: &str) -> Result<(), LatencyError> {
+    if is_valid_op(op) {
+        Ok(())
+    } else {
+        Err(LatencyError::InvalidOp(op.to_string()))
+    }
+}
+
+fn validate_label(label: &Label, op: &str) -> Result<(), LatencyError> {
+    if !is_valid_label_key(&label.key) {
+        return Err(LatencyError::ForbiddenLabel(label.key.clone()));
+    }
+    match label.key.as_str() {
+        "op" => {
+            if !is_valid_op(&label.value) {
+                return Err(LatencyError::InvalidOp(label.value.clone()));
+            }
+            if label.value != op {
+                return Err(LatencyError::InvalidOp(label.value.clone()));
+            }
+            Ok(())
+        }
+        "service" => {
+            if is_valid_service(&label.value) {
+                Ok(())
+            } else {
+                Err(LatencyError::ForbiddenLabel(label.value.clone()))
+            }
+        }
+        "env" => {
+            if is_valid_env(&label.value) {
+                Ok(())
+            } else {
+                Err(LatencyError::ForbiddenLabel(label.value.clone()))
+            }
+        }
+        "version" => {
+            if is_valid_version(&label.value) {
+                Ok(())
+            } else {
+                Err(LatencyError::ForbiddenLabel(label.value.clone()))
+            }
+        }
+        _ => Err(LatencyError::ForbiddenLabel(label.key.clone())),
+    }
+}
+
+fn is_valid_op(value: &str) -> bool {
+    matches!(
+        value,
+        "swap" | "add_liquidity" | "remove_liquidity" | "pricing" | "cdc_consume"
+    )
+}
+
+fn is_valid_service(value: &str) -> bool {
+    let len = value.len();
+    if !(3..=64).contains(&len) {
+        return false;
+    }
+    value
+        .bytes()
+        .all(|b| matches!(b, b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-'))
+}
+
+fn is_valid_env(value: &str) -> bool {
+    matches!(value, "dev" | "stg" | "prod")
+}
+
+fn is_valid_version(value: &str) -> bool {
+    let len = value.len();
+    if !(2..=64).contains(&len) {
+        return false;
+    }
+    value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '_' | '-'))
+}
+
+#[cfg(test)]
+mod internal_tests {
+    use super::*;
+
+    #[test]
+    fn test_label_value_validation() {
+        assert!(is_valid_label_value("dev"));
+        assert!(is_valid_label_value("amm.core"));
+        assert!(is_valid_label_value("v1.2.3"));
+        assert!(is_valid_label_value("swap"));
+        assert!(!is_valid_label_value("invalid label"));
+    }
+
+    #[test]
+    fn test_label_key_validation() {
+        for key in ["op", "service", "env", "version"] {
+            assert!(is_valid_label_key(key));
+        }
+        assert!(!is_valid_label_key("tenant"));
+    }
+
+    #[test]
+    fn validates_op_regex() {
+        assert!(validate_op("swap").is_ok());
+        assert!(validate_op("pricing").is_ok());
+        assert!(validate_op("cdc_consume").is_ok());
+        assert!(validate_op("invalid").is_err());
+    }
+
+    #[test]
+    fn validates_service_values() {
+        assert!(is_valid_service("amm.core"));
+        assert!(!is_valid_service("Amm.Core"));
+    }
+
+    #[test]
+    fn validates_version_values() {
+        assert!(is_valid_version("v1.0.0"));
+        assert!(!is_valid_version("v"));
+    }
+}

--- a/tests/telemetry_latency_tests.rs
+++ b/tests/telemetry_latency_tests.rs
@@ -1,0 +1,130 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use credit_engine_core::telemetry_latency::{
+    guard, is_valid_label_key, is_valid_label_value, with_latency, Label, LatencyError,
+    LatencyGuard, LatencySink,
+};
+
+#[derive(Debug, Clone, Default)]
+struct MockSink {
+    inner: Arc<Mutex<Vec<(f64, Vec<Label>)>>>,
+}
+
+impl MockSink {
+    fn records(&self) -> Vec<(f64, Vec<Label>)> {
+        self.inner.lock().expect("records lock poisoned").clone()
+    }
+}
+
+impl LatencySink for MockSink {
+    fn record(&self, seconds: f64, labels: &[Label]) {
+        self.inner
+            .lock()
+            .expect("record lock poisoned")
+            .push((seconds, labels.to_vec()));
+    }
+}
+
+#[test]
+fn wrapper_records_latency_and_labels() {
+    let sink = MockSink::default();
+    let base_labels = vec![
+        Label::new("service", "amm.core"),
+        Label::new("env", "dev"),
+        Label::new("version", "v1.0.0"),
+    ];
+    let expected = 7u32;
+    let result = with_latency("swap", &base_labels, &sink, || {
+        std::thread::sleep(Duration::from_millis(2));
+        expected
+    });
+    assert_eq!(result, expected);
+
+    let records = sink.records();
+    assert_eq!(records.len(), 1);
+    let (seconds, labels) = &records[0];
+    assert!(
+        *seconds > 0.0,
+        "expected elapsed seconds > 0, got {seconds}"
+    );
+    assert_eq!(labels.len(), 4);
+    assert!(labels.iter().any(|l| l.key == "op" && l.value == "swap"));
+    for required in ["service", "env", "version"] {
+        assert!(labels.iter().any(|l| l.key == required));
+    }
+    println!(
+        "OBS1_MOCK_SAMPLE seconds={:.6} labels={:?}",
+        seconds, labels
+    );
+}
+
+#[test]
+fn guard_records_latency_via_drop() {
+    let sink = MockSink::default();
+    let base_labels = vec![Label::new("service", "amm.core")];
+    {
+        let _g = guard("pricing", &base_labels, &sink);
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    let records = sink.records();
+    assert_eq!(records.len(), 1);
+    let (seconds, labels) = &records[0];
+    assert!(*seconds > 0.0);
+    assert!(labels.iter().any(|l| l.key == "op" && l.value == "pricing"));
+}
+
+#[test]
+fn guard_allows_existing_op_label() {
+    let sink = MockSink::default();
+    let base_labels = vec![
+        Label::new("service", "amm.core"),
+        Label::new("op", "add_liquidity"),
+    ];
+    let guard =
+        LatencyGuard::new("add_liquidity", &base_labels, &sink).expect("guard should be created");
+    drop(guard);
+
+    let records = sink.records();
+    assert_eq!(records.len(), 1);
+    let (_, labels) = &records[0];
+    let op_count = labels.iter().filter(|l| l.key == "op").count();
+    assert_eq!(op_count, 1);
+}
+
+#[test]
+fn rejects_forbidden_label_key() {
+    let sink = MockSink::default();
+    let labels = vec![Label::new("tenant", "demo")];
+    let err = LatencyGuard::new("swap", &labels, &sink).expect_err("should reject forbidden label");
+    match err {
+        LatencyError::ForbiddenLabel(ref key) => assert_eq!(key, "tenant"),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_invalid_label_value() {
+    let sink = MockSink::default();
+    let labels = vec![Label::new("service", "InvalidCaps")];
+    let err = LatencyGuard::new("swap", &labels, &sink).expect_err("should reject invalid value");
+    matches!(err, LatencyError::ForbiddenLabel(_));
+}
+
+#[test]
+fn rejects_invalid_op_value() {
+    let sink = MockSink::default();
+    let err = LatencyGuard::new("unknown", &[], &sink).expect_err("invalid op");
+    match err {
+        LatencyError::InvalidOp(op) => assert_eq!(op, "unknown"),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn helper_validation_functions_match_policy() {
+    assert!(is_valid_label_key("service"));
+    assert!(is_valid_label_value("amm.core"));
+    assert!(is_valid_label_value("prod"));
+    assert!(!is_valid_label_value("bad value"));
+}


### PR DESCRIPTION
## Summary
- implement `telemetry_latency` module with guard and wrapper APIs plus validation helpers
- add documentation, gatecheck README, and evidence JSON for OBS-1 latency contract
- provide integration test suite, smoke script, and require `obs` feature for telemetry smoke binary

## Testing
- `cargo test`
- `cargo test --test telemetry_latency_tests wrapper_records_latency_and_labels -- --nocapture`

## Checklist
- [x] DONE Implementar `src/telemetry_latency.rs` com trait, guard, wrapper e validações
- [x] DONE Redigir `docs/obs1_latency_contract.md`
- [x] DONE Criar `tests/telemetry_latency_tests.rs`
- [x] DONE Gerar `out/obs_gatecheck/docs/OBS1_LATENCY_README.md`
- [x] DONE Produzir `out/obs_gatecheck/evidence/obs1_latency_report.json`
- [x] DONE (Opcional) Adicionar `scripts/obs1_latency_smoke.sh`


------
https://chatgpt.com/codex/tasks/task_e_68df541e9a388330a16ab70db65c8d17