### PR TITLE
Pin prometheus dependencies and enable OTLP gRPC feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendo
 once_cell = "1"
 thiserror = "2.0.16"
 regex = "1"
-prometheus = "*"
-opentelemetry-prometheus = "*"
+prometheus = "0.14"
+opentelemetry-prometheus = "0.29.1"
 serde_json = "1"
 
 [dev-dependencies]
@@ -54,4 +54,5 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["grpc-tonic"]
+grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]


### PR DESCRIPTION
## Summary
- pin the prometheus and opentelemetry-prometheus dependencies to their intended versions
- wire the metrics-otlp-grpc feature to propagate the opentelemetry-otlp gRPC exporter feature

## Testing
- cargo check --features metrics-otlp-grpc *(fails: crates.io 403 while downloading `hyper-timeout`)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c57efa2c833098e796a557d5fd99