### PR TITLE
Remove OTLP shim and use upstream metrics exporter builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ prometheus = "*"
 opentelemetry-prometheus = "*"
 serde_json = "1"
 
+[patch.crates-io]
+hyper-timeout = { path = "vendor/hyper-timeout" }
+
 [dev-dependencies]
 proptest = "1"
 criterion = { version = "0.5", default-features = false }
@@ -54,4 +57,4 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]

--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -1,94 +1,11 @@
 use std::{collections::HashMap, time::Duration};
 
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
+use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::Resource;
 use thiserror::Error;
 use tracing::warn;
-
-mod opentelemetry_otlp {
-    use std::time::Duration;
-
-    use ::opentelemetry_otlp::WithExportConfig;
-    pub use ::opentelemetry_otlp::*;
-
-    #[derive(Clone, Copy)]
-    enum ExporterKind {
-        Grpc,
-        Http,
-    }
-
-    pub struct MetricExporterBuilderCompat {
-        kind: Option<ExporterKind>,
-        endpoint: Option<String>,
-        timeout: Option<Duration>,
-    }
-
-    impl MetricExporterBuilderCompat {
-        pub fn tonic(mut self) -> Self {
-            self.kind = Some(ExporterKind::Grpc);
-            self
-        }
-
-        pub fn http(mut self) -> Self {
-            self.kind = Some(ExporterKind::Http);
-            self
-        }
-
-        pub fn with_endpoint(mut self, endpoint: String) -> Self {
-            self.endpoint = Some(endpoint);
-            self
-        }
-
-        pub fn with_timeout(mut self, timeout: Duration) -> Self {
-            self.timeout = Some(timeout);
-            self
-        }
-
-        pub fn build_metric_exporter(self) -> Result<MetricExporter, ExporterBuildError> {
-            match self.kind.unwrap_or(ExporterKind::Http) {
-                ExporterKind::Grpc => {
-                    #[cfg(feature = "metrics-otlp-grpc")]
-                    {
-                        let mut builder =
-                            ::opentelemetry_otlp::MetricExporter::builder().with_tonic();
-                        if let Some(endpoint) = self.endpoint {
-                            builder = builder.with_endpoint(endpoint);
-                        }
-                        if let Some(timeout) = self.timeout {
-                            builder = builder.with_timeout(timeout);
-                        }
-                        builder.build()
-                    }
-                    #[cfg(not(feature = "metrics-otlp-grpc"))]
-                    {
-                        Err(ExporterBuildError::InternalFailure(
-                            "gRPC metrics exporter support is not enabled".into(),
-                        ))
-                    }
-                }
-                ExporterKind::Http => {
-                    let mut builder = ::opentelemetry_otlp::MetricExporter::builder().with_http();
-                    if let Some(endpoint) = self.endpoint {
-                        builder = builder.with_endpoint(endpoint);
-                    }
-                    if let Some(timeout) = self.timeout {
-                        builder = builder.with_timeout(timeout);
-                    }
-                    builder.build()
-                }
-            }
-        }
-    }
-
-    pub fn new_exporter() -> MetricExporterBuilderCompat {
-        MetricExporterBuilderCompat {
-            kind: None,
-            endpoint: None,
-            timeout: None,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObsLevel {
@@ -253,13 +170,28 @@ fn build_otlp_exporter(
     endpoint: &str,
     protocol: OtlpProtocol,
     export_timeout_ms: u64,
-) -> Result<opentelemetry_otlp::MetricExporter, MetricsInitError> {
+) -> Result<MetricExporter, MetricsInitError> {
     let timeout = Duration::from_millis(export_timeout_ms);
+
     match protocol {
-        OtlpProtocol::Grpc => Err(MetricsInitError::OtlpBuildError(
-            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
+        OtlpProtocol::Grpc => {
+            #[cfg(feature = "metrics-otlp-grpc")]
+            {
+                MetricExporter::builder()
+                    .with_tonic()
+                    .with_endpoint(endpoint.to_string())
+                    .with_timeout(timeout)
+                    .build()
+                    .map_err(|err| MetricsInitError::OtlpBuildError(err.to_string()))
+            }
+            #[cfg(not(feature = "metrics-otlp-grpc"))]
+            {
+                Err(MetricsInitError::OtlpBuildError(
+                    "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
+                ))
+            }
+        }
+        OtlpProtocol::Http => MetricExporter::builder()
             .with_http()
             .with_endpoint(endpoint.to_string())
             .with_timeout(timeout)
@@ -269,9 +201,9 @@ fn build_otlp_exporter(
 }
 
 fn build_periodic_reader(
-    exporter: opentelemetry_otlp::MetricExporter,
+    exporter: MetricExporter,
     export_interval_ms: u64,
-) -> PeriodicReader<opentelemetry_otlp::MetricExporter> {
+) -> PeriodicReader<MetricExporter> {
     let interval = Duration::from_millis(export_interval_ms);
 
     PeriodicReader::builder(exporter)


### PR DESCRIPTION
## Summary
- remove the local `opentelemetry_otlp` shim and construct OTLP metric exporters via the upstream builder API
- wire the gRPC exporter path through the real builder behind the `metrics-otlp-grpc` feature and patch `hyper-timeout` to the vendored crate for offline builds

## Testing
- `cargo fmt`
- `cargo check --all-targets --all-features` *(fails: unable to download crates such as h2 in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c9ec29b883308f883583437b1b42