### PR TITLE
Update OTLP metrics exporter pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]

--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -1,94 +1,11 @@
 use std::{collections::HashMap, time::Duration};
 
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
+use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::Resource;
 use thiserror::Error;
 use tracing::warn;
-
-mod opentelemetry_otlp {
-    use std::time::Duration;
-
-    use ::opentelemetry_otlp::WithExportConfig;
-    pub use ::opentelemetry_otlp::*;
-
-    #[derive(Clone, Copy)]
-    enum ExporterKind {
-        Grpc,
-        Http,
-    }
-
-    pub struct MetricExporterBuilderCompat {
-        kind: Option<ExporterKind>,
-        endpoint: Option<String>,
-        timeout: Option<Duration>,
-    }
-
-    impl MetricExporterBuilderCompat {
-        pub fn tonic(mut self) -> Self {
-            self.kind = Some(ExporterKind::Grpc);
-            self
-        }
-
-        pub fn http(mut self) -> Self {
-            self.kind = Some(ExporterKind::Http);
-            self
-        }
-
-        pub fn with_endpoint(mut self, endpoint: String) -> Self {
-            self.endpoint = Some(endpoint);
-            self
-        }
-
-        pub fn with_timeout(mut self, timeout: Duration) -> Self {
-            self.timeout = Some(timeout);
-            self
-        }
-
-        pub fn build_metric_exporter(self) -> Result<MetricExporter, ExporterBuildError> {
-            match self.kind.unwrap_or(ExporterKind::Http) {
-                ExporterKind::Grpc => {
-                    #[cfg(feature = "metrics-otlp-grpc")]
-                    {
-                        let mut builder =
-                            ::opentelemetry_otlp::MetricExporter::builder().with_tonic();
-                        if let Some(endpoint) = self.endpoint {
-                            builder = builder.with_endpoint(endpoint);
-                        }
-                        if let Some(timeout) = self.timeout {
-                            builder = builder.with_timeout(timeout);
-                        }
-                        builder.build()
-                    }
-                    #[cfg(not(feature = "metrics-otlp-grpc"))]
-                    {
-                        Err(ExporterBuildError::InternalFailure(
-                            "gRPC metrics exporter support is not enabled".into(),
-                        ))
-                    }
-                }
-                ExporterKind::Http => {
-                    let mut builder = ::opentelemetry_otlp::MetricExporter::builder().with_http();
-                    if let Some(endpoint) = self.endpoint {
-                        builder = builder.with_endpoint(endpoint);
-                    }
-                    if let Some(timeout) = self.timeout {
-                        builder = builder.with_timeout(timeout);
-                    }
-                    builder.build()
-                }
-            }
-        }
-    }
-
-    pub fn new_exporter() -> MetricExporterBuilderCompat {
-        MetricExporterBuilderCompat {
-            kind: None,
-            endpoint: None,
-            timeout: None,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObsLevel {
@@ -256,14 +173,28 @@ fn build_otlp_exporter(
 ) -> Result<opentelemetry_otlp::MetricExporter, MetricsInitError> {
     let timeout = Duration::from_millis(export_timeout_ms);
     match protocol {
-        OtlpProtocol::Grpc => Err(MetricsInitError::OtlpBuildError(
-            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
-            .with_http()
+        OtlpProtocol::Grpc => {
+            #[cfg(feature = "metrics-otlp-grpc")]
+            {
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint(endpoint.to_string())
+                    .with_timeout(timeout)
+                    .build_metrics_exporter()
+                    .map_err(|err| MetricsInitError::OtlpBuildError(err.to_string()))
+            }
+            #[cfg(not(feature = "metrics-otlp-grpc"))]
+            {
+                Err(MetricsInitError::OtlpBuildError(
+                    "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
+                ))
+            }
+        }
+        OtlpProtocol::Http => opentelemetry_otlp::new_exporter()
+            .http()
             .with_endpoint(endpoint.to_string())
             .with_timeout(timeout)
-            .build()
+            .build_metrics_exporter()
             .map_err(|err| MetricsInitError::OtlpBuildError(err.to_string())),
     }
 }


### PR DESCRIPTION
## Summary
- build the OTLP metrics exporter through `opentelemetry_otlp::new_exporter()` for both HTTP and gRPC transports
- wire the `metrics-otlp-grpc` crate feature to enable tonic-based exporters when requested

## Testing
- `cargo check --all-targets --all-features` *(fails: crates.io returned 403 while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c57bdb7c8330aaacd36ecdc6f69b