### PR TITLE
Refactor Prometheus exporter setup and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,14 +534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.5.0"
-dependencies = [
- "http",
- "tower-service",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,7 +872,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.29.0"
 version = "0.29.1"
 dependencies = [
  "opentelemetry",
@@ -987,7 +978,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.0"
 version = "0.14.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,43 +11,30 @@ http-body-util = "0.1"
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
 httpdate = { version = "1", path = "vendor/httpdate" }
+metrics = { version = "0.21", path = "vendor/metrics" }
+metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendor/metrics-exporter-prometheus" }
+once_cell = "1"
 opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
-opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio", "testing"] }
-opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
 opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto"] }
+opentelemetry-prometheus = { version = "0.29.1", path = "vendor/opentelemetry-prometheus" }
 opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
+prometheus = { version = "0.14.0", path = "vendor/prometheus" }
+regex = "1"
+serde_json = "1"
+thiserror = "2.0.16"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tracing = "0.1"
 tracing-core = "0.1.34"
 tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uint = "0.9"
-metrics = { version = "0.21", path = "vendor/metrics" }
-metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendor/metrics-exporter-prometheus" }
-once_cell = "1"
-thiserror = "2.0.16"
-regex = "1"
-prometheus = { path = "vendor/prometheus" }
-opentelemetry-prometheus = { path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29"
-prometheus = { version = "0.13", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
-prometheus = { version = "0.14", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29.1"
-serde_json = "1"
-
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }
 opentelemetry = { version = "0.29.1", features = ["testing"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["testing"] }
 proptest = "1"
+
 [lib]
 name = "credit_engine_core"
 path = "src/lib.rs"
@@ -67,16 +54,15 @@ name = "bench_liquidity"
 harness = false
 
 [features]
+default = []
 obs = ["metrics-exporter-prometheus"]
 grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
 metrics-otlp-grpc = ["grpc-tonic"]
 
 [patch.crates-io]
 hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
-
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["grpc-tonic"]
-grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
+httpdate = { path = "vendor/httpdate" }
+metrics = { path = "vendor/metrics" }
+metrics-exporter-prometheus = { path = "vendor/metrics-exporter-prometheus" }
+opentelemetry-prometheus = { path = "vendor/opentelemetry-prometheus" }
+prometheus = { path = "vendor/prometheus" }

--- a/src/telemetry_metrics_prom.rs
+++ b/src/telemetry_metrics_prom.rs
@@ -10,26 +10,22 @@ use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder as HyperBuilder,
 };
-use prometheus::TextEncoder;
 use opentelemetry_prometheus::PrometheusExporter as OtelPromExporter;
-use prometheus::{Registry, TextEncoder};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use prometheus::{Encoder, TextEncoder};
+use thiserror::Error;
 use tokio::net::TcpListener;
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-
-use opentelemetry_sdk::metrics::SdkMeterProvider;
-use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PromServerConfig {
     pub addr: String,
 }
 
-#[derive(Clone)]
 pub struct PromExporter {
-    exporter: opentelemetry_prometheus::PrometheusExporter,
-    inner: OtelPromExporter,
+    exporter: Arc<OtelPromExporter>,
 }
 
 impl PromExporter {
@@ -39,11 +35,14 @@ impl PromExporter {
 
     fn registry(&self) -> &prometheus::Registry {
         self.exporter.registry()
-        self.inner.provider()
     }
+}
 
-    fn registry(&self) -> &Registry {
-        self.inner.registry()
+impl Clone for PromExporter {
+    fn clone(&self) -> Self {
+        Self {
+            exporter: Arc::clone(&self.exporter),
+        }
     }
 }
 
@@ -96,32 +95,9 @@ pub fn init_prom_exporter() -> PromExporter {
         .build()
         .expect("failed to build Prometheus exporter");
 
-    PromExporter { exporter }
-        .with_registry(Registry::new())
-        .build()
-        .expect("failed to build Prometheus exporter");
-
-    let provider = exporter.provider();
-    let registry = prometheus::Registry::new();
-    let provider = Arc::new(
-        SdkMeterProvider::builder()
-            .with_reader(
-                opentelemetry_prometheus::exporter()
-                    .with_registry(registry.clone())
-                    .build()
-                    .expect("failed to build Prometheus exporter"),
-            )
-            .build(),
-    );
-    let reader = opentelemetry_prometheus::exporter()
-        .with_registry(registry.clone())
-        .build()
-        .expect("failed to build Prometheus exporter");
-
-    let provider = Arc::new(SdkMeterProvider::builder().with_reader(reader).build());
-    let provider = Arc::new(SdkMeterProvider::builder().with_reader(exporter).build());
-
-    PromExporter { inner: exporter }
+    PromExporter {
+        exporter: Arc::new(exporter),
+    }
 }
 
 pub async fn spawn_metrics_http(
@@ -142,7 +118,7 @@ pub async fn spawn_metrics_http(
 
     let exporter = Arc::new(exporter);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let server_exporter = exporter.clone();
+    let server_exporter = Arc::clone(&exporter);
 
     let handle =
         tokio::spawn(async move { run_server(listener, server_exporter, shutdown_rx).await });
@@ -169,9 +145,9 @@ async fn run_server(
             }
             accept_result = listener.accept() => {
                 let (stream, _) = accept_result.map_err(|err| PromHttpError::Serve(err.to_string()))?;
-                let service_exporter = exporter.clone();
+                let service_exporter = Arc::clone(&exporter);
                 let service = service_fn(move |req| {
-                    let exporter = service_exporter.clone();
+                    let exporter = Arc::clone(&service_exporter);
                     async move { handle_request(req, exporter).await }
                 });
                 let io = TokioIo::new(stream);

--- a/tests/telemetry_metrics_prom_tests.rs
+++ b/tests/telemetry_metrics_prom_tests.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::sync::Arc;
 use std::time::Duration;
 
 use credit_engine_core::telemetry_metrics_prom::{
@@ -29,6 +30,13 @@ async fn prometheus_http_server_exposes_metrics() -> Result<(), Box<dyn Error>> 
     .await?;
 
     tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let guard_exporter = guard.exporter();
+    let guard_provider = guard_exporter.meter_provider();
+    assert!(Arc::ptr_eq(&provider, &guard_provider));
+    let guard_meter = guard_provider.meter("test-prom-guard");
+    let late_counter = guard_meter.u64_counter("late_counter_total").build();
+    late_counter.add(1, &[]);
 
     let addr = guard.local_addr();
     println!("bound on {}", addr);
@@ -65,6 +73,7 @@ async fn prometheus_http_server_exposes_metrics() -> Result<(), Box<dyn Error>> 
     assert!(body.contains("test_histogram_seconds_sum"));
     assert!(body.contains("test_histogram_seconds_count"));
     assert!(body.contains("le=\"+Inf\""));
+    assert!(body.contains("late_counter_total"));
 
     guard.shutdown().await;
 


### PR DESCRIPTION
## Summary
- wrap the Prometheus exporter in an `Arc` to share the SDK provider and registry through the HTTP server
- simplify the Prometheus exporter initialization and metric gathering logic while keeping a single registry instance
- extend the Prometheus metrics integration test to verify shared exporter state

## Testing
- cargo test --tests telemetry_metrics_prom_tests *(fails: unable to download crates via proxy)*
- cargo check --lib --features obs *(fails: unable to download crates via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e17c3a79988330b4735205c52ee08e