### PR TITLE
obs1/spans-cdc: add CDC consume span helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "opentelemetry_sdk",
  "proptest",
  "regex",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 anyhow = "1"
 opentelemetry = { version = "0.29", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
-opentelemetry_sdk = { version = "0.29", features = ["metrics", "rt-tokio"] }
+opentelemetry_sdk = { version = "0.29", features = ["metrics", "rt-tokio", "testing"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.30"
@@ -16,12 +16,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uint = "0.9"
 metrics = { version = "0.21", path = "vendor/metrics" }
 metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendor/metrics-exporter-prometheus" }
+once_cell = "1"
+regex = "1"
 
 [dev-dependencies]
 proptest = "1"
 criterion = { version = "0.5", default-features = false }
-once_cell = "1"
-regex = "1"
+serde_json = "1"
 [lib]
 name = "credit_engine_core"
 path = "src/lib.rs"

--- a/docs/obs1_spans_cdc_contract.md
+++ b/docs/obs1_spans_cdc_contract.md
@@ -1,0 +1,87 @@
+# OBS-1 — Contrato de spans `cdc.consume`
+
+Este documento normativo descreve o contrato para spans de consumo CDC na aplicação OBS-1. O objetivo é garantir telemetria
+consistente para monitorar vazão, atraso e saúde por stream/partição.
+
+## 1. Nome do span e operação
+
+- **Nome do span:** `cdc.consume`
+- **Campo `op`:** `"cdc_consume"`
+
+O nome é estático e obrigatório. O campo `op` permite correlacionar spans e logs.
+
+## 2. Atributos obrigatórios
+
+| Atributo             | Tipo    | Restrições                                                                 |
+|----------------------|---------|----------------------------------------------------------------------------|
+| `cdc.stream`         | string  | Regex `^[a-z0-9._-]{3,64}$`; minúsculas; sem espaços.                      |
+| `cdc.partition`      | string  | Regex `^[a-zA-Z0-9._-]{1,32}$`; evita cardinalidade explosiva.            |
+| `cdc.offset_before`  | int64   | `>= -1`; use `-1` apenas quando o offset inicial é desconhecido.          |
+| `cdc.offset_after`   | int64   | `>= offset_before`.                                                        |
+| `cdc.records`        | int64   | `>= 0`.                                                                    |
+| `cdc.lag_seconds`    | double  | `>= 0`; deve ser número finito (sem `NaN`, `+∞` ou `-∞`).                  |
+
+### 2.1 Regras de coerência
+
+1. `offset_after >= offset_before`.
+2. Se `records > 0`, então `offset_after - offset_before >= records` (mínimo avanço monotônico).
+3. `lag_seconds` representa o atraso observado **no momento do consumo**.
+
+Violação de qualquer regra deve abortar a criação do span com mensagem acionável.
+
+## 3. Boas práticas de cardinalidade
+
+- Reutilize identificadores estáveis para `stream` e `partition`.
+- Evite incluir `tenant_id`, `request_id` ou UUIDs; use nomes curtos como `trades`, `balances_eu`, `p0`.
+- Mantenha `partition` alinhado à nomenclatura do broker (`p0`, `p1`, `shard-1`).
+- Ao versionar contratos, prefira `stream` diferentes (`trades.v2`) em vez de valores dinâmicos.
+
+## 4. Exemplos
+
+### 4.1 Válido
+
+```rust
+let attrs = CdcConsumeAttrs {
+    stream: "trades".into(),
+    partition: "p0".into(),
+    offset_before: 1000,
+    offset_after: 1042,
+    records: 42,
+    lag_seconds: 0.250,
+};
+let span = span_cdc_consume(&attrs);
+```
+
+### 4.2 Wrapper RAII
+
+```rust
+let out = in_cdc_consume(&attrs, || process_batch());
+```
+
+### 4.3 Inválidos
+
+| Cenário                         | Motivo                                                                 |
+|---------------------------------|------------------------------------------------------------------------|
+| `stream = ""`                  | Falha na regex `^[a-z0-9._-]{3,64}$`.                                  |
+| `offset_after < offset_before`  | Offsets regressivos quebram monotonicidade.                            |
+| `records = -1`                  | Contador de registros deve ser não-negativo.                           |
+| `lag_seconds = -0.1`            | Atraso não pode ser negativo.                                          |
+| `lag_seconds = NaN`             | Valores não finitos são proibidos.                                     |
+
+## 5. Troubleshooting
+
+| Sintoma                                           | Causa provável                                     | Ação recomendada                                      |
+|---------------------------------------------------|----------------------------------------------------|--------------------------------------------------------|
+| Erro `invalid cdc.consume attribute \`cdc.stream\`` | Nome da stream fora do padrão ou vazio.            | Ajustar para formato `^[a-z0-9._-]{3,64}$`.            |
+| Erro sobre `offset_after`                         | Offset final menor que o inicial.                  | Garantir commit monotônico antes de criar o span.      |
+| Erro de `records`                                 | Contagem negativa ou inconsistência com offsets.   | Revisar cálculo; se `records>0`, avance offsets.       |
+| Erro `lag_seconds`                                | Valor negativo ou não finito.                      | Verificar fonte de tempo; sanitize antes do span.      |
+| Lag alto (> SLA)                                  | CDC atrasado.                                      | Consultar painel `cdc.lag`, acionar hook A110 se preciso. |
+
+## 6. Referência rápida
+
+- Span RAII: `span_cdc_consume(&attrs)` retorna `tracing::Span` com validade automática.
+- Wrapper: `in_cdc_consume(&attrs, || {...})` executa a closure dentro do span.
+- Falhas de validação causam `panic!` com mensagem clara para corrigir a entrada.
+
+Mantenha este contrato sincronizado com as implementações e testes automatizados.

--- a/out/obs_gatecheck/docs/OBS1_SPANS_CDC_README.md
+++ b/out/obs_gatecheck/docs/OBS1_SPANS_CDC_README.md
@@ -1,0 +1,74 @@
+# OBS-1 Gatecheck — Helpers `telemetry_spans_cdc`
+
+Este README explica como instrumentar consumo de CDC com os helpers da thread OBS-1/T11.
+
+## 1. API disponível
+
+```rust
+use credit_engine_core::telemetry_spans_cdc::{CdcConsumeAttrs, in_cdc_consume, span_cdc_consume};
+```
+
+### 1.1 RAII (`span_cdc_consume`)
+
+Retorna `tracing::Span` válido enquanto estiver em escopo. Ideal para integrar com frameworks que já manipulam `Span` diretamente.
+
+### 1.2 Wrapper (`in_cdc_consume`)
+
+Executa uma closure dentro do span e devolve o resultado:
+
+```rust
+let result = in_cdc_consume(&attrs, || process_batch());
+```
+
+## 2. Preparando o tracer provider
+
+Os helpers não inicializam tracer global. Para testes locais ou serviços que já possuem `tracing` configurado, conecte o provider manualmente:
+
+```rust
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+let exporter = InMemorySpanExporter::default();
+let provider = SdkTracerProvider::builder()
+    .with_simple_exporter(exporter)
+    .build();
+let tracer = provider.tracer("cdc-consumer", None);
+let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+let subscriber = Registry::default().with(layer);
+let _guard = tracing::subscriber::set_default(subscriber);
+```
+
+A thread OBS-1/T4 decidirá como expor isso globalmente; por ora conecte localmente conforme acima.
+
+## 3. Atributos obrigatórios
+
+- `op = "cdc_consume"`
+- `cdc.stream` (`^[a-z0-9._-]{3,64}$`)
+- `cdc.partition` (`^[a-zA-Z0-9._-]{1,32}$`)
+- `cdc.offset_before` (`>= -1`)
+- `cdc.offset_after` (`>= offset_before`)
+- `cdc.records` (`>= 0`)
+- `cdc.lag_seconds` (`>= 0`, finito)
+
+## 4. Boas práticas de cardinalidade
+
+- Streams: nomes curtos e estáveis (`trades`, `balances_eu`).
+- Partições: seguir padrão do broker (`p0`, `p1`, `shard-1`).
+- Evitar IDs dinâmicos ou tokens únicos nas strings.
+- Caso haja reprocessamento, mantenha `stream` igual e use offsets coerentes.
+
+## 5. Validação e mensagens de erro
+
+Entrada inválida gera `panic!` com mensagens como `invalid cdc.consume attribute \\`cdc.stream\\``. Corrija a origem dos dados antes de tentar abrir o span.
+
+## 6. Fluxo sugerido
+
+1. Calcule offsets e contagem de registros antes de abrir o span.
+2. Popule `CdcConsumeAttrs` com dados limpos.
+3. Abra o span via RAII ou wrapper.
+4. Execute lógica de consumo/ack dentro do span.
+5. Ao final, deixe o span sair de escopo; o exportador cuidará da emissão.
+
+## 7. Testes
+
+Execute `cargo test -- --nocapture telemetry_spans_cdc_tests` para validar o comportamento com exportador in-memory.

--- a/out/obs_gatecheck/evidence/obs1_spans_cdc_report.json
+++ b/out/obs_gatecheck/evidence/obs1_spans_cdc_report.json
@@ -1,0 +1,33 @@
+{
+  "timestamp_utc": "2025-10-03T05:09:11+00:00",
+  "module_sha256": "c16ca6085e3963f24f93fc7599840acff49a02cc3e9bf0010bad041e97c2c147",
+  "span_sample": {
+    "name": "cdc.consume",
+    "attributes": {
+      "busy_ns": 4880,
+      "cdc.lag_seconds": 0.25,
+      "cdc.offset_after": 1042,
+      "cdc.offset_before": 1000,
+      "cdc.partition": "p0",
+      "cdc.records": 42,
+      "cdc.stream": "trades",
+      "code.filepath": "src/telemetry_spans_cdc.rs",
+      "code.lineno": 108,
+      "code.namespace": "credit_engine_core::telemetry_spans_cdc",
+      "idle_ns": 71096,
+      "op": "cdc_consume",
+      "thread.id": 11,
+      "thread.name": "span_exports_attributes_via_in_memory_exporter"
+    }
+  },
+  "tests": [
+    {
+      "command": "cargo test --features obs --test telemetry_spans_cdc_tests -- --nocapture",
+      "status": "pass"
+    },
+    {
+      "command": "cargo test --features obs",
+      "status": "pass"
+    }
+  ]
+}

--- a/scripts/obs1_spans_cdc_smoke.sh
+++ b/scripts/obs1_spans_cdc_smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo test --features obs --test telemetry_spans_cdc_tests -- span_exports_attributes_via_in_memory_exporter --nocapture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,6 @@ pub mod amm; // existe
 pub mod ce_core; // expõe o namespace ce_core
 
 pub mod telemetry;
+pub mod telemetry_cfg;
 pub mod telemetry_identity;
+pub mod telemetry_spans_cdc;

--- a/src/telemetry_spans_cdc.rs
+++ b/src/telemetry_spans_cdc.rs
@@ -1,0 +1,150 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::fmt;
+use tracing::{field, Level, Span};
+
+const OPERATION_NAME: &str = "cdc_consume";
+const SPAN_NAME: &str = "cdc.consume";
+
+static STREAM_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-z0-9._-]{3,64}$").unwrap());
+static PARTITION_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9._-]{1,32}$").unwrap());
+
+#[derive(Debug, Clone)]
+pub struct CdcConsumeAttrs {
+    pub stream: String,
+    pub partition: String,
+    pub offset_before: i64,
+    pub offset_after: i64,
+    pub records: i64,
+    pub lag_seconds: f64,
+}
+
+#[derive(Debug, Clone)]
+struct CdcValidationError {
+    message: String,
+}
+
+impl fmt::Display for CdcValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+fn validate_attrs(attrs: &CdcConsumeAttrs) -> Result<(), CdcValidationError> {
+    if !STREAM_REGEX.is_match(attrs.stream.as_str()) {
+        return Err(CdcValidationError {
+            message: format!(
+                "invalid cdc.consume attribute `cdc.stream`: expected ^[a-z0-9._-]{{3,64}}$, got `{}`",
+                attrs.stream
+            ),
+        });
+    }
+
+    if !PARTITION_REGEX.is_match(attrs.partition.as_str()) {
+        return Err(CdcValidationError {
+            message: format!(
+                "invalid cdc.consume attribute `cdc.partition`: expected ^[a-zA-Z0-9._-]{{1,32}}$, got `{}`",
+                attrs.partition
+            ),
+        });
+    }
+
+    if attrs.offset_before < -1 {
+        return Err(CdcValidationError {
+            message: format!(
+                "invalid cdc.consume attribute `cdc.offset_before`: expected >= -1, got {}",
+                attrs.offset_before
+            ),
+        });
+    }
+
+    if attrs.offset_after < attrs.offset_before {
+        return Err(CdcValidationError {
+            message: format!(
+                "invalid cdc.consume attribute `cdc.offset_after`: expected >= offset_before ({}), got {}",
+                attrs.offset_before, attrs.offset_after
+            ),
+        });
+    }
+
+    if attrs.records < 0 {
+        return Err(CdcValidationError {
+            message: format!(
+                "invalid cdc.consume attribute `cdc.records`: expected >= 0, got {}",
+                attrs.records
+            ),
+        });
+    }
+
+    if !attrs.lag_seconds.is_finite() || attrs.lag_seconds < 0.0 {
+        return Err(CdcValidationError {
+            message: format!(
+                "invalid cdc.consume attribute `cdc.lag_seconds`: expected finite >= 0, got {}",
+                attrs.lag_seconds
+            ),
+        });
+    }
+
+    if attrs.records > 0 {
+        let delta = (attrs.offset_after as i128) - (attrs.offset_before as i128);
+        if delta < attrs.records as i128 {
+            return Err(CdcValidationError {
+                message: format!(
+                    "invalid cdc.consume attribute combination: offset_after - offset_before ({} - {}) < records ({})",
+                    attrs.offset_after, attrs.offset_before, attrs.records
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+pub fn span_cdc_consume(attrs: &CdcConsumeAttrs) -> Span {
+    if let Err(err) = validate_attrs(attrs) {
+        panic!("invalid cdc.consume attributes: {}", err);
+    }
+
+    let span = tracing::span!(
+        target: "obs.cdc",
+        Level::INFO,
+        SPAN_NAME,
+        op = OPERATION_NAME,
+        "cdc.stream" = field::display(&attrs.stream),
+        "cdc.partition" = field::display(&attrs.partition),
+        "cdc.offset_before" = attrs.offset_before,
+        "cdc.offset_after" = attrs.offset_after,
+        "cdc.records" = attrs.records,
+        "cdc.lag_seconds" = attrs.lag_seconds
+    );
+
+    span
+}
+
+pub fn in_cdc_consume<F, T>(attrs: &CdcConsumeAttrs, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let span = span_cdc_consume(attrs);
+    span.in_scope(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "invalid cdc.consume attribute `cdc.stream`")]
+    fn span_cdc_consume_invalid_stream_panics() {
+        let attrs = CdcConsumeAttrs {
+            stream: "".into(),
+            partition: "p0".into(),
+            offset_before: 0,
+            offset_after: 0,
+            records: 0,
+            lag_seconds: 0.0,
+        };
+
+        let _ = span_cdc_consume(&attrs);
+    }
+}

--- a/tests/telemetry_spans_cdc_tests.rs
+++ b/tests/telemetry_spans_cdc_tests.rs
@@ -1,0 +1,196 @@
+use credit_engine_core::telemetry_spans_cdc::{in_cdc_consume, span_cdc_consume, CdcConsumeAttrs};
+use opentelemetry::trace::TracerProvider;
+use opentelemetry::KeyValue;
+use opentelemetry::Value;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Registry;
+
+fn make_attrs() -> CdcConsumeAttrs {
+    CdcConsumeAttrs {
+        stream: "trades".into(),
+        partition: "p0".into(),
+        offset_before: 1000,
+        offset_after: 1042,
+        records: 42,
+        lag_seconds: 0.250,
+    }
+}
+
+#[test]
+fn span_exports_attributes_via_in_memory_exporter() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("obs1-tests");
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = Registry::default().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        let attrs = make_attrs();
+        let span = span_cdc_consume(&attrs);
+        assert!(
+            !span.is_disabled(),
+            "cdc.consume span should be enabled for export"
+        );
+        span.in_scope(|| {});
+        drop(span);
+    });
+
+    provider.force_flush().expect("force flush spans");
+
+    let exported = exporter
+        .get_finished_spans()
+        .expect("spans should be captured");
+    assert_eq!(1, exported.len(), "expected a single span export");
+    let span = &exported[0];
+    assert_eq!("cdc.consume", span.name.as_ref());
+
+    let attributes: HashMap<String, Value> = span
+        .attributes
+        .iter()
+        .map(|KeyValue { key, value, .. }| (key.as_str().to_string(), value.clone()))
+        .collect();
+
+    assert_eq!(Some(&Value::from("cdc_consume")), attributes.get("op"));
+    assert_eq!(Some(&Value::from("trades")), attributes.get("cdc.stream"));
+    assert_eq!(Some(&Value::from("p0")), attributes.get("cdc.partition"));
+    assert_eq!(
+        Some(&Value::from(1000_i64)),
+        attributes.get("cdc.offset_before")
+    );
+    assert_eq!(
+        Some(&Value::from(1042_i64)),
+        attributes.get("cdc.offset_after")
+    );
+    assert_eq!(Some(&Value::from(42_i64)), attributes.get("cdc.records"));
+    assert_eq!(
+        Some(&Value::from(0.250_f64)),
+        attributes.get("cdc.lag_seconds")
+    );
+
+    let mut attr_json = JsonMap::new();
+    for (key, value) in &attributes {
+        attr_json.insert(key.clone(), otel_value_to_json(value));
+    }
+
+    let mut sample = JsonMap::new();
+    sample.insert("name".to_string(), JsonValue::String(span.name.to_string()));
+    sample.insert("attributes".to_string(), JsonValue::Object(attr_json));
+    println!(
+        "telemetry_spans_cdc.sample={}",
+        serde_json::to_string_pretty(&JsonValue::Object(sample)).expect("serialize sample")
+    );
+}
+
+#[test]
+fn wrapper_executes_closure() {
+    let attrs = make_attrs();
+    let result = in_cdc_consume(&attrs, || 2 + 2);
+    assert_eq!(4, result);
+}
+
+fn expect_invalid(attrs: CdcConsumeAttrs, needle: &str) {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = span_cdc_consume(&attrs);
+    }));
+    match result {
+        Ok(_) => panic!("expected panic for {:?}", needle),
+        Err(payload) => {
+            let message = if let Some(s) = payload.downcast_ref::<String>() {
+                s.as_str()
+            } else if let Some(s) = payload.downcast_ref::<&'static str>() {
+                s
+            } else {
+                panic!("unexpected panic payload type");
+            };
+            assert!(
+                message.contains(needle),
+                "panic message `{}` did not contain `{}`",
+                message,
+                needle
+            );
+        }
+    }
+}
+
+fn otel_value_to_json(value: &Value) -> JsonValue {
+    match value {
+        Value::Bool(v) => JsonValue::Bool(*v),
+        Value::I64(v) => JsonValue::Number((*v).into()),
+        Value::F64(v) => serde_json::Number::from_f64(*v)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        Value::String(s) => JsonValue::String(s.to_string()),
+        Value::Array(array) => JsonValue::String(array.to_string()),
+        other => JsonValue::String(other.to_string()),
+    }
+}
+
+#[test]
+fn invalid_stream_rejected() {
+    let mut attrs = make_attrs();
+    attrs.stream = "".into();
+    expect_invalid(attrs, "cdc.stream");
+}
+
+#[test]
+fn invalid_partition_rejected() {
+    let mut attrs = make_attrs();
+    attrs.partition = "bad partition".into();
+    expect_invalid(attrs, "cdc.partition");
+}
+
+#[test]
+fn invalid_offset_order_rejected() {
+    let mut attrs = make_attrs();
+    attrs.offset_after = 999;
+    expect_invalid(attrs, "cdc.offset_after");
+}
+
+#[test]
+fn invalid_offset_before_lower_bound() {
+    let mut attrs = make_attrs();
+    attrs.offset_before = -2;
+    expect_invalid(attrs, "cdc.offset_before");
+}
+
+#[test]
+fn invalid_records_negative() {
+    let mut attrs = make_attrs();
+    attrs.records = -1;
+    expect_invalid(attrs, "cdc.records");
+}
+
+#[test]
+fn invalid_records_offset_gap() {
+    let mut attrs = make_attrs();
+    attrs.records = 50;
+    attrs.offset_after = attrs.offset_before + 1;
+    expect_invalid(attrs, "offset_after - offset_before");
+}
+
+#[test]
+fn invalid_lag_negative() {
+    let mut attrs = make_attrs();
+    attrs.lag_seconds = -0.1;
+    expect_invalid(attrs, "cdc.lag_seconds");
+}
+
+#[test]
+fn invalid_lag_nan() {
+    let mut attrs = make_attrs();
+    attrs.lag_seconds = f64::NAN;
+    expect_invalid(attrs, "cdc.lag_seconds");
+}
+
+#[test]
+fn invalid_lag_infinite() {
+    let mut attrs = make_attrs();
+    attrs.lag_seconds = f64::INFINITY;
+    expect_invalid(attrs, "cdc.lag_seconds");
+}


### PR DESCRIPTION
## Summary
- add `telemetry_spans_cdc` module with CDC consume span helpers, validation, and re-export in the crate root
- document the canonical contract plus gatecheck README/evidence for CDC spans and provide a smoke script
- add comprehensive integration tests with the in-memory exporter that validate attributes and capture sample output

## Testing
- `cargo test --features obs --test telemetry_spans_cdc_tests -- --nocapture`
- `cargo test --features obs`

## Checklist
- [x] 1. Criar branch: `obs1/spans-cdc`
- [x] 2. Implementar `src/telemetry_spans_cdc.rs`
- [x] 3. Redigir `docs/obs1_spans_cdc_contract.md`
- [x] 4. Criar `tests/telemetry_spans_cdc_tests.rs`
- [x] 5. Gerar `out/obs_gatecheck/docs/OBS1_SPANS_CDC_README.md`
- [x] 6. Produzir `out/obs_gatecheck/evidence/obs1_spans_cdc_report.json`
- [x] 7. (Opcional) `scripts/obs1_spans_cdc_smoke.sh`
- [x] 8. Abrir PR com checklist preenchido

------
https://chatgpt.com/codex/tasks/task_e_68df5714d808833092a4d851de8e50b9