### PR TITLE
Update OTLP metrics exporter interfaces for v0.29

### DIFF
--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -2,9 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::metrics::{
-    periodic_reader_with_async_runtime::PeriodicReader, SdkMeterProvider,
-};
+use opentelemetry_sdk::metrics::{reader::PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::runtime::Tokio;
 use opentelemetry_sdk::Resource;
 use thiserror::Error;

--- a/tests/telemetry_metrics_otlp_tests.rs
+++ b/tests/telemetry_metrics_otlp_tests.rs
@@ -11,8 +11,8 @@ use credit_engine_core::telemetry_metrics_otlp::{
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::metrics::{
-    exporter::{ExportFuture, PushMetricExporter},
-    periodic_reader_with_async_runtime::PeriodicReader,
+    exporter::{Context, MetricsError, PushMetricExporter},
+    reader::PeriodicReader,
     Temporality,
 };
 use opentelemetry_sdk::runtime::Tokio;
@@ -31,19 +31,20 @@ impl RecordingExporter {
 }
 
 impl PushMetricExporter for RecordingExporter {
-    fn export<'a>(
-        &'a self,
-        _metrics: &'a mut opentelemetry_sdk::metrics::data::ResourceMetrics,
-    ) -> ExportFuture<'a> {
+    fn export(
+        &self,
+        _cx: &Context,
+        _metrics: &mut opentelemetry_sdk::metrics::data::ResourceMetrics,
+    ) -> Result<(), MetricsError> {
         self.exports.fetch_add(1, Ordering::Relaxed);
-        Box::pin(async { Ok(()) })
-    }
-
-    fn force_flush(&self) -> opentelemetry_sdk::metrics::MetricResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> opentelemetry_sdk::metrics::MetricResult<()> {
+    fn force_flush(&self, _cx: &Context) -> Result<(), MetricsError> {
+        Ok(())
+    }
+
+    fn shutdown(&self, _cx: &Context) -> Result<(), MetricsError> {
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- update the OTLP metrics exporter test implementation to use the v0.29 `PushMetricExporter` context-based contract
- move periodic reader imports in both test and production code to `opentelemetry_sdk::metrics::reader`
- keep the production meter initialization aligned with the new exporter API

## Testing
- `cargo test --no-run` *(fails: workspace manifest defines duplicate `telemetry_smoke` binaries)*
- `rustfmt --edition 2021 tests/telemetry_metrics_otlp_tests.rs src/telemetry_metrics_otlp.rs`


------
https://chatgpt.com/codex/tasks/task_e_68e069443b4083309046161731789e8c