### PR TITLE
Fix Prometheus exporter initialization and clean up OTLP builders

### DIFF
--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -255,17 +255,27 @@ fn build_otlp_exporter(
     export_timeout_ms: u64,
 ) -> Result<opentelemetry_otlp::MetricExporter, MetricsInitError> {
     let timeout = Duration::from_millis(export_timeout_ms);
-    match protocol {
-        OtlpProtocol::Grpc => Err(MetricsInitError::OtlpBuildError(
-            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
-            .with_http()
-            .with_endpoint(endpoint.to_string())
-            .with_timeout(timeout)
-            .build()
-            .map_err(|err| MetricsInitError::OtlpBuildError(err.to_string())),
-    }
+    let builder = match protocol {
+        OtlpProtocol::Grpc => opentelemetry_otlp::new_exporter().tonic(),
+        OtlpProtocol::Http => opentelemetry_otlp::new_exporter().http(),
+    };
+
+    builder
+        .with_endpoint(endpoint.to_string())
+        .with_timeout(timeout)
+        .build_metric_exporter()
+        .map_err(|err| match (protocol, err) {
+            (
+                OtlpProtocol::Grpc,
+                opentelemetry_otlp::ExporterBuildError::InternalFailure(message),
+            ) if message.contains("gRPC metrics exporter support is not enabled") => {
+                MetricsInitError::OtlpBuildError(
+                    "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                        .into(),
+                )
+            }
+            (_, other) => MetricsInitError::OtlpBuildError(other.to_string()),
+        })
 }
 
 fn build_periodic_reader(

--- a/src/telemetry_metrics_prom.rs
+++ b/src/telemetry_metrics_prom.rs
@@ -84,13 +84,8 @@ pub fn init_prom_exporter() -> PromExporter {
         .with_registry(registry.clone())
         .build()
         .expect("failed to build Prometheus exporter");
-    let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
 
-    let provider = Arc::new(
-        SdkMeterProvider::builder()
-            .with_reader(exporter)
-            .build(),
-    );
+    let provider = Arc::new(SdkMeterProvider::builder().with_reader(exporter).build());
 
     PromExporter { registry, provider }
 }

--- a/src/telemetry_trace.rs
+++ b/src/telemetry_trace.rs
@@ -216,15 +216,18 @@ fn build_otlp_exporter(
 ) -> Result<OtlpSpanExporter, TraceInitError> {
     let timeout = Duration::from_millis(cfg.export_timeout_ms);
     match protocol {
-        OtlpProtocol::Grpc => Err(TraceInitError::OtlpBuildError(
-            "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => OtlpSpanExporter::builder()
-            .with_http()
-            .with_endpoint(endpoint.to_string())
-            .with_timeout(timeout)
-            .build()
-            .map_err(|err| TraceInitError::OtlpBuildError(err.to_string())),
+        OtlpProtocol::Grpc => build_grpc_exporter(endpoint, timeout).map_err(|err| {
+            if let TraceInitError::OtlpBuildError(message) = &err {
+                if message.contains("not enabled") {
+                    return TraceInitError::OtlpBuildError(
+                        "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                            .into(),
+                    );
+                }
+            }
+            err
+        }),
+        OtlpProtocol::Http => build_http_exporter(endpoint, timeout),
     }
 }
 
@@ -248,7 +251,7 @@ fn build_grpc_exporter(endpoint: &str, timeout: Duration) -> Result<OtlpSpanExpo
 #[cfg(not(feature = "grpc-tonic"))]
 fn build_grpc_exporter(_endpoint: &str, _timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
     Err(TraceInitError::OtlpBuildError(
-        "opentelemetry-otlp built without gRPC support".to_string(),
+        "gRPC trace exporter support is not enabled".to_string(),
     ))
 }
 


### PR DESCRIPTION
## Summary
- fix the Prometheus metrics exporter initialization to pass the built reader directly into the SDK provider
- hook up the OTLP metrics builder compatibility helpers so the module compiles cleanly with warnings-as-errors
- reuse the trace exporter helper functions so OTLP trace builder warnings are eliminated while preserving existing error messaging

## Testing
- RUSTFLAGS=-Dwarnings cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e0c4ad82a0833090392f6b7c73344f