### PR TITLE
Add Makefile target for obs feature tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,8 @@ hooks.dry:
 
 gate.a110: watchers.dry hooks.dry
 	./scripts/a110_run_invariants.sh
+
+# Observability feature tests sem alterar os defaults.
+obs.test:
+	cargo test --features obs --no-run
+	cargo test --features obs -q

--- a/out/diagnostics/task-k-make.txt
+++ b/out/diagnostics/task-k-make.txt
@@ -1,0 +1,8 @@
+cargo test --features obs --no-run
+error: duplicate key `opentelemetry-otlp` in table `dependencies`
+  --> Cargo.toml:17:1
+   |
+17 | opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "http-proto"] }
+   | ^
+   |
+make: *** [Makefile:14: obs.test] Error 101


### PR DESCRIPTION
## Summary
- add an `obs.test` Makefile target that runs the obs-feature test suite without changing existing defaults
- persist the diagnostic output from running the new target in `out/diagnostics/task-k-make.txt`

## Testing
- make obs.test *(fails: duplicate key `opentelemetry-otlp` in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68e17c3ee8e48330a0a16f854a0f7dca