### PR TITLE
Document OBS-1 post-sync workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Badges e links para workflows/pipelines.
 
 This repository now ships with first-class governance artifacts to guarantee that the mandatory watchers and A110 hooks defined in `agents.md` stay green across environments.
 
+## Observabilidade OBS-1
+
+- Consulte o runbook pós-sync em [`docs/OBS-1.md`](docs/OBS-1.md) para executar o fluxo canônico (`cargo check`, `cargo test`, `make obs.test` e `./scripts/obs1_postsync_validate.sh`) e revisar troubleshooting e checklist de métricas/traces/Prometheus.
+
 ### Inventory
 
 * **Watchers:** Domain-specific configurations live under [`ops/watchers/`](ops/watchers). Each `.yml` file describes the KPI, window, action, owner, and rollback policy for the mandatory watches covering DEC, PM, ML, DATA, PLAT, FE, SEC/PRIV and INT domains. These inventories are the single source of truth consumed by `ops/scripts/watchers_dry_run.py`, which now enumerates every `.yml` file in that directory when generating `ops/reports/watchers_dry.json`.

--- a/docs/OBS-1.md
+++ b/docs/OBS-1.md
@@ -1,0 +1,34 @@
+# OBS-1 Pós-Sync Runbook — versão 2025-10-04
+
+## Objetivo
+- Garantir que o fluxo pós-sync do pack OBS-1 valide código, telemetria e instrumentação antes de liberar mudanças para observabilidade.
+- Reunir comandos obrigatórios, artefatos esperados e ações corretivas rápidas para manter métricas, traces e dashboards íntegros.
+
+## Passo a passo canônico
+1. `cargo check --all-targets`
+   - Confirma que todos os binários e testes compilam com e sem instrumentação.
+   - Se o pack exigir telemetria, reexecute com `cargo check --all-targets --features obs`.
+2. `cargo test --all-targets`
+   - Executa cobertura mínima dos cenários sem feature gating.
+   - Para validar observabilidade, inclua `--features obs` ou defina `CARGO_FEATURES=obs`.
+3. `make obs.test`
+   - Encapsula suites específicas de métricas, traces e logs para OBS-1.
+   - Armazena logs adicionais em `out/diagnostics/*.txt` quando ocorrerem falhas.
+4. `./scripts/obs1_postsync_validate.sh`
+   - Orquestra validações incrementais, rerodando testes condicionais com `--features obs` quando `cfg(feature = "obs")` for detectado.
+   - Consolida a saída em `out/diagnostics/test-run-sync.txt`, `out/diagnostics/cfg-obs-uses.txt` e relatórios auxiliares.
+
+> **Dica:** Ao trabalhar localmente, exporte `CARGO_FEATURES=obs` ou adicione `--features obs` aos comandos que precisam da instrumentação ativa. Sempre limpe artefatos antigos com `rm -f out/diagnostics/*.txt` antes de uma rodada final.
+
+## Troubleshooting
+- **Falha de compilação:** verificar `out/diagnostics/test-run-sync.txt` para a primeira ocorrência e aplicar `cargo clean` se a mensagem apontar para build cache.
+- **Testes flakey de trace/métrica:** reexecutar `make obs.test` com `RUST_LOG=debug` e confirmar spans em `out/logs/*`.
+- **Prometheus scrape vazio:** conferir `out/diagnostics/summary.md` e o endpoint local `http://localhost:9464/metrics` com `curl` para validar exposição.
+- **Script abortado:** habilitar `set -x` temporariamente em `scripts/obs1_postsync_validate.sh` e inspecionar `out/diagnostics/*.txt` por stacktrace.
+
+## Checklist rápido
+- [ ] Métricas `obs1_metrics_prom` exportando séries críticas e scrape OK em Prometheus.
+- [ ] Traces OTLP (`obs1_trace_contract.md`) com spans preenchidos e atributos `trace_id` propagados.
+- [ ] Logs estruturados (`obs1_logs_contract.md`) sincronizados com os testes do script pós-sync.
+- [ ] Dashboards/alertas revisados após atualizar artefatos em `out/diagnostics/`.
+- [ ] Evidências anexadas aos watchers/metrics antes de solicitar revisão.

--- a/out/diagnostics/task-m-markdownlint.txt
+++ b/out/diagnostics/task-m-markdownlint.txt
@@ -1,0 +1,5 @@
+markdownlint docs/OBS-1.md README.md
+bash: command not found: markdownlint
+
+Fallback: cargo fmt --all
+error: duplicate key `opentelemetry-otlp` in table `dependencies` (Cargo.toml:17)


### PR DESCRIPTION
## Summary
- add a dedicated OBS-1 pós-sync runbook covering objetivos, fluxo canônico, troubleshooting e checklist
- link the new runbook from the main README under an observabilidade subsection
- capture lint evidence output for the task in out/diagnostics/task-m-markdownlint.txt

## Testing
- cargo fmt --all *(fails: duplicate key `opentelemetry-otlp` in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e17cb7b940833091f0f5e4c38014d1