### PR TITLE
Pin Prometheus dependencies and expose OTLP gRPC feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
 httpdate = { version = "1", path = "vendor/httpdate" }
 opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tracing = "0.1"
@@ -25,8 +25,8 @@ metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendo
 once_cell = "1"
 thiserror = "2.0.16"
 regex = "1"
-prometheus = "*"
-opentelemetry-prometheus = "*"
+prometheus = "0.14"
+opentelemetry-prometheus = "0.29"
 serde_json = "1"
 
 [dev-dependencies]
@@ -54,4 +54,5 @@ harness = false
 
 [features]
 obs = ["metrics-exporter-prometheus"]
-metrics-otlp-grpc = []
+grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
+metrics-otlp-grpc = ["grpc-tonic"]


### PR DESCRIPTION
## Summary
- pin prometheus crates to the versions required by the observability spec
- forward the opentelemetry-otlp gRPC feature through a dedicated crate flag so the OTLP gRPC pipeline can be enabled

## Testing
- cargo check *(fails: registry access blocked by 403 CONNECT tunnel errors when fetching tonic's hyper-timeout dependency)*
- cargo check --features metrics-otlp-grpc *(fails: registry access blocked by 403 CONNECT tunnel errors when fetching tonic's hyper-timeout dependency)*
- cargo check --features "metrics-otlp-grpc obs" *(fails: registry access blocked by 403 CONNECT tunnel errors when fetching tonic's hyper-timeout dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c9ef95f083309726ecf45c464e18