### PR TITLE
Enable OTLP gRPC exporter feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]

--- a/docs/obs1_metrics_otlp_contract.md
+++ b/docs/obs1_metrics_otlp_contract.md
@@ -54,8 +54,9 @@ pub fn select_protocol(endpoint: &str, explicit: Option<OtlpProtocol>) -> OtlpPr
    * Port `4318` or path `/v1/metrics` → `OtlpProtocol::Http`.
    * Otherwise → `OtlpProtocol::Grpc`.
 3. Supports TLS endpoints transparently (`https://` URLs are forwarded to the OTLP client).
-4. Enabling real gRPC transport requires the crate feature `metrics-otlp-grpc`. Without it, `init_meter_otlp` returns
-   `MetricsInitError::OtlpBuildError` for gRPC endpoints.
+4. Enabling real gRPC transport requires the crate feature `metrics-otlp-grpc`, which now activates
+   `opentelemetry-otlp`'s `grpc-tonic` support so the `.with_tonic()` exporter builder is compiled. Without the feature,
+   `init_meter_otlp` returns `MetricsInitError::OtlpBuildError` for gRPC endpoints.
 
 ## 4. Periodic Export & Shutdown
 


### PR DESCRIPTION
## Summary
- enable the `metrics-otlp-grpc` feature to activate `opentelemetry-otlp`'s gRPC client implementation
- clarify in the OTLP metrics contract documentation that the feature now brings in the tonic-backed exporter

## Testing
- cargo check --features metrics-otlp-grpc *(fails: unable to download `hyper-timeout` due to 403 from crates.io proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c4af46f48330ba3d5c7ed0696b7a