### PR TITLE
Refactor OTLP exporter builders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
 httpdate = { version = "1", path = "vendor/httpdate" }
 opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
+opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tracing = "0.1"
@@ -54,4 +54,7 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
+
+[patch.crates-io]
+hyper-timeout = { path = "vendor/hyper-timeout" }

--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -1,94 +1,11 @@
 use std::{collections::HashMap, time::Duration};
 
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider, Temporality};
 use opentelemetry_sdk::Resource;
 use thiserror::Error;
 use tracing::warn;
-
-mod opentelemetry_otlp {
-    use std::time::Duration;
-
-    use ::opentelemetry_otlp::WithExportConfig;
-    pub use ::opentelemetry_otlp::*;
-
-    #[derive(Clone, Copy)]
-    enum ExporterKind {
-        Grpc,
-        Http,
-    }
-
-    pub struct MetricExporterBuilderCompat {
-        kind: Option<ExporterKind>,
-        endpoint: Option<String>,
-        timeout: Option<Duration>,
-    }
-
-    impl MetricExporterBuilderCompat {
-        pub fn tonic(mut self) -> Self {
-            self.kind = Some(ExporterKind::Grpc);
-            self
-        }
-
-        pub fn http(mut self) -> Self {
-            self.kind = Some(ExporterKind::Http);
-            self
-        }
-
-        pub fn with_endpoint(mut self, endpoint: String) -> Self {
-            self.endpoint = Some(endpoint);
-            self
-        }
-
-        pub fn with_timeout(mut self, timeout: Duration) -> Self {
-            self.timeout = Some(timeout);
-            self
-        }
-
-        pub fn build_metric_exporter(self) -> Result<MetricExporter, ExporterBuildError> {
-            match self.kind.unwrap_or(ExporterKind::Http) {
-                ExporterKind::Grpc => {
-                    #[cfg(feature = "metrics-otlp-grpc")]
-                    {
-                        let mut builder =
-                            ::opentelemetry_otlp::MetricExporter::builder().with_tonic();
-                        if let Some(endpoint) = self.endpoint {
-                            builder = builder.with_endpoint(endpoint);
-                        }
-                        if let Some(timeout) = self.timeout {
-                            builder = builder.with_timeout(timeout);
-                        }
-                        builder.build()
-                    }
-                    #[cfg(not(feature = "metrics-otlp-grpc"))]
-                    {
-                        Err(ExporterBuildError::InternalFailure(
-                            "gRPC metrics exporter support is not enabled".into(),
-                        ))
-                    }
-                }
-                ExporterKind::Http => {
-                    let mut builder = ::opentelemetry_otlp::MetricExporter::builder().with_http();
-                    if let Some(endpoint) = self.endpoint {
-                        builder = builder.with_endpoint(endpoint);
-                    }
-                    if let Some(timeout) = self.timeout {
-                        builder = builder.with_timeout(timeout);
-                    }
-                    builder.build()
-                }
-            }
-        }
-    }
-
-    pub fn new_exporter() -> MetricExporterBuilderCompat {
-        MetricExporterBuilderCompat {
-            kind: None,
-            endpoint: None,
-            timeout: None,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObsLevel {
@@ -256,14 +173,27 @@ fn build_otlp_exporter(
 ) -> Result<opentelemetry_otlp::MetricExporter, MetricsInitError> {
     let timeout = Duration::from_millis(export_timeout_ms);
     match protocol {
-        OtlpProtocol::Grpc => Err(MetricsInitError::OtlpBuildError(
-            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
-            .with_http()
+        OtlpProtocol::Grpc => {
+            #[cfg(feature = "metrics-otlp-grpc")]
+            {
+                opentelemetry_otlp::TonicExporterBuilder::default()
+                    .with_endpoint(endpoint.to_string())
+                    .with_timeout(timeout)
+                    .build_metrics_exporter(Temporality::Cumulative)
+                    .map_err(|err| MetricsInitError::OtlpBuildError(err.to_string()))
+            }
+            #[cfg(not(feature = "metrics-otlp-grpc"))]
+            {
+                Err(MetricsInitError::OtlpBuildError(
+                    "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                        .into(),
+                ))
+            }
+        }
+        OtlpProtocol::Http => opentelemetry_otlp::HttpExporterBuilder::default()
             .with_endpoint(endpoint.to_string())
             .with_timeout(timeout)
-            .build()
+            .build_metrics_exporter(Temporality::Cumulative)
             .map_err(|err| MetricsInitError::OtlpBuildError(err.to_string())),
     }
 }

--- a/src/telemetry_trace.rs
+++ b/src/telemetry_trace.rs
@@ -216,14 +216,27 @@ fn build_otlp_exporter(
 ) -> Result<OtlpSpanExporter, TraceInitError> {
     let timeout = Duration::from_millis(cfg.export_timeout_ms);
     match protocol {
-        OtlpProtocol::Grpc => Err(TraceInitError::OtlpBuildError(
-            "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
-        )),
-        OtlpProtocol::Http => OtlpSpanExporter::builder()
-            .with_http()
+        OtlpProtocol::Grpc => {
+            #[cfg(feature = "metrics-otlp-grpc")]
+            {
+                opentelemetry_otlp::TonicExporterBuilder::default()
+                    .with_endpoint(endpoint.to_string())
+                    .with_timeout(timeout)
+                    .build_span_exporter()
+                    .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
+            }
+            #[cfg(not(feature = "metrics-otlp-grpc"))]
+            {
+                Err(TraceInitError::OtlpBuildError(
+                    "gRPC trace exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                        .into(),
+                ))
+            }
+        }
+        OtlpProtocol::Http => opentelemetry_otlp::HttpExporterBuilder::default()
             .with_endpoint(endpoint.to_string())
             .with_timeout(timeout)
-            .build()
+            .build_span_exporter()
             .map_err(|err| TraceInitError::OtlpBuildError(err.to_string())),
     }
 }
@@ -234,30 +247,6 @@ fn build_batch_config(cfg: &TraceConfig) -> BatchConfig {
         .with_max_export_batch_size(cfg.max_export_batch_size)
         .with_scheduled_delay(Duration::from_millis(cfg.scheduled_delay_ms))
         .build()
-}
-
-#[cfg(feature = "grpc-tonic")]
-fn build_grpc_exporter(endpoint: &str, timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    opentelemetry_otlp::TonicExporterBuilder::default()
-        .with_endpoint(endpoint.to_string())
-        .with_timeout(timeout)
-        .build_span_exporter()
-        .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
-}
-
-#[cfg(not(feature = "grpc-tonic"))]
-fn build_grpc_exporter(_endpoint: &str, _timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    Err(TraceInitError::OtlpBuildError(
-        "opentelemetry-otlp built without gRPC support".to_string(),
-    ))
-}
-
-fn build_http_exporter(endpoint: &str, timeout: Duration) -> Result<OtlpSpanExporter, TraceInitError> {
-    opentelemetry_otlp::HttpExporterBuilder::default()
-        .with_endpoint(endpoint.to_string())
-        .with_timeout(timeout)
-        .build_span_exporter()
-        .map_err(|err| TraceInitError::OtlpBuildError(err.to_string()))
 }
 
 fn build_resource(pairs: ResourcePairs) -> Result<Resource, TraceInitError> {


### PR DESCRIPTION
## Summary
- switch the trace OTLP exporter to the new opentelemetry_otlp builder interfaces with real span exporter construction
- remove the metrics exporter compatibility shim and gate tonic support behind the crate feature that enables grpc-tonic
- disable opentelemetry-otlp default features and patch hyper-timeout to the vendored copy to avoid implicit gRPC deps

## Testing
- cargo check --all-targets --all-features *(fails: unable to download crates from crates.io due to 403 CONNECT tunnel errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c9ec89888330a03bd20b8a734bdb