### PR TITLE
Refine obs1 postsync diagnostics script

### DIFF
--- a/scripts/obs1_postsync_validate.sh
+++ b/scripts/obs1_postsync_validate.sh
@@ -4,30 +4,29 @@ set -euo pipefail
 mkdir -p out/diagnostics
 status=0
 
-RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt || status=$?
-cargo clean || status=$?
-cargo build -q || status=$?
-cargo test --no-run 2>&1 | tee out/diagnostics/test-norun-sync.txt || status=$?
-cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt || status=$?
-if rg --glob '*.rs' --quiet 'cfg\(feature = "obs"\)' src tests; then
-  cargo test --features obs -q 2>&1 | tee -a out/diagnostics/test-run-sync.txt || status=$?
+if ! RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt; then
+  status=$?
+fi
 
-RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt || true
-cargo test --no-run 2>&1 | tee out/diagnostics/test-norun-sync.txt || true
-cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt || true
-if rg --quiet 'cfg\(feature = "obs"\)' src tests; then
-RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features 2>&1 | tee out/diagnostics/check-sync.txt
-cargo clean
-cargo build -q
-cargo test --no-run 2>&1 | tee out/diagnostics/test-norun-sync.txt || true
-cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt || true
+if ! cargo test --no-run 2>&1 | tee out/diagnostics/test-norun-sync.txt; then
+  status=$?
+fi
+
+if ! cargo test -q 2>&1 | tee out/diagnostics/test-run-sync.txt; then
+  status=$?
+fi
 
 if rg --files-with-matches 'cfg\(feature = "obs"\)' src tests >/dev/null 2>&1; then
-  cargo test --features obs -q 2>&1 | tee -a out/diagnostics/test-run-sync.txt || true
+  if ! cargo test --features obs -q 2>&1 | tee out/diagnostics/test-run-obs-sync.txt; then
+    status=$?
+  fi
 fi
 
 tail -n 80 out/diagnostics/check-sync.txt || true
 tail -n 80 out/diagnostics/test-norun-sync.txt || true
 tail -n 80 out/diagnostics/test-run-sync.txt || true
+if [[ -f out/diagnostics/test-run-obs-sync.txt ]]; then
+  tail -n 80 out/diagnostics/test-run-obs-sync.txt || true
+fi
 
 exit $status


### PR DESCRIPTION
## Summary
- streamline the obs1 postsync validation script to run the required cargo commands sequentially with diagnostics captured under out/diagnostics
- retain the tailing of recent log output while adding a conditional obs-feature test log when the feature is present
- ensure the script remains executable with the expected bash shebang and strict flags

## Testing
- shellcheck scripts/obs1_postsync_validate.sh *(fails: shellcheck is not available in the execution environment)*
- ./scripts/obs1_postsync_validate.sh *(fails because the workspace currently has duplicate opentelemetry-otlp dependencies, but the diagnostics artifacts are produced)*

------
https://chatgpt.com/codex/tasks/task_e_68e17c3f86408330bf68038c68d4f593