### PR TITLE
Fix OTEL testing setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ opentelemetry-prometheus = "*"
 serde_json = "1"
 
 [dev-dependencies]
-proptest = "1"
 criterion = { version = "0.5", default-features = false }
 opentelemetry = { version = "0.29.1", features = ["testing"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["testing"] }
+proptest = "1"
 [lib]
 name = "credit_engine_core"
 path = "src/lib.rs"

--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, time::Duration};
 
+use ::opentelemetry_otlp::WithExportConfig;
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::Resource;
@@ -257,7 +258,8 @@ fn build_otlp_exporter(
     let timeout = Duration::from_millis(export_timeout_ms);
     match protocol {
         OtlpProtocol::Grpc => Err(MetricsInitError::OtlpBuildError(
-            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
+            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                .into(),
         )),
         OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
             .with_http()

--- a/src/telemetry_metrics_prom.rs
+++ b/src/telemetry_metrics_prom.rs
@@ -84,13 +84,8 @@ pub fn init_prom_exporter() -> PromExporter {
         .with_registry(registry.clone())
         .build()
         .expect("failed to build Prometheus exporter");
-    let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
 
-    let provider = Arc::new(
-        SdkMeterProvider::builder()
-            .with_reader(exporter)
-            .build(),
-    );
+    let provider = Arc::new(SdkMeterProvider::builder().with_reader(exporter).build());
 
     PromExporter { registry, provider }
 }


### PR DESCRIPTION
## Summary
- align the opentelemetry dev dependencies on the testing feature set without duplicates
- fix the Prometheus metrics exporter initialization to use the constructed reader directly
- import the OTLP exporter configuration trait so HTTP exporter builds compile again

## Testing
- cargo check --tests

------
https://chatgpt.com/codex/tasks/task_e_68e0ca7f28a483309d46e5b252a5dbc6