### PR TITLE
Fix Prometheus exporter integration

### DIFF
--- a/src/telemetry_metrics_prom.rs
+++ b/src/telemetry_metrics_prom.rs
@@ -10,7 +10,7 @@ use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder as HyperBuilder,
 };
-use prometheus::{gather as gather_metrics, TextEncoder};
+use prometheus::{Encoder, TextEncoder};
 use tokio::net::TcpListener;
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -24,15 +24,14 @@ pub struct PromServerConfig {
     pub addr: String,
 }
 
-#[derive(Clone)]
 pub struct PromExporter {
     pub registry: prometheus::Registry,
-    pub reader: opentelemetry_prometheus::PrometheusExporter,
+    meter_provider: Arc<SdkMeterProvider>,
 }
 
 impl PromExporter {
     pub fn meter_provider(&self) -> Arc<SdkMeterProvider> {
-        self.reader.provider()
+        Arc::clone(&self.meter_provider)
     }
 }
 
@@ -85,8 +84,12 @@ pub fn init_prom_exporter() -> PromExporter {
         .with_registry(registry.clone())
         .build()
         .expect("failed to build Prometheus exporter");
+    let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
 
-    PromExporter { registry, reader }
+    PromExporter {
+        registry,
+        meter_provider,
+    }
 }
 
 pub async fn spawn_metrics_http(
@@ -183,7 +186,7 @@ async fn handle_request(
 }
 
 fn gather_and_encode(exporter: &PromExporter) -> Result<Vec<u8>, String> {
-    let metric_families = gather_metrics(&exporter.registry);
+    let metric_families = exporter.registry.gather();
     let mut buffer = Vec::new();
     let encoder = TextEncoder::new();
     encoder


### PR DESCRIPTION
## Summary
- construct the Prometheus metrics exporter using the new opentelemetry-prometheus API and keep the SDK meter provider handle
- gather metrics from the registry directly and ensure the text encoder import matches the new API

## Testing
- cargo test --no-run *(fails: existing compile errors in telemetry_metrics_otlp.rs and telemetry_trace.rs with updated opentelemetry APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b1acdc5c8330b88f26d09bfc8a11