### PR TITLE
OBS‑1 — Pós‑sync build fix + validação autônoma

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,17 @@ opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
 opentelemetry_sdk = { version = "0.29", features = ["metrics", "rt-tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tracing = "0.1"
+tracing-core = "0.1.34"
 tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uint = "0.9"
 metrics = { version = "0.21", path = "vendor/metrics" }
 metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendor/metrics-exporter-prometheus" }
 once_cell = "1"
+thiserror = "2.0.16"
 regex = "1"
+prometheus = "*"
+opentelemetry-prometheus = "*"
 serde_json = "1"
 
 [dev-dependencies]
@@ -50,3 +54,4 @@ harness = false
 
 [features]
 obs = []
+metrics-otlp-grpc = []

--- a/scripts/obs1_postsync_validate.sh
+++ b/scripts/obs1_postsync_validate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p out/diagnostics
+RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt
+cargo clean
+cargo build -q
+cargo test --no-run 2>&1 | tee out/diagnostics/test-norun-sync.txt || true
+cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt || true
+if grep -R "cfg(feature = \"obs\")" -n src tests >/dev/null 2>&1; then
+  cargo test --features obs -q 2>&1 | tee -a out/diagnostics/test-run-sync.txt || true
+fi

--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::metrics::{reader::PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::runtime::Tokio;
 use opentelemetry_sdk::Resource;
 use thiserror::Error;

--- a/tests/telemetry_metrics_otlp_tests.rs
+++ b/tests/telemetry_metrics_otlp_tests.rs
@@ -12,7 +12,7 @@ use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::metrics::{
     exporter::{Context, MetricsError, PushMetricExporter},
-    reader::PeriodicReader,
+    PeriodicReader,
     Temporality,
 };
 use opentelemetry_sdk::runtime::Tokio;


### PR DESCRIPTION
## Escopo
- Adiciona as dependências thiserror, tracing-core, prometheus e opentelemetry-prometheus para restabelecer o build de métricas OTLP.
- Corrige o uso de `PeriodicReader` para a API da SDK 0.29 tanto no módulo quanto nos testes.
- Declara a feature vazia `metrics-otlp-grpc` para alinhar os `cfg`.
- Disponibiliza o script `obs1_postsync_validate.sh` para validar check/build/test e arquivar evidências.

## Arquivos alterados
- Cargo.toml
- src/telemetry_metrics_otlp.rs
- tests/telemetry_metrics_otlp_tests.rs
- scripts/obs1_postsync_validate.sh

## Comando de validação
- `./scripts/obs1_postsync_validate.sh`

## Evidências
- `out/diagnostics/check-sync.txt`
- `out/diagnostics/test-norun-sync.txt`
- `out/diagnostics/test-run-sync.txt`


------
https://chatgpt.com/codex/tasks/task_e_68e06ffb906c833088023598d34f219c