### PR TITLE
Add diagnostics for telemetry module coverage

### DIFF
--- a/out/diagnostics/task-g-telemetry/cargo_check_lib.txt
+++ b/out/diagnostics/task-g-telemetry/cargo_check_lib.txt
@@ -1,0 +1,6 @@
+error: duplicate key `opentelemetry-otlp` in table `dependencies`
+  --> Cargo.toml:17:1
+   |
+17 | opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
+   | ^
+   |

--- a/out/diagnostics/task-g-telemetry/rg_pub_mod_telemetry.txt
+++ b/out/diagnostics/task-g-telemetry/rg_pub_mod_telemetry.txt
@@ -1,0 +1,11 @@
+pub mod telemetry_cfg;
+pub mod telemetry_contract;
+pub mod telemetry_identity;
+pub mod telemetry_instruments;
+pub mod telemetry_latency;
+pub mod telemetry_logs;
+pub mod telemetry_metrics_otlp;
+pub mod telemetry_metrics_prom;
+pub mod telemetry_spans_amm;
+pub mod telemetry_spans_cdc;
+pub mod telemetry_trace;


### PR DESCRIPTION
## Summary
- capture the list of telemetry module exports from src/lib.rs
- archive the cargo check output highlighting the current dependency duplication error

## Testing
- `rg 'pub mod telemetry_' src/lib.rs`
- `cargo check --lib`


------
https://chatgpt.com/codex/tasks/task_e_68e17c3ca2748330a447a8477adf5ffe