### PR TITLE
Refine Prometheus exporter handles

### DIFF
--- a/out/diagnostics/task-f-cargo-check.txt
+++ b/out/diagnostics/task-f-cargo-check.txt
@@ -1,0 +1,6 @@
+error: duplicate key `opentelemetry-otlp` in table `dependencies`
+  --> Cargo.toml:17:1
+   |
+17 | opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
+   | ^
+   |

--- a/out/diagnostics/task-f-cargo-test.txt
+++ b/out/diagnostics/task-f-cargo-test.txt
@@ -1,0 +1,6 @@
+error: duplicate key `opentelemetry-otlp` in table `dependencies`
+  --> Cargo.toml:17:1
+   |
+17 | opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
+   | ^
+   |

--- a/src/bin/telemetry_smoke.rs
+++ b/src/bin/telemetry_smoke.rs
@@ -22,14 +22,14 @@ fn main() {
     }
 
     let addr = env::var("AMM_METRICS_ADDR").unwrap_or_else(|_| "127.0.0.1:9464".to_string());
-    telemetry::start_prometheus(&addr).expect("start prometheus");
+    let prom_handles = telemetry::start_prometheus(&addr).expect("start prometheus");
 
     telemetry::inc_swap("CE-PAIR-TEST");
     telemetry::inc_liquidity("mint");
     telemetry::inc_error("CE-AMM-0000");
     telemetry::observe_swap_latency_ms(2.4);
 
-    let snapshot = metrics::render_prometheus();
+    let snapshot = prom_handles.render();
     spawn_server(&addr, &snapshot);
 
     thread::sleep(Duration::from_millis(800));

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 #[cfg(feature = "obs")]
-use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 #[cfg(feature = "obs")]
 use std::net::SocketAddr;
 
@@ -510,12 +510,28 @@ mod otlp_exporter_compat {
 }
 
 #[cfg(feature = "obs")]
-pub fn start_prometheus(addr: &str) -> anyhow::Result<()> {
+pub struct PrometheusHandles {
+    handle: PrometheusHandle,
+}
+
+#[cfg(feature = "obs")]
+impl PrometheusHandles {
+    pub fn render(&self) -> String {
+        self.handle.render()
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.handle.addr()
+    }
+}
+
+#[cfg(feature = "obs")]
+pub fn start_prometheus(addr: &str) -> anyhow::Result<PrometheusHandles> {
     let sock: SocketAddr = addr.parse()?;
-    PrometheusBuilder::new()
+    let handle = PrometheusBuilder::new()
         .with_http_listener(sock)
         .install()?;
-    Ok(())
+    Ok(PrometheusHandles { handle })
 }
 
 #[cfg(feature = "obs")]

--- a/vendor/metrics-exporter-prometheus/src/lib.rs
+++ b/vendor/metrics-exporter-prometheus/src/lib.rs
@@ -1,8 +1,14 @@
+use metrics::render_prometheus;
 use once_cell::sync::OnceCell;
 use std::net::SocketAddr;
 
 pub struct PrometheusBuilder {
     addr: Option<SocketAddr>,
+}
+
+#[derive(Clone, Copy)]
+pub struct PrometheusHandle {
+    addr: SocketAddr,
 }
 
 static LAST_ADDR: OnceCell<SocketAddr> = OnceCell::new();
@@ -17,10 +23,10 @@ impl PrometheusBuilder {
         self
     }
 
-    pub fn install(self) -> std::io::Result<()> {
+    pub fn install(self) -> std::io::Result<PrometheusHandle> {
         if let Some(addr) = self.addr {
             let _ = LAST_ADDR.set(addr);
-            Ok(())
+            Ok(PrometheusHandle { addr })
         } else {
             Err(std::io::Error::new(
                 std::io::ErrorKind::AddrNotAvailable,
@@ -32,4 +38,14 @@ impl PrometheusBuilder {
 
 pub fn configured_addr() -> Option<SocketAddr> {
     LAST_ADDR.get().copied()
+}
+
+impl PrometheusHandle {
+    pub fn render(&self) -> String {
+        render_prometheus()
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
 }


### PR DESCRIPTION
## Summary
- wrap the vendored Prometheus exporter in a handle that exposes render and addr helpers
- return the new handle from `telemetry::start_prometheus` behind the `obs` feature and adjust the smoke binary to retain it
- gate Prometheus builder imports on the `obs` feature to keep optional dependency usage consistent

## Testing
- `cargo check --bin telemetry_smoke --features obs` *(fails: duplicate key `opentelemetry-otlp` in Cargo.toml)*
- `cargo test --features obs telemetry_metrics_prom_tests` *(fails: duplicate key `opentelemetry-otlp` in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68e17c3c4e5883308f8782c9a320f236