### PR TITLE
Use extractor accessors in telemetry trace test

### DIFF
--- a/tests/telemetry_trace_tests.rs
+++ b/tests/telemetry_trace_tests.rs
@@ -101,9 +101,13 @@ fn propagator_registration_is_idempotent() -> Result<(), TraceInitError> {
         prop.inject_context(&ctx, &mut carrier);
     });
 
-    assert!(carrier.0.contains_key("traceparent"));
+    assert!(
+        carrier
+            .get("traceparent")
+            .is_some(),
+        "traceparent header should be present"
+    );
     let baggage_header = carrier
-        .0
         .get("baggage")
         .expect("baggage header should be present");
     assert!(baggage_header.contains("feature=enabled"));


### PR DESCRIPTION
## Summary
- rely on the HeaderCarrier extractor implementation when checking injected headers

## Testing
- `rg 'TextMapCarrier' -n`
- `cargo test --tests telemetry_trace_tests` *(fails: duplicate key `opentelemetry-otlp` in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68e17c3d264883309a973ce588ac5657