### PR TITLE
Use Extractor/Injector adapter in telemetry trace tests

### DIFF
--- a/tests/telemetry_trace_tests.rs
+++ b/tests/telemetry_trace_tests.rs
@@ -9,7 +9,7 @@ use credit_engine_core::telemetry_trace::{
     OtlpProtocol, ResourcePairs, TraceConfig, TraceInitError,
 };
 use opentelemetry::baggage::BaggageExt;
-use opentelemetry::propagation::TextMapCarrier;
+use opentelemetry::propagation::{Extractor, Injector};
 use opentelemetry::testing::trace::TestSpan;
 use opentelemetry::trace::{SpanContext, TraceContextExt, TraceFlags, TraceId, TraceState};
 use opentelemetry::Context;
@@ -164,11 +164,17 @@ fn test_resource() -> ResourcePairs {
 #[derive(Default)]
 struct HeaderCarrier(HashMap<String, String>);
 
-impl TextMapCarrier for HeaderCarrier {
+impl Extractor for HeaderCarrier {
     fn get(&self, key: &str) -> Option<&str> {
         self.0.get(key).map(|value| value.as_str())
     }
 
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|key| key.as_str()).collect()
+    }
+}
+
+impl Injector for HeaderCarrier {
     fn set(&mut self, key: &str, value: String) {
         self.0.insert(key.to_string(), value);
     }


### PR DESCRIPTION
## Summary
- update telemetry trace tests to depend on opentelemetry Extractor/Injector traits instead of the deprecated TextMapCarrier
- implement both traits for the HashMap-backed HeaderCarrier helper used by the tests

## Testing
- cargo test --no-run *(fails: duplicate binary name telemetry_smoke in Cargo manifest)*

------
https://chatgpt.com/codex/tasks/task_e_68e069453f98833089ff9fee86e93efd