### PR TITLE
Refactor OTLP trace exporter builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
 httpdate = { version = "1", path = "vendor/httpdate" }
 opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
+opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tracing = "0.1"
@@ -54,4 +54,4 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]

--- a/src/telemetry_trace.rs
+++ b/src/telemetry_trace.rs
@@ -10,14 +10,37 @@ use opentelemetry::global;
 use opentelemetry::propagation::TextMapCompositePropagator;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::KeyValue;
+mod opentelemetry_otlp {
+    pub use ::opentelemetry_otlp::{SpanExporter, WithExportConfig};
+
+    pub struct SpanExporterBuilderCompat;
+
+    impl SpanExporterBuilderCompat {
+        pub fn http(self) -> ::opentelemetry_otlp::HttpExporterBuilder {
+            ::opentelemetry_otlp::HttpExporterBuilder::default()
+        }
+    }
+
+    #[cfg(feature = "metrics-otlp-grpc")]
+    impl SpanExporterBuilderCompat {
+        pub fn tonic(self) -> ::opentelemetry_otlp::TonicExporterBuilder {
+            ::opentelemetry_otlp::TonicExporterBuilder::default()
+        }
+    }
+
+    pub fn new_exporter() -> SpanExporterBuilderCompat {
+        SpanExporterBuilderCompat
+    }
+}
+
 use opentelemetry_otlp::{SpanExporter as OtlpSpanExporter, WithExportConfig};
 use opentelemetry_sdk::error::OTelSdkError;
+use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
 use opentelemetry_sdk::resource::Resource;
 use opentelemetry_sdk::trace::{
     BatchConfig, BatchConfigBuilder, BatchSpanProcessor, Sampler, SdkTracerProvider,
     SpanExporter as SdkSpanExporter, Tracer,
 };
-use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
 use thiserror::Error;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::Registry;
@@ -216,14 +239,29 @@ fn build_otlp_exporter(
 ) -> Result<OtlpSpanExporter, TraceInitError> {
     let timeout = Duration::from_millis(cfg.export_timeout_ms);
     match protocol {
-        OtlpProtocol::Grpc => Err(TraceInitError::OtlpBuildError(
-            "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => OtlpSpanExporter::builder()
-            .with_http()
-            .with_endpoint(endpoint.to_string())
+        OtlpProtocol::Grpc => {
+            #[cfg(feature = "metrics-otlp-grpc")]
+            {
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint(endpoint.to_owned())
+                    .with_timeout(timeout)
+                    .build_span_exporter()
+                    .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
+            }
+            #[cfg(not(feature = "metrics-otlp-grpc"))]
+            {
+                Err(TraceInitError::OtlpBuildError(
+                    "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                        .into(),
+                ))
+            }
+        }
+        OtlpProtocol::Http => opentelemetry_otlp::new_exporter()
+            .http()
+            .with_endpoint(endpoint.to_owned())
             .with_timeout(timeout)
-            .build()
+            .build_span_exporter()
             .map_err(|err| TraceInitError::OtlpBuildError(err.to_string())),
     }
 }
@@ -234,30 +272,6 @@ fn build_batch_config(cfg: &TraceConfig) -> BatchConfig {
         .with_max_export_batch_size(cfg.max_export_batch_size)
         .with_scheduled_delay(Duration::from_millis(cfg.scheduled_delay_ms))
         .build()
-}
-
-#[cfg(feature = "grpc-tonic")]
-fn build_grpc_exporter(endpoint: &str, timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    opentelemetry_otlp::TonicExporterBuilder::default()
-        .with_endpoint(endpoint.to_string())
-        .with_timeout(timeout)
-        .build_span_exporter()
-        .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
-}
-
-#[cfg(not(feature = "grpc-tonic"))]
-fn build_grpc_exporter(_endpoint: &str, _timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    Err(TraceInitError::OtlpBuildError(
-        "opentelemetry-otlp built without gRPC support".to_string(),
-    ))
-}
-
-fn build_http_exporter(endpoint: &str, timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    opentelemetry_otlp::HttpExporterBuilder::default()
-        .with_endpoint(endpoint.to_string())
-        .with_timeout(timeout)
-        .build_span_exporter()
-        .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
 }
 
 fn build_resource(pairs: ResourcePairs) -> Result<Resource, TraceInitError> {


### PR DESCRIPTION
## Summary
- wrap `opentelemetry_otlp::new_exporter()` in the trace module to build HTTP and gRPC exporters with the 0.29 span exporter API
- update the OTLP trace exporter construction to honor timeouts for both transports and drop the legacy builder helpers
- disable default OTLP features and forward the `metrics-otlp-grpc` feature to `opentelemetry-otlp`

## Testing
- `cargo check` *(fails: CONNECT tunnel 403 while fetching crates)*
- `cargo check --features metrics-otlp-grpc` *(fails: CONNECT tunnel 403 while fetching crates)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c57d32408330b32ce4ed6dd8eb49