### PR TITLE
Fix Prometheus exporter cloning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]

--- a/src/telemetry_metrics_otlp.rs
+++ b/src/telemetry_metrics_otlp.rs
@@ -53,10 +53,14 @@ mod opentelemetry_otlp {
                         let mut builder =
                             ::opentelemetry_otlp::MetricExporter::builder().with_tonic();
                         if let Some(endpoint) = self.endpoint {
-                            builder = builder.with_endpoint(endpoint);
+                            builder = ::opentelemetry_otlp::WithExportConfig::with_endpoint(
+                                builder, endpoint,
+                            );
                         }
                         if let Some(timeout) = self.timeout {
-                            builder = builder.with_timeout(timeout);
+                            builder = ::opentelemetry_otlp::WithExportConfig::with_timeout(
+                                builder, timeout,
+                            );
                         }
                         builder.build()
                     }
@@ -70,10 +74,13 @@ mod opentelemetry_otlp {
                 ExporterKind::Http => {
                     let mut builder = ::opentelemetry_otlp::MetricExporter::builder().with_http();
                     if let Some(endpoint) = self.endpoint {
-                        builder = builder.with_endpoint(endpoint);
+                        builder = ::opentelemetry_otlp::WithExportConfig::with_endpoint(
+                            builder, endpoint,
+                        );
                     }
                     if let Some(timeout) = self.timeout {
-                        builder = builder.with_timeout(timeout);
+                        builder =
+                            ::opentelemetry_otlp::WithExportConfig::with_timeout(builder, timeout);
                     }
                     builder.build()
                 }
@@ -257,7 +264,8 @@ fn build_otlp_exporter(
     let timeout = Duration::from_millis(export_timeout_ms);
     match protocol {
         OtlpProtocol::Grpc => Err(MetricsInitError::OtlpBuildError(
-            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)".into(),
+            "gRPC metrics exporter support is not enabled (enable the `metrics-otlp-grpc` feature)"
+                .into(),
         )),
         OtlpProtocol::Http => opentelemetry_otlp::MetricExporter::builder()
             .with_http()

--- a/src/telemetry_metrics_prom.rs
+++ b/src/telemetry_metrics_prom.rs
@@ -24,14 +24,18 @@ pub struct PromServerConfig {
     pub addr: String,
 }
 
+#[derive(Clone)]
 pub struct PromExporter {
-    pub registry: prometheus::Registry,
-    provider: Arc<SdkMeterProvider>,
+    exporter: opentelemetry_prometheus::PrometheusExporter,
 }
 
 impl PromExporter {
     pub fn meter_provider(&self) -> Arc<SdkMeterProvider> {
-        Arc::clone(&self.provider)
+        self.exporter.provider()
+    }
+
+    fn registry(&self) -> &prometheus::Registry {
+        self.exporter.registry()
     }
 }
 
@@ -79,20 +83,12 @@ impl Drop for PromServerGuard {
 }
 
 pub fn init_prom_exporter() -> PromExporter {
-    let registry = prometheus::Registry::new();
     let exporter = opentelemetry_prometheus::exporter()
-        .with_registry(registry.clone())
+        .with_registry(prometheus::Registry::new())
         .build()
         .expect("failed to build Prometheus exporter");
-    let meter_provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
 
-    let provider = Arc::new(
-        SdkMeterProvider::builder()
-            .with_reader(exporter)
-            .build(),
-    );
-
-    PromExporter { registry, provider }
+    PromExporter { exporter }
 }
 
 pub async fn spawn_metrics_http(
@@ -189,7 +185,7 @@ async fn handle_request(
 }
 
 fn gather_and_encode(exporter: &PromExporter) -> Result<Vec<u8>, String> {
-    let metric_families = exporter.registry.gather();
+    let metric_families = exporter.registry().gather();
     let mut buffer = Vec::new();
     let encoder = TextEncoder::new();
     encoder


### PR DESCRIPTION
## Summary
- wrap `PromExporter` around the `opentelemetry_prometheus::PrometheusExporter` so it can derive `Clone`
- ensure OTLP builder calls use the `WithExportConfig` trait methods explicitly and hook the `metrics-otlp-grpc` feature into the upstream gRPC feature

## Testing
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features` *(fails: unable to download crates.io index dependency `hyper-timeout` because the proxy returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ca80c7f483309de3b81a39cdd8b1