### PR TITLE
Handle u128 JSON number conversion in obs policy lints

### DIFF
--- a/src/obs_policy_lints.rs
+++ b/src/obs_policy_lints.rs
@@ -139,9 +139,14 @@ impl tracing_core::field::Visit for CollectVisitor {
     }
 
     fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
-        if let Some(number) = serde_json::Number::from_u64(value) {
+        if let Some(number) = serde_json::Number::from_u128(value as u128) {
             self.values
                 .insert(field.name().to_string(), Value::Number(number));
+        } else {
+            self.values.insert(
+                field.name().to_string(),
+                Value::String(value.to_string()),
+            );
         }
     }
 

--- a/tests/obs_policy_lints_tests.rs
+++ b/tests/obs_policy_lints_tests.rs
@@ -146,8 +146,10 @@ impl tracing_core::field::Visit for TestVisitor {
     }
 
     fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
-        if let Some(number) = serde_json::Number::from_u64(value) {
+        if let Some(number) = serde_json::Number::from_u128(value as u128) {
             self.record_value(field, Value::Number(number));
+        } else {
+            self.record_value(field, Value::String(value.to_string()));
         }
     }
 


### PR DESCRIPTION
## Summary
- update observability policy lints to construct JSON numbers from u128 values with a string fallback
- mirror the new fallback in the corresponding tests to keep expectations aligned

## Testing
- cargo test --no-run *(fails: manifest has duplicate binary name telemetry_smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68e069467ba88330b48bffd55ea4b5d9