### PR TITLE
Adjust features and patch configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,14 +534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.5.0"
-dependencies = [
- "http",
- "tower-service",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,7 +872,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.29.0"
 version = "0.29.1"
 dependencies = [
  "opentelemetry",
@@ -987,7 +978,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.0"
 version = "0.14.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
 httpdate = { version = "1", path = "vendor/httpdate" }
 opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
-opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio", "testing"] }
-opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
 opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
@@ -28,16 +25,8 @@ metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendo
 once_cell = "1"
 thiserror = "2.0.16"
 regex = "1"
-prometheus = { path = "vendor/prometheus" }
-opentelemetry-prometheus = { path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29"
-prometheus = { version = "0.13", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
 prometheus = { version = "0.14", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29.1"
+opentelemetry-prometheus = { version = "0.29.1", path = "vendor/opentelemetry-prometheus" }
 serde_json = "1"
 
 [patch.crates-io]
@@ -67,16 +56,7 @@ name = "bench_liquidity"
 harness = false
 
 [features]
+default = []
 obs = ["metrics-exporter-prometheus"]
 grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
-metrics-otlp-grpc = ["grpc-tonic"]
-
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
-
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["grpc-tonic"]
-grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
+metrics-otlp-grpc = []

--- a/out/diagnostics/task-b-cargo-check.txt
+++ b/out/diagnostics/task-b-cargo-check.txt
@@ -1,0 +1,14 @@
+    Updating crates.io index
+warning: spurious network error (3 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (2 tries remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+warning: spurious network error (1 try remaining): [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)
+error: failed to get `hyper` as a dependency of package `credit-engine-core v0.1.0 (/workspace/trendmarket)`
+
+Caused by:
+  download of config.json failed
+
+Caused by:
+  failed to download from `https://index.crates.io/config.json`
+
+Caused by:
+  [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403)

--- a/out/diagnostics/task-b-diff.patch
+++ b/out/diagnostics/task-b-diff.patch
@@ -1,0 +1,86 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 4b49b55..e38043b 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -533,14 +533,6 @@ dependencies = [
+  "tracing",
+ ]
+ 
+-[[package]]
+-name = "hyper-timeout"
+-version = "0.5.0"
+-dependencies = [
+- "http",
+- "tower-service",
+-]
+-
+ [[package]]
+ name = "icu_collections"
+ version = "2.0.0"
+@@ -880,7 +872,6 @@ dependencies = [
+ 
+ [[package]]
+ name = "opentelemetry-prometheus"
+-version = "0.29.0"
+ version = "0.29.1"
+ dependencies = [
+  "opentelemetry",
+@@ -987,7 +978,6 @@ dependencies = [
+ 
+ [[package]]
+ name = "prometheus"
+-version = "0.13.0"
+ version = "0.14.0"
+ 
+ [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index 12f7502..b0ed067 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -12,9 +12,6 @@ hyper = { version = "1", features = ["http1", "server"] }
+ hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
+ httpdate = { version = "1", path = "vendor/httpdate" }
+ opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
+-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
+-opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio", "testing"] }
+-opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
+ opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto"] }
+ opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
+ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
+@@ -28,16 +25,8 @@ metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendo
+ once_cell = "1"
+ thiserror = "2.0.16"
+ regex = "1"
+-prometheus = { path = "vendor/prometheus" }
+-opentelemetry-prometheus = { path = "vendor/opentelemetry-prometheus" }
+-prometheus = "0.14"
+-opentelemetry-prometheus = "0.29"
+-prometheus = { version = "0.13", path = "vendor/prometheus" }
+-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
+ prometheus = { version = "0.14", path = "vendor/prometheus" }
+-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
+-prometheus = "0.14"
+-opentelemetry-prometheus = "0.29.1"
++opentelemetry-prometheus = { version = "0.29.1", path = "vendor/opentelemetry-prometheus" }
+ serde_json = "1"
+ 
+ [patch.crates-io]
+@@ -67,16 +56,7 @@ name = "bench_liquidity"
+ harness = false
+ 
+ [features]
++default = []
+ obs = ["metrics-exporter-prometheus"]
+ grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
+-metrics-otlp-grpc = ["grpc-tonic"]
+-
+-[patch.crates-io]
+-hyper-timeout = { path = "vendor/hyper-timeout" }
+-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
+-
+-[patch.crates-io]
+-hyper-timeout = { path = "vendor/hyper-timeout" }
+-metrics-otlp-grpc = ["grpc-tonic"]
+-grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
+-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
++metrics-otlp-grpc = []

--- a/out/diagnostics/task-b-rg.txt
+++ b/out/diagnostics/task-b-rg.txt
@@ -1,0 +1,1 @@
+metrics-otlp-grpc = []


### PR DESCRIPTION
## Summary
- declare an empty default feature set, keep existing flags, and add a metrics-otlp-grpc feature stub
- deduplicate telemetry dependency entries while keeping the hyper-timeout patch consolidated after dependencies
- capture task-b diagnostics artifacts for the feature updates

## Testing
- `cargo check --all-targets` *(fails: network access to crates.io returns HTTP 403)*
- `rg 'metrics-otlp-grpc' Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68e17c389a6883308e3df9646661c1fa