### PR TITLE
Refine OTLP span exporter setup for traces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,7 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
+
+[patch.crates-io]
+hyper-timeout = { path = "vendor/hyper-timeout" }

--- a/src/telemetry_trace.rs
+++ b/src/telemetry_trace.rs
@@ -6,21 +6,105 @@ use std::panic;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use self::opentelemetry_otlp::SpanExporter as OtlpSpanExporter;
 use opentelemetry::global;
 use opentelemetry::propagation::TextMapCompositePropagator;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::KeyValue;
-use opentelemetry_otlp::{SpanExporter as OtlpSpanExporter, WithExportConfig};
 use opentelemetry_sdk::error::OTelSdkError;
+use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
 use opentelemetry_sdk::resource::Resource;
 use opentelemetry_sdk::trace::{
     BatchConfig, BatchConfigBuilder, BatchSpanProcessor, Sampler, SdkTracerProvider,
     SpanExporter as SdkSpanExporter, Tracer,
 };
-use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
 use thiserror::Error;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::Registry;
+
+mod opentelemetry_otlp {
+    use std::time::Duration;
+
+    pub use ::opentelemetry_otlp::*;
+
+    #[derive(Clone, Copy)]
+    enum ExporterKind {
+        Grpc,
+        Http,
+    }
+
+    pub struct SpanExporterBuilderCompat {
+        kind: Option<ExporterKind>,
+        endpoint: Option<String>,
+        timeout: Option<Duration>,
+    }
+
+    impl SpanExporterBuilderCompat {
+        pub fn tonic(mut self) -> Self {
+            self.kind = Some(ExporterKind::Grpc);
+            self
+        }
+
+        pub fn http(mut self) -> Self {
+            self.kind = Some(ExporterKind::Http);
+            self
+        }
+
+        pub fn with_endpoint(mut self, endpoint: String) -> Self {
+            self.endpoint = Some(endpoint);
+            self
+        }
+
+        pub fn with_timeout(mut self, timeout: Duration) -> Self {
+            self.timeout = Some(timeout);
+            self
+        }
+
+        pub fn build_span_exporter(self) -> Result<SpanExporter, ExporterBuildError> {
+            match self.kind.unwrap_or(ExporterKind::Http) {
+                ExporterKind::Grpc => {
+                    #[cfg(feature = "metrics-otlp-grpc")]
+                    {
+                        let mut builder =
+                            ::opentelemetry_otlp::SpanExporter::builder().with_tonic();
+                        if let Some(endpoint) = self.endpoint {
+                            builder = builder.with_endpoint(endpoint);
+                        }
+                        if let Some(timeout) = self.timeout {
+                            builder = builder.with_timeout(timeout);
+                        }
+                        builder.build_span_exporter()
+                    }
+                    #[cfg(not(feature = "metrics-otlp-grpc"))]
+                    {
+                        Err(ExporterBuildError::InternalFailure(
+                            "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                                .into(),
+                        ))
+                    }
+                }
+                ExporterKind::Http => {
+                    let mut builder = ::opentelemetry_otlp::SpanExporter::builder().with_http();
+                    if let Some(endpoint) = self.endpoint {
+                        builder = builder.with_endpoint(endpoint);
+                    }
+                    if let Some(timeout) = self.timeout {
+                        builder = builder.with_timeout(timeout);
+                    }
+                    builder.build_span_exporter()
+                }
+            }
+        }
+    }
+
+    pub fn new_exporter() -> SpanExporterBuilderCompat {
+        SpanExporterBuilderCompat {
+            kind: None,
+            endpoint: None,
+            timeout: None,
+        }
+    }
+}
 
 const REQUIRED_RESOURCE_KEYS: [&str; 3] =
     ["service.name", "service.version", "deployment.environment"];
@@ -216,14 +300,28 @@ fn build_otlp_exporter(
 ) -> Result<OtlpSpanExporter, TraceInitError> {
     let timeout = Duration::from_millis(cfg.export_timeout_ms);
     match protocol {
-        OtlpProtocol::Grpc => Err(TraceInitError::OtlpBuildError(
-            "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => OtlpSpanExporter::builder()
-            .with_http()
+        OtlpProtocol::Grpc => {
+            #[cfg(feature = "metrics-otlp-grpc")]
+            {
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint(endpoint.to_string())
+                    .with_timeout(timeout)
+                    .build_span_exporter()
+                    .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
+            }
+            #[cfg(not(feature = "metrics-otlp-grpc"))]
+            {
+                Err(TraceInitError::OtlpBuildError(
+                    "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
+                ))
+            }
+        }
+        OtlpProtocol::Http => opentelemetry_otlp::new_exporter()
+            .http()
             .with_endpoint(endpoint.to_string())
             .with_timeout(timeout)
-            .build()
+            .build_span_exporter()
             .map_err(|err| TraceInitError::OtlpBuildError(err.to_string())),
     }
 }
@@ -234,30 +332,6 @@ fn build_batch_config(cfg: &TraceConfig) -> BatchConfig {
         .with_max_export_batch_size(cfg.max_export_batch_size)
         .with_scheduled_delay(Duration::from_millis(cfg.scheduled_delay_ms))
         .build()
-}
-
-#[cfg(feature = "grpc-tonic")]
-fn build_grpc_exporter(endpoint: &str, timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    opentelemetry_otlp::TonicExporterBuilder::default()
-        .with_endpoint(endpoint.to_string())
-        .with_timeout(timeout)
-        .build_span_exporter()
-        .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
-}
-
-#[cfg(not(feature = "grpc-tonic"))]
-fn build_grpc_exporter(_endpoint: &str, _timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    Err(TraceInitError::OtlpBuildError(
-        "opentelemetry-otlp built without gRPC support".to_string(),
-    ))
-}
-
-fn build_http_exporter(endpoint: &str, timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    opentelemetry_otlp::HttpExporterBuilder::default()
-        .with_endpoint(endpoint.to_string())
-        .with_timeout(timeout)
-        .build_span_exporter()
-        .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
 }
 
 fn build_resource(pairs: ResourcePairs) -> Result<Resource, TraceInitError> {


### PR DESCRIPTION
## Summary
- wrap `opentelemetry-otlp` span exporter construction behind a compatibility builder that exposes `new_exporter().http()/tonic()`
- apply TraceConfig endpoint/timeout to both HTTP and gRPC exporters and remove the legacy helper functions
- gate gRPC exporter support on the local `metrics-otlp-grpc` feature and vendor `hyper-timeout` for offline builds

## Testing
- cargo check --all-targets --all-features *(fails: network access to crates.io blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c79e52188330bebb597bd8a4f960