### PR TITLE
Normalize prometheus dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,13 +501,6 @@ dependencies = [
  "want",
 ]
 
-[[package]]
-name = "hyper-timeout"
-version = "0.5.0"
-dependencies = [
- "http",
- "tower-service",
-]
 
 [[package]]
 name = "hyper-util"
@@ -880,7 +873,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.29.0"
 version = "0.29.1"
 dependencies = [
  "opentelemetry",
@@ -987,7 +979,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.0"
 version = "0.14.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
 httpdate = { version = "1", path = "vendor/httpdate" }
 opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
-opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio", "testing"] }
-opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
 opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
@@ -28,16 +25,8 @@ metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendo
 once_cell = "1"
 thiserror = "2.0.16"
 regex = "1"
-prometheus = { path = "vendor/prometheus" }
-opentelemetry-prometheus = { path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29"
-prometheus = { version = "0.13", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
 prometheus = { version = "0.14", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29.1"
+opentelemetry-prometheus = { version = "0.29.1", path = "vendor/opentelemetry-prometheus" }
 serde_json = "1"
 
 [patch.crates-io]
@@ -71,12 +60,3 @@ obs = ["metrics-exporter-prometheus"]
 grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
 metrics-otlp-grpc = ["grpc-tonic"]
 
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
-
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["grpc-tonic"]
-grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]

--- a/out/diagnostics/task-a-all-features.txt
+++ b/out/diagnostics/task-a-all-features.txt
@@ -1,0 +1,14 @@
+    Updating crates.io index
+warning: spurious network error (3 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (2 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (1 try remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+error: failed to get `hyper` as a dependency of package `credit-engine-core v0.1.0 (/workspace/trendmarket)`
+
+Caused by:
+  download of config.json failed
+
+Caused by:
+  failed to download from `https://index.crates.io/config.json`
+
+Caused by:
+  [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)

--- a/out/diagnostics/task-a-no-default.txt
+++ b/out/diagnostics/task-a-no-default.txt
@@ -1,0 +1,14 @@
+    Updating crates.io index
+warning: spurious network error (3 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (2 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (1 try remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+error: failed to get `hyper` as a dependency of package `credit-engine-core v0.1.0 (/workspace/trendmarket)`
+
+Caused by:
+  download of config.json failed
+
+Caused by:
+  failed to download from `https://index.crates.io/config.json`
+
+Caused by:
+  [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)


### PR DESCRIPTION
## Summary
- deduplicate prometheus-related dependencies and point vendored crates at the vendor directory
- clean duplicate opentelemetry entries and redundant patch tables
- fix Cargo.lock duplicates for prom/opentelemetry-prometheus and hyper-timeout
- add cargo check logs for requested configurations

## Testing
- cargo check --no-default-features --all-targets *(fails: network access to crates.io is blocked)*
- cargo check --all-features --tests *(fails: network access to crates.io is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68e17c377c788330b8444058db3d5028