### PR TITLE
Update obs1 postsync validation script

### DIFF
--- a/scripts/obs1_postsync_validate.sh
+++ b/scripts/obs1_postsync_validate.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 mkdir -p out/diagnostics
+
 RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt
 cargo clean
 cargo build -q
 cargo test --no-run 2>&1 | tee out/diagnostics/test-norun-sync.txt || true
 cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt || true
-if grep -R "cfg(feature = \"obs\")" -n src tests >/dev/null 2>&1; then
+
+if rg --files-with-matches 'cfg\(feature = "obs"\)' src tests >/dev/null 2>&1; then
   cargo test --features obs -q 2>&1 | tee -a out/diagnostics/test-run-sync.txt || true
 fi
-sed -n '1,60p' out/diagnostics/check-sync.txt || true
-sed -n '1,60p' out/diagnostics/test-norun-sync.txt || true
-sed -n '1,60p' out/diagnostics/test-run-sync.txt || true
+
+tail -n 80 out/diagnostics/check-sync.txt || true
+tail -n 80 out/diagnostics/test-norun-sync.txt || true
+tail -n 80 out/diagnostics/test-run-sync.txt || true


### PR DESCRIPTION
## Summary
- update the obs1 postsync validation script to use the requested ripgrep feature probe while preserving the existing command order
- replace the sed log previews with tail -n 80 so the latest diagnostics are shown

## Testing
- ./scripts/obs1_postsync_validate.sh *(fails: existing cargo check compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c57faae883308930453ae990c2ef