### PR TITLE
Adjust OpenTelemetry dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,14 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.5.0"
-dependencies = [
- "http",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,7 +872,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.29.0"
 version = "0.29.1"
 dependencies = [
  "opentelemetry",
@@ -987,7 +978,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.0"
 version = "0.14.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,34 +11,23 @@ http-body-util = "0.1"
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["server", "http1", "tokio"] }
 httpdate = { version = "1", path = "vendor/httpdate" }
+metrics = { version = "0.21", path = "vendor/metrics" }
+metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendor/metrics-exporter-prometheus" }
+once_cell = "1"
 opentelemetry = { version = "0.29.1", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29", features = ["http-proto"] }
-opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio", "testing"] }
-opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
-opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto"] }
-opentelemetry_sdk = { version = "0.29.0", features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.29", default-features = false, features = ["grpc-tonic", "http-proto"] }
+opentelemetry-prometheus = { version = "0.29.1", path = "vendor/opentelemetry-prometheus" }
+opentelemetry_sdk = { version = "0.29.0", features = ["trace", "metrics", "rt-tokio"] }
+prometheus = { version = "0.14", path = "vendor/prometheus" }
+regex = "1"
+serde_json = "1"
+thiserror = "2.0.16"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tracing = "0.1"
 tracing-core = "0.1.34"
 tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uint = "0.9"
-metrics = { version = "0.21", path = "vendor/metrics" }
-metrics-exporter-prometheus = { version = "0.13", optional = true, path = "vendor/metrics-exporter-prometheus" }
-once_cell = "1"
-thiserror = "2.0.16"
-regex = "1"
-prometheus = { path = "vendor/prometheus" }
-opentelemetry-prometheus = { path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29"
-prometheus = { version = "0.13", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
-prometheus = { version = "0.14", path = "vendor/prometheus" }
-opentelemetry-prometheus = { version = "0.29", path = "vendor/opentelemetry-prometheus" }
-prometheus = "0.14"
-opentelemetry-prometheus = "0.29.1"
-serde_json = "1"
 
 [patch.crates-io]
 hyper-timeout = { path = "vendor/hyper-timeout" }
@@ -71,12 +60,3 @@ obs = ["metrics-exporter-prometheus"]
 grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
 metrics-otlp-grpc = ["grpc-tonic"]
 
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]
-
-[patch.crates-io]
-hyper-timeout = { path = "vendor/hyper-timeout" }
-metrics-otlp-grpc = ["grpc-tonic"]
-grpc-tonic = ["opentelemetry-otlp/grpc-tonic"]
-metrics-otlp-grpc = ["opentelemetry-otlp/grpc-tonic"]


### PR DESCRIPTION
## Summary
- configure OpenTelemetry dependencies for production features only and ensure the OTLP exporter opts into the required transports
- keep testing-only features isolated under dev-dependencies while cleaning up duplicate dependency and patch declarations
- refresh the lockfile to match the dependency changes and drop duplicate package records

## Testing
- `CARGO_NET_OFFLINE=true cargo check --lib` *(fails: offline mode cannot resolve `bytes` without the crates.io index)*
- `rg 'features = ["testing"]' Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68e17c3e2f208330a8e8de0690394df1