### PR TITLE
Fix Prometheus exporter initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]

--- a/src/telemetry_metrics_prom.rs
+++ b/src/telemetry_metrics_prom.rs
@@ -80,15 +80,14 @@ impl Drop for PromServerGuard {
 
 pub fn init_prom_exporter() -> PromExporter {
     let registry = prometheus::Registry::new();
-    let exporter = opentelemetry_prometheus::exporter()
-        .with_registry(registry.clone())
-        .build()
-        .expect("failed to build Prometheus exporter");
-    let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
-
     let provider = Arc::new(
         SdkMeterProvider::builder()
-            .with_reader(exporter)
+            .with_reader(
+                opentelemetry_prometheus::exporter()
+                    .with_registry(registry.clone())
+                    .build()
+                    .expect("failed to build Prometheus exporter"),
+            )
             .build(),
     );
 


### PR DESCRIPTION
## Summary
- build the Prometheus meter provider directly from the exporter builder while keeping the Arc-wrapped registry and provider
- wire the `metrics-otlp-grpc` feature to enable the upstream gRPC transport so the optional path compiles when requested

## Testing
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features` *(fails: unable to download `hyper-timeout` because the environment blocks the crates.io proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c9ee5be883308d87663fd79dd1b2