### PR TITLE
Add OBS-1 diagnostics preview to postsync script

### DIFF
--- a/scripts/obs1_postsync_validate.sh
+++ b/scripts/obs1_postsync_validate.sh
@@ -9,3 +9,9 @@ cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt || true
 if grep -R "cfg(feature = \"obs\")" -n src tests >/dev/null 2>&1; then
   cargo test --features obs -q 2>&1 | tee -a out/diagnostics/test-run-sync.txt || true
 fi
+printf '\n[obs1] check-sync.txt (first 60 lines)\n'
+sed -n '1,60p' out/diagnostics/check-sync.txt
+printf '\n[obs1] test-norun-sync.txt (first 60 lines)\n'
+sed -n '1,60p' out/diagnostics/test-norun-sync.txt
+printf '\n[obs1] test-run-sync.txt (first 60 lines)\n'
+sed -n '1,60p' out/diagnostics/test-run-sync.txt


### PR DESCRIPTION
## Summary
- append OBS-1 diagnostic previews to the postsync validation script so the first 60 lines of each log are printed

## Testing
- ./scripts/obs1_postsync_validate.sh *(fails: cargo check reports existing compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b1aeb22483308eaaf92f44374bb7