### PR TITLE
Update obs1 postsync validation command sequence

### DIFF
--- a/out/diagnostics/check-sync.txt
+++ b/out/diagnostics/check-sync.txt
@@ -1,14 +1,41 @@
-    Updating crates.io index
-warning: spurious network error (3 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
-warning: spurious network error (2 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
-warning: spurious network error (1 try remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
-error: failed to get `hyper` as a dependency of package `credit-engine-core v0.1.0 (/workspace/trendmarket)`
+    Checking credit-engine-core v0.1.0 (/workspace/trendmarket)
+    Checking oorandom v11.1.5
+    Checking criterion v0.5.1
+error[E0425]: cannot find value `reader` in this scope
+  --> src/telemetry_metrics_prom.rs:87:75
+   |
+87 |     let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
+   |                                                                           ^^^^^^ not found in this scope
 
-Caused by:
-  download of config.json failed
+error[E0599]: no method named `with_tonic` found for struct `opentelemetry_otlp::metric::MetricExporterBuilder` in the current scope
+  --> src/telemetry_metrics_otlp.rs:54:77
+   |
+54 | ...                   ::opentelemetry_otlp::MetricExporter::builder().with_tonic();
+   |                                                                       ^^^^^^^^^^ method not found in `opentelemetry_otlp::metric::MetricExporterBuilder<NoExporterBuilderSet>`
 
-Caused by:
-  failed to download from `https://index.crates.io/config.json`
+error[E0599]: no method named `with_endpoint` found for struct `opentelemetry_otlp::metric::MetricExporterBuilder` in the current scope
+   --> src/telemetry_metrics_otlp.rs:264:14
+    |
+262 |           OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
+    |  _______________________________-
+263 | |             .with_http()
+264 | |             .with_endpoint(endpoint.to_string())
+    | |             -^^^^^^^^^^^^^ method not found in `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>`
+    | |_____________|
+    |
+    |
+   ::: /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-otlp-0.29.0/src/exporter/mod.rs:233:8
+    |
+233 |       fn with_endpoint<T: Into<String>>(self, endpoint: T) -> Self;
+    |          ------------- the method is available for `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>` here
+    |
+    = help: items from traits can only be used if the trait is in scope
+help: trait `WithExportConfig` which provides `with_endpoint` is implemented but not in scope; perhaps you want to import it
+    |
+1   + use opentelemetry_otlp::WithExportConfig;
+    |
 
-Caused by:
-  [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+Some errors have detailed explanations: E0425, E0599.
+For more information about an error, try `rustc --explain E0425`.
+error: could not compile `credit-engine-core` (lib) due to 3 previous errors
+warning: build failed, waiting for other jobs to finish...

--- a/out/diagnostics/test-norun-sync.txt
+++ b/out/diagnostics/test-norun-sync.txt
@@ -1,0 +1,202 @@
+   Compiling proc-macro2 v1.0.101
+   Compiling unicode-ident v1.0.19
+   Compiling libc v0.2.175
+   Compiling quote v1.0.40
+   Compiling cfg-if v1.0.3
+   Compiling once_cell v1.21.3
+   Compiling syn v2.0.106
+   Compiling memchr v2.7.5
+   Compiling pin-project-lite v0.2.16
+   Compiling futures-core v0.3.31
+   Compiling itoa v1.0.15
+   Compiling bytes v1.10.1
+   Compiling stable_deref_trait v1.2.0
+   Compiling serde_core v1.0.222
+   Compiling futures-sink v0.3.31
+   Compiling smallvec v1.15.1
+   Compiling fnv v1.0.7
+   Compiling synstructure v0.13.2
+   Compiling tokio-macros v2.5.0
+   Compiling zerofrom-derive v0.1.6
+   Compiling yoke-derive v0.8.0
+   Compiling zerofrom v0.1.6
+   Compiling zerovec-derive v0.11.1
+   Compiling yoke v0.8.0
+   Compiling socket2 v0.6.0
+   Compiling mio v1.0.4
+   Compiling getrandom v0.3.3
+   Compiling zerovec v0.11.4
+   Compiling tokio v1.47.1
+   Compiling displaydoc v0.2.5
+   Compiling tracing-core v0.1.34
+   Compiling pin-utils v0.1.0
+   Compiling futures-macro v0.3.31
+   Compiling tracing-attributes v0.1.30
+   Compiling percent-encoding v2.3.2
+   Compiling futures-io v0.3.31
+   Compiling slab v0.4.11
+   Compiling futures-task v0.3.31
+   Compiling tracing v0.1.41
+   Compiling futures-util v0.3.31
+   Compiling ryu v1.0.20
+   Compiling zerocopy v0.8.27
+   Compiling tinystr v0.8.1
+   Compiling http v1.3.1
+   Compiling litemap v0.8.0
+   Compiling thiserror v2.0.16
+   Compiling writeable v0.6.1
+   Compiling serde v1.0.222
+   Compiling icu_locale_core v2.0.0
+   Compiling http-body v1.0.1
+   Compiling rand_core v0.9.3
+   Compiling zerotrie v0.2.2
+   Compiling potential_utf v0.1.3
+   Compiling serde_derive v1.0.222
+   Compiling thiserror-impl v2.0.16
+   Compiling futures-channel v0.3.31
+   Compiling icu_normalizer_data v2.0.0
+   Compiling serde_json v1.0.145
+   Compiling icu_properties_data v2.0.1
+   Compiling ppv-lite86 v0.2.21
+   Compiling icu_collections v2.0.0
+   Compiling icu_provider v2.0.0
+   Compiling either v1.15.0
+   Compiling bitflags v2.9.4
+   Compiling tower-service v0.3.3
+   Compiling itertools v0.10.5
+   Compiling rand_chacha v0.9.0
+   Compiling tower-layer v0.3.3
+   Compiling anyhow v1.0.99
+   Compiling regex-syntax v0.8.6
+   Compiling httparse v1.10.1
+   Compiling icu_properties v2.0.1
+   Compiling icu_normalizer v2.0.0
+   Compiling rand v0.9.2
+   Compiling opentelemetry v0.29.1
+   Compiling tokio-stream v0.1.17
+   Compiling aho-corasick v1.1.3
+   Compiling try-lock v0.2.5
+   Compiling base64 v0.22.1
+   Compiling log v0.4.28
+   Compiling thiserror v1.0.69
+   Compiling lazy_static v1.5.0
+   Compiling regex-automata v0.4.10
+   Compiling want v0.3.1
+   Compiling idna_adapter v1.2.1
+   Compiling http-body-util v0.1.3
+   Compiling futures-executor v0.3.31
+   Compiling form_urlencoded v1.2.2
+   Compiling thiserror-impl v1.0.69
+   Compiling sync_wrapper v1.0.2
+   Compiling glob v0.3.3
+   Compiling atomic-waker v1.1.2
+   Compiling parking_lot_core v0.9.12
+   Compiling httpdate v1.0.3
+   Compiling utf8_iter v1.0.4
+   Compiling idna v1.1.0
+   Compiling hyper v1.7.0
+   Compiling opentelemetry_sdk v0.29.0
+   Compiling tower v0.5.2
+   Compiling prost-derive v0.13.5
+   Compiling pin-project-internal v1.1.10
+   Compiling async-trait v0.1.89
+   Compiling iri-string v0.7.8
+   Compiling scopeguard v1.2.0
+   Compiling protobuf v3.7.2
+   Compiling ipnet v2.11.0
+   Compiling hyper-util v0.1.17
+   Compiling tower-http v0.6.6
+   Compiling lock_api v0.4.14
+   Compiling pin-project v1.1.10
+   Compiling prost v0.13.5
+   Compiling protobuf-support v3.7.2
+   Compiling url v2.5.7
+   Compiling serde_urlencoded v0.7.1
+   Compiling autocfg v1.5.0
+   Compiling crunchy v0.2.4
+   Compiling prometheus v0.14.0
+   Compiling rustix v1.1.2
+   Compiling num-traits v0.2.19
+   Compiling reqwest v0.12.23
+   Compiling parking_lot v0.12.5
+   Compiling tonic v0.12.3
+   Compiling matchers v0.2.0
+   Compiling sharded-slab v0.1.7
+   Compiling tracing-log v0.2.0
+   Compiling thread_local v1.1.9
+   Compiling linux-raw-sys v0.11.0
+   Compiling nu-ansi-term v0.50.1
+   Compiling tracing-subscriber v0.3.20
+   Compiling opentelemetry-proto v0.29.0
+   Compiling opentelemetry-http v0.29.0
+   Compiling regex v1.11.2
+   Compiling half v2.6.0
+   Compiling static_assertions v1.1.0
+   Compiling anstyle v1.0.11
+   Compiling ciborium-io v0.2.2
+   Compiling clap_lex v0.7.5
+   Compiling hex v0.4.3
+   Compiling credit-engine-core v0.1.0 (/workspace/trendmarket)
+   Compiling byteorder v1.5.0
+   Compiling fastrand v2.3.0
+   Compiling tempfile v3.22.0
+   Compiling uint v0.9.5
+   Compiling clap_builder v4.5.47
+   Compiling ciborium-ll v0.2.2
+   Compiling opentelemetry-otlp v0.29.0
+   Compiling opentelemetry-prometheus v0.29.1
+   Compiling tracing-opentelemetry v0.30.0
+   Compiling metrics v0.21.0 (/workspace/trendmarket/vendor/metrics)
+   Compiling wait-timeout v0.2.1
+   Compiling httpdate v1.0.0 (/workspace/trendmarket/vendor/httpdate)
+   Compiling same-file v1.0.6
+   Compiling cast v0.3.0
+   Compiling quick-error v1.2.3
+   Compiling bit-vec v0.8.0
+   Compiling criterion-plot v0.5.0
+   Compiling bit-set v0.8.0
+   Compiling rusty-fork v0.3.0
+   Compiling walkdir v2.5.0
+   Compiling clap v4.5.47
+   Compiling ciborium v0.2.2
+   Compiling tinytemplate v1.2.1
+   Compiling rand_xorshift v0.4.0
+   Compiling is-terminal v0.4.16
+   Compiling anes v0.1.6
+   Compiling unarray v0.1.4
+   Compiling oorandom v11.1.5
+   Compiling criterion v0.5.1
+   Compiling proptest v1.7.0
+error[E0425]: cannot find value `reader` in this scope
+  --> src/telemetry_metrics_prom.rs:87:75
+   |
+87 |     let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
+   |                                                                           ^^^^^^ not found in this scope
+
+error[E0599]: no method named `with_endpoint` found for struct `opentelemetry_otlp::metric::MetricExporterBuilder` in the current scope
+   --> src/telemetry_metrics_otlp.rs:264:14
+    |
+262 |           OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
+    |  _______________________________-
+263 | |             .with_http()
+264 | |             .with_endpoint(endpoint.to_string())
+    | |             -^^^^^^^^^^^^^ method not found in `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>`
+    | |_____________|
+    |
+    |
+   ::: /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-otlp-0.29.0/src/exporter/mod.rs:233:8
+    |
+233 |       fn with_endpoint<T: Into<String>>(self, endpoint: T) -> Self;
+    |          ------------- the method is available for `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>` here
+    |
+    = help: items from traits can only be used if the trait is in scope
+help: trait `WithExportConfig` which provides `with_endpoint` is implemented but not in scope; perhaps you want to import it
+    |
+1   + use opentelemetry_otlp::WithExportConfig;
+    |
+
+Some errors have detailed explanations: E0425, E0599.
+For more information about an error, try `rustc --explain E0425`.
+error: could not compile `credit-engine-core` (lib) due to 2 previous errors
+warning: build failed, waiting for other jobs to finish...
+error: could not compile `credit-engine-core` (lib test) due to 2 previous errors

--- a/out/diagnostics/test-run-sync.txt
+++ b/out/diagnostics/test-run-sync.txt
@@ -1,0 +1,64 @@
+error[E0425]: cannot find value `reader` in this scope
+  --> src/telemetry_metrics_prom.rs:87:75
+   |
+87 |     let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
+   |                                                                           ^^^^^^ not found in this scope
+
+error[E0599]: no method named `with_endpoint` found for struct `opentelemetry_otlp::metric::MetricExporterBuilder` in the current scope
+   --> src/telemetry_metrics_otlp.rs:264:14
+    |
+262 |           OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
+    |  _______________________________-
+263 | |             .with_http()
+264 | |             .with_endpoint(endpoint.to_string())
+    | |             -^^^^^^^^^^^^^ method not found in `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>`
+    | |_____________|
+    |
+    |
+   ::: /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-otlp-0.29.0/src/exporter/mod.rs:233:8
+    |
+233 |       fn with_endpoint<T: Into<String>>(self, endpoint: T) -> Self;
+    |          ------------- the method is available for `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>` here
+    |
+    = help: items from traits can only be used if the trait is in scope
+help: trait `WithExportConfig` which provides `with_endpoint` is implemented but not in scope; perhaps you want to import it
+    |
+1   + use opentelemetry_otlp::WithExportConfig;
+    |
+
+Some errors have detailed explanations: E0425, E0599.
+For more information about an error, try `rustc --explain E0425`.
+error: could not compile `credit-engine-core` (lib) due to 2 previous errors
+error: could not compile `credit-engine-core` (lib test) due to 2 previous errors
+error[E0425]: cannot find value `reader` in this scope
+  --> src/telemetry_metrics_prom.rs:87:75
+   |
+87 |     let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
+   |                                                                           ^^^^^^ not found in this scope
+
+error[E0599]: no method named `with_endpoint` found for struct `opentelemetry_otlp::metric::MetricExporterBuilder` in the current scope
+   --> src/telemetry_metrics_otlp.rs:264:14
+    |
+262 |           OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
+    |  _______________________________-
+263 | |             .with_http()
+264 | |             .with_endpoint(endpoint.to_string())
+    | |             -^^^^^^^^^^^^^ method not found in `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>`
+    | |_____________|
+    |
+    |
+   ::: /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-otlp-0.29.0/src/exporter/mod.rs:233:8
+    |
+233 |       fn with_endpoint<T: Into<String>>(self, endpoint: T) -> Self;
+    |          ------------- the method is available for `opentelemetry_otlp::metric::MetricExporterBuilder<HttpExporterBuilderSet>` here
+    |
+    = help: items from traits can only be used if the trait is in scope
+help: trait `WithExportConfig` which provides `with_endpoint` is implemented but not in scope; perhaps you want to import it
+    |
+1   + use opentelemetry_otlp::WithExportConfig;
+    |
+
+Some errors have detailed explanations: E0425, E0599.
+For more information about an error, try `rustc --explain E0425`.
+error: could not compile `credit-engine-core` (lib) due to 2 previous errors
+error: could not compile `credit-engine-core` (lib test) due to 2 previous errors

--- a/scripts/obs1_postsync_validate.sh
+++ b/scripts/obs1_postsync_validate.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 mkdir -p out/diagnostics
-RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt
-cargo clean
-cargo build -q
+
+RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt || true
 cargo test --no-run 2>&1 | tee out/diagnostics/test-norun-sync.txt || true
 cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt || true
-if grep -R "cfg(feature = \"obs\")" -n src tests >/dev/null 2>&1; then
+if rg --quiet 'cfg\(feature = "obs"\)' src tests; then
   cargo test --features obs -q 2>&1 | tee -a out/diagnostics/test-run-sync.txt || true
 fi
-sed -n '1,60p' out/diagnostics/check-sync.txt || true
-sed -n '1,60p' out/diagnostics/test-norun-sync.txt || true
-sed -n '1,60p' out/diagnostics/test-run-sync.txt || true
+
+tail -n 80 out/diagnostics/check-sync.txt || true
+tail -n 80 out/diagnostics/test-norun-sync.txt || true
+tail -n 80 out/diagnostics/test-run-sync.txt || true


### PR DESCRIPTION
## Summary
- replace the postsync validation script body with the required command sequence, including the ripgrep guard and tail-based diagnostics
- regenerate the sync diagnostics artifacts with the new workflow output

## Testing
- ./scripts/obs1_postsync_validate.sh

------
https://chatgpt.com/codex/tasks/task_e_68e0c7a29cb48330929c32e1790bc9a5