### PR TITLE
Use 128-bit serde_json::Number constructors

### DIFF
--- a/src/obs_policy_lints.rs
+++ b/src/obs_policy_lints.rs
@@ -134,8 +134,13 @@ struct CollectVisitor {
 
 impl tracing_core::field::Visit for CollectVisitor {
     fn record_i64(&mut self, field: &tracing_core::Field, value: i64) {
-        self.values
-            .insert(field.name().to_string(), Value::Number(value.into()));
+        if let Some(number) = serde_json::Number::from_i128(value as i128) {
+            self.values
+                .insert(field.name().to_string(), Value::Number(number));
+        } else {
+            self.values
+                .insert(field.name().to_string(), Value::String(value.to_string()));
+        }
     }
 
     fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
@@ -143,10 +148,8 @@ impl tracing_core::field::Visit for CollectVisitor {
             self.values
                 .insert(field.name().to_string(), Value::Number(number));
         } else {
-            self.values.insert(
-                field.name().to_string(),
-                Value::String(value.to_string()),
-            );
+            self.values
+                .insert(field.name().to_string(), Value::String(value.to_string()));
         }
     }
 

--- a/src/telemetry_logs.rs
+++ b/src/telemetry_logs.rs
@@ -414,11 +414,19 @@ impl Visit for EventFieldVisitor {
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.record_value(field, Value::Number(value.into()));
+        if let Some(number) = serde_json::Number::from_i128(value as i128) {
+            self.record_value(field, Value::Number(number));
+        } else {
+            self.record_value(field, Value::String(value.to_string()));
+        }
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.record_value(field, Value::Number(value.into()));
+        if let Some(number) = serde_json::Number::from_u128(value as u128) {
+            self.record_value(field, Value::Number(number));
+        } else {
+            self.record_value(field, Value::String(value.to_string()));
+        }
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {

--- a/tests/obs_policy_lints_tests.rs
+++ b/tests/obs_policy_lints_tests.rs
@@ -142,7 +142,11 @@ impl tracing_core::field::Visit for TestVisitor {
     }
 
     fn record_i64(&mut self, field: &tracing_core::Field, value: i64) {
-        self.record_value(field, Value::Number(value.into()));
+        if let Some(number) = serde_json::Number::from_i128(value as i128) {
+            self.record_value(field, Value::Number(number));
+        } else {
+            self.record_value(field, Value::String(value.to_string()));
+        }
     }
 
     fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {

--- a/tests/telemetry_spans_cdc_tests.rs
+++ b/tests/telemetry_spans_cdc_tests.rs
@@ -121,7 +121,9 @@ fn expect_invalid(attrs: CdcConsumeAttrs, needle: &str) {
 fn otel_value_to_json(value: &Value) -> JsonValue {
     match value {
         Value::Bool(v) => JsonValue::Bool(*v),
-        Value::I64(v) => JsonValue::Number((*v).into()),
+        Value::I64(v) => serde_json::Number::from_i128((*v) as i128)
+            .map(JsonValue::Number)
+            .unwrap_or_else(|| JsonValue::String(v.to_string())),
         Value::F64(v) => serde_json::Number::from_f64(*v)
             .map(JsonValue::Number)
             .unwrap_or(JsonValue::Null),


### PR DESCRIPTION
## Summary
- update telemetry log field visitors to use `serde_json::Number::from_i128`/`from_u128` with string fallbacks when a JSON number cannot be formed
- switch obs policy lint collectors and CDC span tests to the 128-bit constructors so we avoid the deprecated 64-bit helpers

## Testing
- `cargo test --no-run` *(fails: existing build errors in telemetry_metrics_prom.rs and telemetry_metrics_otlp.rs about missing `reader` binding and `WithExportConfig` import)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ca7e1d788330b82ac27565aeff7c